### PR TITLE
add the projectKey and the organisationKey for SonarCloud

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -93,9 +93,9 @@ android {
 
 sonar {
     properties {
-        property("sonar.projectKey", "gf_android-sample")
-        property("sonar.projectName", "Android-Sample")
-        property("sonar.organization", "gabrielfleischer")
+        property("sonar.projectKey", "Swent-team-6_icebreakrr")
+        property("sonar.projectName", "icebreakrr")
+        property("sonar.organization", "swent-team-6")
         property("sonar.host.url", "https://sonarcloud.io")
         // Comma-separated paths to the various directories containing the *.xml JUnit report files. Each path may be absolute or relative to the project base directory.
         property("sonar.junit.reportPaths", "${project.layout.buildDirectory.get()}/test-results/testDebugunitTest/")


### PR DESCRIPTION
Change the app build.gradle so that the right projectKey and organisation key. This enables us to use SonarCloud.
Modify some settings in the SonarCloud project like switching off Automatic Analysis so that the continues integration works normaly