### PR TITLE
feature/add-profiles-viewmodel

### DIFF
--- a/app/src/main/java/com/github/se/icebreakrr/model/profile/ProfilesViewModel.kt
+++ b/app/src/main/java/com/github/se/icebreakrr/model/profile/ProfilesViewModel.kt
@@ -1,0 +1,154 @@
+package com.github.se.icebreakrr.model.profile
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.ViewModelProvider
+import com.google.firebase.Firebase
+import com.google.firebase.firestore.GeoPoint
+import com.google.firebase.firestore.firestore
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+
+open class ProfilesViewModel(private val repository: ProfilesRepository) : ViewModel() {
+
+    private val _profiles = MutableStateFlow<List<Profile>>(emptyList())
+    val profiles: StateFlow<List<Profile>> = _profiles
+
+    private val _selectedProfile = MutableStateFlow<Profile?>(null)
+    val selectedProfile: StateFlow<Profile?> = _selectedProfile
+
+    private val _loading = MutableStateFlow(false)
+    val loading: StateFlow<Boolean> = _loading
+
+    private val _error = MutableStateFlow<Exception?>(null)
+    val error: StateFlow<Exception?> = _error
+
+    init {
+        repository.init { //TODO getProfilesInRadius}
+        }
+    }
+
+    companion object {
+        val Factory: ViewModelProvider.Factory =
+            object : ViewModelProvider.Factory {
+                @Suppress("UNCHECKED_CAST")
+                override fun <T : ViewModel> create(modelClass: Class<T>): T {
+                    return ProfilesViewModel(ProfilesRepositoryFirestore(Firebase.firestore)) as T
+                }
+            }
+    }
+
+    /**
+     * Fetches profiles within a given radius around a center point with optional filters.
+     *
+     * @param center The center location as a GeoPoint.
+     * @param radiusInMeters The radius around the center in meters to search for profiles.
+     * @param gender Optional filter for gender.
+     * @param ageRange Optional filter for age range.
+     * @param tags Optional filter for specific tags.
+     */
+    fun getFilteredProfilesInRadius(
+        center: GeoPoint,
+        radiusInMeters: Double,
+        gender: Gender? = null,
+        ageRange: IntRange? = null,
+        tags: List<String>? = null
+    ) {
+        _loading.value = true
+        repository.getProfilesInRadius(
+            center = center,
+            radiusInMeters = radiusInMeters,
+            onSuccess = { profileList ->
+                val filteredProfiles = profileList.filter { profile ->
+
+                    // Filter by gender if specified
+                    (gender == null || profile.gender == gender) &&
+
+                            // Filter by age range if specified
+                            (ageRange == null || profile.calculateAge() in ageRange) &&
+
+                            // Filter by tags if specified
+                            (tags == null || profile.tags.containsAll(tags))
+                }
+                _profiles.value = filteredProfiles
+                _loading.value = false
+            },
+            onFailure = { exception ->
+                _error.value = exception
+                _loading.value = false
+            }
+        )
+    }
+
+    /**
+     * Adds a new profile to the repository.
+     *
+     * @param profile The profile to be added.
+     */
+    fun addNewProfile(profile: Profile) {
+        _loading.value = true
+        repository.addNewProfile(profile,
+            onSuccess = {
+                _loading.value = false
+            },
+            onFailure = { exception ->
+                _error.value = exception
+                _loading.value = false
+            }
+        )
+    }
+
+    /**
+     * Updates an existing profile in the repository.
+     *
+     * @param profile The profile with updated information.
+     */
+    fun updateProfile(profile: Profile) {
+        _loading.value = true
+        repository.updateProfile(profile,
+            onSuccess = {
+                _loading.value = false
+            },
+            onFailure = { exception ->
+                _error.value = exception
+                _loading.value = false
+            }
+        )
+    }
+
+    /**
+     * Fetches a profile by its user ID (UID).
+     *
+     * @param uid The unique ID of the user whose profile is being retrieved.
+     */
+    fun getProfileByUid(uid: String) {
+        _loading.value = true
+        repository.getProfileByUid(uid,
+            onSuccess = { profile ->
+                _selectedProfile.value = profile
+                _loading.value = false
+            },
+            onFailure = { exception ->
+                _error.value = exception
+                _loading.value = false
+            }
+        )
+    }
+
+    /**
+     * Deletes a profile by its user ID (UID).
+     *
+     * @param uid The unique ID of the user whose profile is to be deleted.
+     */
+    fun deleteProfileByUid(uid: String) {
+        _loading.value = true
+        repository.deleteProfileByUid(uid,
+            onSuccess = {
+                _loading.value = false
+            },
+            onFailure = { exception ->
+                _error.value = exception
+                _loading.value = false
+            }
+        )
+    }
+}

--- a/app/src/main/java/com/github/se/icebreakrr/model/profile/ProfilesViewModel.kt
+++ b/app/src/main/java/com/github/se/icebreakrr/model/profile/ProfilesViewModel.kt
@@ -42,14 +42,14 @@ open class ProfilesViewModel(private val repository: ProfilesRepository) : ViewM
    *
    * @param center The center location as a GeoPoint.
    * @param radiusInMeters The radius around the center in meters to search for profiles.
-   * @param gender Optional filter for gender.
+   * @param genders Optional filter for a list of genders.
    * @param ageRange Optional filter for age range.
    * @param tags Optional filter for specific tags.
    */
   fun getFilteredProfilesInRadius(
       center: GeoPoint,
       radiusInMeters: Double,
-      gender: Gender? = null,
+      genders: List<Gender>? = null,
       ageRange: IntRange? = null,
       tags: List<String>? = null
   ) {
@@ -61,8 +61,8 @@ open class ProfilesViewModel(private val repository: ProfilesRepository) : ViewM
           val filteredProfiles =
               profileList.filter { profile ->
 
-                // Filter by gender if specified
-                (gender == null || profile.gender == gender) &&
+                // Filter by genders if specified
+                (genders == null || profile.gender in genders) &&
 
                     // Filter by age range if specified
                     (ageRange == null || profile.calculateAge() in ageRange) &&
@@ -73,10 +73,7 @@ open class ProfilesViewModel(private val repository: ProfilesRepository) : ViewM
           _profiles.value = filteredProfiles
           _loading.value = false
         },
-        onFailure = { exception ->
-          _error.value = exception
-          _loading.value = false
-        })
+        onFailure = { e -> handleError(e) })
   }
 
   /**
@@ -87,12 +84,7 @@ open class ProfilesViewModel(private val repository: ProfilesRepository) : ViewM
   fun addNewProfile(profile: Profile) {
     _loading.value = true
     repository.addNewProfile(
-        profile,
-        onSuccess = { _loading.value = false },
-        onFailure = { exception ->
-          _error.value = exception
-          _loading.value = false
-        })
+        profile, onSuccess = { _loading.value = false }, onFailure = { e -> handleError(e) })
   }
 
   /**
@@ -103,12 +95,7 @@ open class ProfilesViewModel(private val repository: ProfilesRepository) : ViewM
   fun updateProfile(profile: Profile) {
     _loading.value = true
     repository.updateProfile(
-        profile,
-        onSuccess = { _loading.value = false },
-        onFailure = { exception ->
-          _error.value = exception
-          _loading.value = false
-        })
+        profile, onSuccess = { _loading.value = false }, onFailure = { e -> handleError(e) })
   }
 
   /**
@@ -124,10 +111,7 @@ open class ProfilesViewModel(private val repository: ProfilesRepository) : ViewM
           _selectedProfile.value = profile
           _loading.value = false
         },
-        onFailure = { exception ->
-          _error.value = exception
-          _loading.value = false
-        })
+        onFailure = { e -> handleError(e) })
   }
 
   /**
@@ -138,11 +122,16 @@ open class ProfilesViewModel(private val repository: ProfilesRepository) : ViewM
   fun deleteProfileByUid(uid: String) {
     _loading.value = true
     repository.deleteProfileByUid(
-        uid,
-        onSuccess = { _loading.value = false },
-        onFailure = { exception ->
-          _error.value = exception
-          _loading.value = false
-        })
+        uid, onSuccess = { _loading.value = false }, onFailure = { e -> handleError(e) })
+  }
+
+  /**
+   * Handles errors by updating the error and loading states.
+   *
+   * @param exception The exception to log and indicate the error state.
+   */
+  private fun handleError(exception: Exception) {
+    _error.value = exception
+    _loading.value = false
   }
 }

--- a/app/src/main/java/com/github/se/icebreakrr/model/profile/ProfilesViewModel.kt
+++ b/app/src/main/java/com/github/se/icebreakrr/model/profile/ProfilesViewModel.kt
@@ -10,145 +10,139 @@ import kotlinx.coroutines.flow.StateFlow
 
 open class ProfilesViewModel(private val repository: ProfilesRepository) : ViewModel() {
 
-    private val _profiles = MutableStateFlow<List<Profile>>(emptyList())
-    val profiles: StateFlow<List<Profile>> = _profiles
+  private val _profiles = MutableStateFlow<List<Profile>>(emptyList())
+  val profiles: StateFlow<List<Profile>> = _profiles
 
-    private val _selectedProfile = MutableStateFlow<Profile?>(null)
-    val selectedProfile: StateFlow<Profile?> = _selectedProfile
+  private val _selectedProfile = MutableStateFlow<Profile?>(null)
+  val selectedProfile: StateFlow<Profile?> = _selectedProfile
 
-    private val _loading = MutableStateFlow(false)
-    val loading: StateFlow<Boolean> = _loading
+  private val _loading = MutableStateFlow(false)
+  val loading: StateFlow<Boolean> = _loading
 
-    private val _error = MutableStateFlow<Exception?>(null)
-    val error: StateFlow<Exception?> = _error
+  private val _error = MutableStateFlow<Exception?>(null)
+  val error: StateFlow<Exception?> = _error
 
-    init {
-        repository.init { //TODO getProfilesInRadius}
+  init {
+    repository.init { // TODO getProfilesInRadius}
+    }
+  }
+
+  companion object {
+    val Factory: ViewModelProvider.Factory =
+        object : ViewModelProvider.Factory {
+          @Suppress("UNCHECKED_CAST")
+          override fun <T : ViewModel> create(modelClass: Class<T>): T {
+            return ProfilesViewModel(ProfilesRepositoryFirestore(Firebase.firestore)) as T
+          }
         }
-    }
+  }
 
-    companion object {
-        val Factory: ViewModelProvider.Factory =
-            object : ViewModelProvider.Factory {
-                @Suppress("UNCHECKED_CAST")
-                override fun <T : ViewModel> create(modelClass: Class<T>): T {
-                    return ProfilesViewModel(ProfilesRepositoryFirestore(Firebase.firestore)) as T
-                }
-            }
-    }
+  /**
+   * Fetches profiles within a given radius around a center point with optional filters.
+   *
+   * @param center The center location as a GeoPoint.
+   * @param radiusInMeters The radius around the center in meters to search for profiles.
+   * @param gender Optional filter for gender.
+   * @param ageRange Optional filter for age range.
+   * @param tags Optional filter for specific tags.
+   */
+  fun getFilteredProfilesInRadius(
+      center: GeoPoint,
+      radiusInMeters: Double,
+      gender: Gender? = null,
+      ageRange: IntRange? = null,
+      tags: List<String>? = null
+  ) {
+    _loading.value = true
+    repository.getProfilesInRadius(
+        center = center,
+        radiusInMeters = radiusInMeters,
+        onSuccess = { profileList ->
+          val filteredProfiles =
+              profileList.filter { profile ->
 
-    /**
-     * Fetches profiles within a given radius around a center point with optional filters.
-     *
-     * @param center The center location as a GeoPoint.
-     * @param radiusInMeters The radius around the center in meters to search for profiles.
-     * @param gender Optional filter for gender.
-     * @param ageRange Optional filter for age range.
-     * @param tags Optional filter for specific tags.
-     */
-    fun getFilteredProfilesInRadius(
-        center: GeoPoint,
-        radiusInMeters: Double,
-        gender: Gender? = null,
-        ageRange: IntRange? = null,
-        tags: List<String>? = null
-    ) {
-        _loading.value = true
-        repository.getProfilesInRadius(
-            center = center,
-            radiusInMeters = radiusInMeters,
-            onSuccess = { profileList ->
-                val filteredProfiles = profileList.filter { profile ->
+                // Filter by gender if specified
+                (gender == null || profile.gender == gender) &&
 
-                    // Filter by gender if specified
-                    (gender == null || profile.gender == gender) &&
+                    // Filter by age range if specified
+                    (ageRange == null || profile.calculateAge() in ageRange) &&
 
-                            // Filter by age range if specified
-                            (ageRange == null || profile.calculateAge() in ageRange) &&
+                    // Filter by tags if specified
+                    (tags == null || profile.tags.containsAll(tags))
+              }
+          _profiles.value = filteredProfiles
+          _loading.value = false
+        },
+        onFailure = { exception ->
+          _error.value = exception
+          _loading.value = false
+        })
+  }
 
-                            // Filter by tags if specified
-                            (tags == null || profile.tags.containsAll(tags))
-                }
-                _profiles.value = filteredProfiles
-                _loading.value = false
-            },
-            onFailure = { exception ->
-                _error.value = exception
-                _loading.value = false
-            }
-        )
-    }
+  /**
+   * Adds a new profile to the repository.
+   *
+   * @param profile The profile to be added.
+   */
+  fun addNewProfile(profile: Profile) {
+    _loading.value = true
+    repository.addNewProfile(
+        profile,
+        onSuccess = { _loading.value = false },
+        onFailure = { exception ->
+          _error.value = exception
+          _loading.value = false
+        })
+  }
 
-    /**
-     * Adds a new profile to the repository.
-     *
-     * @param profile The profile to be added.
-     */
-    fun addNewProfile(profile: Profile) {
-        _loading.value = true
-        repository.addNewProfile(profile,
-            onSuccess = {
-                _loading.value = false
-            },
-            onFailure = { exception ->
-                _error.value = exception
-                _loading.value = false
-            }
-        )
-    }
+  /**
+   * Updates an existing profile in the repository.
+   *
+   * @param profile The profile with updated information.
+   */
+  fun updateProfile(profile: Profile) {
+    _loading.value = true
+    repository.updateProfile(
+        profile,
+        onSuccess = { _loading.value = false },
+        onFailure = { exception ->
+          _error.value = exception
+          _loading.value = false
+        })
+  }
 
-    /**
-     * Updates an existing profile in the repository.
-     *
-     * @param profile The profile with updated information.
-     */
-    fun updateProfile(profile: Profile) {
-        _loading.value = true
-        repository.updateProfile(profile,
-            onSuccess = {
-                _loading.value = false
-            },
-            onFailure = { exception ->
-                _error.value = exception
-                _loading.value = false
-            }
-        )
-    }
+  /**
+   * Fetches a profile by its user ID (UID).
+   *
+   * @param uid The unique ID of the user whose profile is being retrieved.
+   */
+  fun getProfileByUid(uid: String) {
+    _loading.value = true
+    repository.getProfileByUid(
+        uid,
+        onSuccess = { profile ->
+          _selectedProfile.value = profile
+          _loading.value = false
+        },
+        onFailure = { exception ->
+          _error.value = exception
+          _loading.value = false
+        })
+  }
 
-    /**
-     * Fetches a profile by its user ID (UID).
-     *
-     * @param uid The unique ID of the user whose profile is being retrieved.
-     */
-    fun getProfileByUid(uid: String) {
-        _loading.value = true
-        repository.getProfileByUid(uid,
-            onSuccess = { profile ->
-                _selectedProfile.value = profile
-                _loading.value = false
-            },
-            onFailure = { exception ->
-                _error.value = exception
-                _loading.value = false
-            }
-        )
-    }
-
-    /**
-     * Deletes a profile by its user ID (UID).
-     *
-     * @param uid The unique ID of the user whose profile is to be deleted.
-     */
-    fun deleteProfileByUid(uid: String) {
-        _loading.value = true
-        repository.deleteProfileByUid(uid,
-            onSuccess = {
-                _loading.value = false
-            },
-            onFailure = { exception ->
-                _error.value = exception
-                _loading.value = false
-            }
-        )
-    }
+  /**
+   * Deletes a profile by its user ID (UID).
+   *
+   * @param uid The unique ID of the user whose profile is to be deleted.
+   */
+  fun deleteProfileByUid(uid: String) {
+    _loading.value = true
+    repository.deleteProfileByUid(
+        uid,
+        onSuccess = { _loading.value = false },
+        onFailure = { exception ->
+          _error.value = exception
+          _loading.value = false
+        })
+  }
 }

--- a/app/src/test/java/com/github/se/icebreakrr/model/profile/ProfilesViewModelTest.kt
+++ b/app/src/test/java/com/github/se/icebreakrr/model/profile/ProfilesViewModelTest.kt
@@ -1,0 +1,183 @@
+package com.github.se.icebreakrr.model.profile
+
+import com.google.firebase.Timestamp
+import com.google.firebase.firestore.GeoPoint
+import java.util.Calendar
+import kotlinx.coroutines.runBlocking
+import org.hamcrest.CoreMatchers.`is`
+import org.hamcrest.MatcherAssert.assertThat
+import org.junit.Before
+import org.junit.Test
+import org.mockito.Mockito.mock
+import org.mockito.Mockito.verify
+import org.mockito.kotlin.any
+import org.mockito.kotlin.eq
+import org.mockito.kotlin.whenever
+
+class ProfilesViewModelTest {
+  private lateinit var profilesRepository: ProfilesRepository
+  private lateinit var profilesViewModel: ProfilesViewModel
+
+  private val birthDate2002 =
+      Timestamp(
+          Calendar.getInstance()
+              .apply {
+                set(2002, Calendar.JANUARY, 1, 0, 0, 0)
+                set(Calendar.MILLISECOND, 0)
+              }
+              .time)
+
+  private val profile1 =
+      Profile(
+          uid = "1",
+          name = "John Doe",
+          gender = Gender.MEN,
+          birthDate = birthDate2002, // 22 years old
+          catchPhrase = "Just a friendly guy",
+          description = "I love meeting new people.",
+          tags = listOf("friendly", "outgoing"))
+
+  private val profile2 =
+      Profile(
+          uid = "2",
+          name = "Jane Smith",
+          gender = Gender.WOMEN,
+          birthDate = Timestamp.now(),
+          catchPhrase = "Adventure awaits!",
+          description = "Always looking for new experiences.",
+          tags = listOf("adventurous", "outgoing"))
+
+  @Before
+  fun setUp() {
+    profilesRepository = mock(ProfilesRepository::class.java)
+    profilesViewModel = ProfilesViewModel(profilesRepository)
+  }
+
+  @Test
+  fun getFilteredProfilesInRadiusCallsRepositoryWithFilters() = runBlocking {
+    val center = GeoPoint(0.0, 0.0)
+    val radiusInMeters = 1000.0
+
+    val profilesList = listOf(profile1, profile2)
+    whenever(profilesRepository.getProfilesInRadius(eq(center), eq(radiusInMeters), any(), any()))
+        .thenAnswer {
+          val onSuccess = it.getArgument<(List<Profile>) -> Unit>(2)
+          onSuccess(profilesList)
+        }
+
+    // Test filtering by gender and tags
+    profilesViewModel.getFilteredProfilesInRadius(
+        center, radiusInMeters, Gender.MEN, 20..30, listOf("friendly"))
+
+    verify(profilesRepository).getProfilesInRadius(eq(center), eq(radiusInMeters), any(), any())
+    assertThat(profilesViewModel.profiles.value.size, `is`(1)) // Should return only profile1
+    assertThat(profilesViewModel.profiles.value[0].uid, `is`("1")) // profile1 should be returned
+  }
+
+  @Test
+  fun addNewProfileCallsRepository() = runBlocking {
+    profilesViewModel.addNewProfile(profile1)
+
+    verify(profilesRepository).addNewProfile(eq(profile1), any(), any())
+  }
+
+  @Test
+  fun updateProfileCallsRepository() = runBlocking {
+    profilesViewModel.updateProfile(profile1)
+
+    verify(profilesRepository).updateProfile(eq(profile1), any(), any())
+  }
+
+  @Test
+  fun getProfileByUidCallsRepository() = runBlocking {
+    whenever(profilesRepository.getProfileByUid(eq("1"), any(), any())).thenAnswer {
+      val onSuccess = it.getArgument<(Profile) -> Unit>(1)
+      onSuccess(profile1)
+    }
+
+    profilesViewModel.getProfileByUid("1")
+
+    verify(profilesRepository).getProfileByUid(eq("1"), any(), any())
+    assertThat(profilesViewModel.selectedProfile.value?.uid, `is`("1"))
+  }
+
+  @Test
+  fun deleteProfileByUidCallsRepository() = runBlocking {
+    profilesViewModel.deleteProfileByUid("1")
+
+    verify(profilesRepository).deleteProfileByUid(eq("1"), any(), any())
+  }
+
+  @Test
+  fun getFilteredProfilesInRadiusHandlesError() = runBlocking {
+    val center = GeoPoint(0.0, 0.0)
+    val radiusInMeters = 1000.0
+    val exception = Exception("Test exception")
+
+    whenever(profilesRepository.getProfilesInRadius(eq(center), eq(radiusInMeters), any(), any()))
+        .thenAnswer {
+          val onFailure = it.getArgument<(Exception) -> Unit>(3)
+          onFailure(exception)
+        }
+
+    profilesViewModel.getFilteredProfilesInRadius(center, radiusInMeters)
+
+    assertThat(profilesViewModel.error.value, `is`(exception))
+  }
+
+  @Test
+  fun addNewProfileHandlesError() = runBlocking {
+    val exception = Exception("Failed to add profile")
+
+    whenever(profilesRepository.addNewProfile(eq(profile1), any(), any())).thenAnswer {
+      val onFailure = it.getArgument<(Exception) -> Unit>(2)
+      onFailure(exception)
+    }
+
+    profilesViewModel.addNewProfile(profile1)
+
+    assertThat(profilesViewModel.error.value, `is`(exception))
+  }
+
+  @Test
+  fun updateProfileHandlesError() = runBlocking {
+    val exception = Exception("Failed to update profile")
+
+    whenever(profilesRepository.updateProfile(eq(profile1), any(), any())).thenAnswer {
+      val onFailure = it.getArgument<(Exception) -> Unit>(2)
+      onFailure(exception)
+    }
+
+    profilesViewModel.updateProfile(profile1)
+
+    assertThat(profilesViewModel.error.value, `is`(exception))
+  }
+
+  @Test
+  fun getProfileByUidHandlesError() = runBlocking {
+    val exception = Exception("Profile not found")
+
+    whenever(profilesRepository.getProfileByUid(eq("1"), any(), any())).thenAnswer {
+      val onFailure = it.getArgument<(Exception) -> Unit>(2)
+      onFailure(exception)
+    }
+
+    profilesViewModel.getProfileByUid("1")
+
+    assertThat(profilesViewModel.error.value, `is`(exception))
+  }
+
+  @Test
+  fun deleteProfileByUidHandlesError() = runBlocking {
+    val exception = Exception("Failed to delete profile")
+
+    whenever(profilesRepository.deleteProfileByUid(eq("1"), any(), any())).thenAnswer {
+      val onFailure = it.getArgument<(Exception) -> Unit>(2)
+      onFailure(exception)
+    }
+
+    profilesViewModel.deleteProfileByUid("1")
+
+    assertThat(profilesViewModel.error.value, `is`(exception))
+  }
+}


### PR DESCRIPTION
# Profiles ViewModel

## Overview
This pull request introduces the `ProfilesViewModel` for managing user profiles and the corresponding unit tests to ensure its functionality. 

## Changes
### Features Added
- **ProfilesViewModel**: 
  - Handles profile fetching, filtering, and management.
  - Implements state management for profiles, selected profile, loading state, and error handling.
  - Methods for:
    - Fetching filtered profiles within a radius.
    - Adding, updating, retrieving, and deleting profiles by UID.
  - Integrated with Firebase Firestore for data operations.

### Tests Added
- **ProfilesViewModelTest**: 
  - Unit tests for `ProfilesViewModel` using Mockito.
  - Tests for:
    - Fetching filtered profiles in a radius.
    - Adding, updating, retrieving, and deleting profiles.
    - Error handling to ensure proper state management on failures.
  - Verification of interaction with `ProfilesRepository` to ensure correct method calls and parameters.

## Additional Notes
- All tests are designed to mock the `ProfilesRepository` to isolate the `ProfilesViewModel` logic.

