### PR TITLE
Feature/profile edit

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -141,6 +141,10 @@ dependencies {
     implementation(platform(libs.compose.bom))
     implementation(libs.androidx.navigation.compose)
     implementation(libs.androidx.navigation.testing)
+
+    implementation(libs.play.services.location)
+    implementation(libs.coil.compose)
+
     implementation(libs.firebase.firestore.ktx)
     testImplementation(libs.junit)
     globalTestImplementation(libs.androidx.junit)

--- a/app/src/androidTest/java/com/github/se/icebreakrr/ui/profile/profileEditTest.kt
+++ b/app/src/androidTest/java/com/github/se/icebreakrr/ui/profile/profileEditTest.kt
@@ -27,6 +27,12 @@ class ProfileEditingScreenTest {
 
     composeTestRule.setContent { ProfileEditingScreen(navigationActions) }
 
+    // Check if topAppBar is displayed
+    composeTestRule.onNodeWithTag("topAppBar").assertIsDisplayed()
+
+    // Check if profileEditScreenContent is displayed
+    composeTestRule.onNodeWithTag("profileEditScreenContent").assertIsDisplayed()
+
     // Check if profile picture is displayed
     composeTestRule.onNodeWithTag("profilePicture").assertIsDisplayed()
 

--- a/app/src/androidTest/java/com/github/se/icebreakrr/ui/profile/profileEditTest.kt
+++ b/app/src/androidTest/java/com/github/se/icebreakrr/ui/profile/profileEditTest.kt
@@ -1,0 +1,82 @@
+package com.github.se.icebreakrr.ui.profile
+
+import androidx.compose.ui.test.*
+import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.github.se.icebreakrr.ui.navigation.NavigationActions
+import com.github.se.icebreakrr.ui.navigation.Screen
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.mockito.Mockito.mock
+import org.mockito.Mockito.`when`
+
+@RunWith(AndroidJUnit4::class)
+class ProfileEditingScreenTest {
+
+    private lateinit var navigationActions: NavigationActions
+
+    @get:Rule val composeTestRule = createComposeRule()
+
+    @Before
+    fun setUp() {
+        navigationActions = mock()
+    }
+
+    @Test
+    fun testProfileEditingScreenUI() {
+
+        composeTestRule.setContent { ProfileEditingScreen(navigationActions)}
+
+        // Check if profile picture is displayed
+        composeTestRule.onNodeWithTag("profilePicture").assertIsDisplayed()
+
+        // Check if name and age are displayed correctly
+        composeTestRule.onNodeWithTag("nameAndAge").assertIsDisplayed()
+
+        // Test catchphrase input
+        composeTestRule.onNodeWithTag("catchphrase").performTextInput("New Catchphrase")
+        composeTestRule.onNodeWithTag("catchphrase").assertTextContains("New Catchphrase")
+
+
+        // Test description input
+        composeTestRule.onNodeWithTag("description").performTextInput("New Description")
+        composeTestRule.onNodeWithTag("description").assertTextContains("New Description")
+
+
+        // Test back button functionality
+        composeTestRule.onNodeWithTag("goBackButton").performClick()
+        composeTestRule.onNodeWithTag("alertDialog").assertIsDisplayed()
+
+        // Test dialog buttons
+        composeTestRule.onNodeWithText("Cancel").performClick()
+        composeTestRule.onNodeWithTag("alertDialog").assertIsNotDisplayed()
+
+        // Test check button
+        composeTestRule.onNodeWithTag("checkButton").assertIsDisplayed()
+
+    }
+
+    @Test
+    fun testEdgeCases() {
+
+        composeTestRule.setContent { ProfileEditingScreen(navigationActions)}
+
+        // Test empty catchphrase
+        composeTestRule.onNodeWithTag("description").performTextInput("New catchphrase")
+        composeTestRule.onNodeWithTag("catchphrase").performTextClearance()
+        composeTestRule.onNodeWithTag("catchphrase").assertTextContains("")
+
+        // Test empty description
+        composeTestRule.onNodeWithTag("description").performTextInput("New Description")
+        composeTestRule.onNodeWithTag("description").performTextClearance()
+        composeTestRule.onNodeWithTag("description").assertTextContains("")
+
+        // Test long text input
+        val longText = "A".repeat(1000)
+        composeTestRule.onNodeWithTag("description").performTextInput(longText)
+        composeTestRule.onNodeWithTag("description").assertTextContains(longText.take(1000))
+
+    }
+}

--- a/app/src/androidTest/java/com/github/se/icebreakrr/ui/profile/profileEditTest.kt
+++ b/app/src/androidTest/java/com/github/se/icebreakrr/ui/profile/profileEditTest.kt
@@ -4,79 +4,73 @@ import androidx.compose.ui.test.*
 import androidx.compose.ui.test.junit4.createComposeRule
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.github.se.icebreakrr.ui.navigation.NavigationActions
-import com.github.se.icebreakrr.ui.navigation.Screen
 import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.mockito.Mockito.mock
-import org.mockito.Mockito.`when`
 
 @RunWith(AndroidJUnit4::class)
 class ProfileEditingScreenTest {
 
-    private lateinit var navigationActions: NavigationActions
+  private lateinit var navigationActions: NavigationActions
 
-    @get:Rule val composeTestRule = createComposeRule()
+  @get:Rule val composeTestRule = createComposeRule()
 
-    @Before
-    fun setUp() {
-        navigationActions = mock()
-    }
+  @Before
+  fun setUp() {
+    navigationActions = mock()
+  }
 
-    @Test
-    fun testProfileEditingScreenUI() {
+  @Test
+  fun testProfileEditingScreenUI() {
 
-        composeTestRule.setContent { ProfileEditingScreen(navigationActions)}
+    composeTestRule.setContent { ProfileEditingScreen(navigationActions) }
 
-        // Check if profile picture is displayed
-        composeTestRule.onNodeWithTag("profilePicture").assertIsDisplayed()
+    // Check if profile picture is displayed
+    composeTestRule.onNodeWithTag("profilePicture").assertIsDisplayed()
 
-        // Check if name and age are displayed correctly
-        composeTestRule.onNodeWithTag("nameAndAge").assertIsDisplayed()
+    // Check if name and age are displayed correctly
+    composeTestRule.onNodeWithTag("nameAndAge").assertIsDisplayed()
 
-        // Test catchphrase input
-        composeTestRule.onNodeWithTag("catchphrase").performTextInput("New Catchphrase")
-        composeTestRule.onNodeWithTag("catchphrase").assertTextContains("New Catchphrase")
+    // Test catchphrase input
+    composeTestRule.onNodeWithTag("catchphrase").performTextInput("New Catchphrase")
+    composeTestRule.onNodeWithTag("catchphrase").assertTextContains("New Catchphrase")
 
+    // Test description input
+    composeTestRule.onNodeWithTag("description").performTextInput("New Description")
+    composeTestRule.onNodeWithTag("description").assertTextContains("New Description")
 
-        // Test description input
-        composeTestRule.onNodeWithTag("description").performTextInput("New Description")
-        composeTestRule.onNodeWithTag("description").assertTextContains("New Description")
+    // Test back button functionality
+    composeTestRule.onNodeWithTag("goBackButton").performClick()
+    composeTestRule.onNodeWithTag("alertDialog").assertIsDisplayed()
 
+    // Test dialog buttons
+    composeTestRule.onNodeWithText("Cancel").performClick()
+    composeTestRule.onNodeWithTag("alertDialog").assertIsNotDisplayed()
 
-        // Test back button functionality
-        composeTestRule.onNodeWithTag("goBackButton").performClick()
-        composeTestRule.onNodeWithTag("alertDialog").assertIsDisplayed()
+    // Test check button
+    composeTestRule.onNodeWithTag("checkButton").assertIsDisplayed()
+  }
 
-        // Test dialog buttons
-        composeTestRule.onNodeWithText("Cancel").performClick()
-        composeTestRule.onNodeWithTag("alertDialog").assertIsNotDisplayed()
+  @Test
+  fun testEdgeCases() {
 
-        // Test check button
-        composeTestRule.onNodeWithTag("checkButton").assertIsDisplayed()
+    composeTestRule.setContent { ProfileEditingScreen(navigationActions) }
 
-    }
+    // Test empty catchphrase
+    composeTestRule.onNodeWithTag("description").performTextInput("New catchphrase")
+    composeTestRule.onNodeWithTag("catchphrase").performTextClearance()
+    composeTestRule.onNodeWithTag("catchphrase").assertTextContains("")
 
-    @Test
-    fun testEdgeCases() {
+    // Test empty description
+    composeTestRule.onNodeWithTag("description").performTextInput("New Description")
+    composeTestRule.onNodeWithTag("description").performTextClearance()
+    composeTestRule.onNodeWithTag("description").assertTextContains("")
 
-        composeTestRule.setContent { ProfileEditingScreen(navigationActions)}
-
-        // Test empty catchphrase
-        composeTestRule.onNodeWithTag("description").performTextInput("New catchphrase")
-        composeTestRule.onNodeWithTag("catchphrase").performTextClearance()
-        composeTestRule.onNodeWithTag("catchphrase").assertTextContains("")
-
-        // Test empty description
-        composeTestRule.onNodeWithTag("description").performTextInput("New Description")
-        composeTestRule.onNodeWithTag("description").performTextClearance()
-        composeTestRule.onNodeWithTag("description").assertTextContains("")
-
-        // Test long text input
-        val longText = "A".repeat(1000)
-        composeTestRule.onNodeWithTag("description").performTextInput(longText)
-        composeTestRule.onNodeWithTag("description").assertTextContains(longText.take(1000))
-
-    }
+    // Test long text input
+    val longText = "A".repeat(1000)
+    composeTestRule.onNodeWithTag("description").performTextInput(longText)
+    composeTestRule.onNodeWithTag("description").assertTextContains(longText.take(1000))
+  }
 }

--- a/app/src/main/java/com/github/se/icebreakrr/MainActivity.kt
+++ b/app/src/main/java/com/github/se/icebreakrr/MainActivity.kt
@@ -14,6 +14,7 @@ import androidx.navigation.compose.rememberNavController
 import com.github.se.icebreakrr.ui.navigation.NavigationActions
 import com.github.se.icebreakrr.ui.navigation.Route
 import com.github.se.icebreakrr.ui.navigation.Screen
+import com.github.se.icebreakrr.ui.profile.ProfileEditingScreen
 import com.github.se.icebreakrr.ui.sections.AroundYouScreen
 import com.github.se.icebreakrr.ui.sections.NotificationScreen
 import com.github.se.icebreakrr.ui.sections.SettingsScreen
@@ -63,6 +64,13 @@ fun IcebreakrrApp() {
         route = Route.NOTIFICATIONS,
     ) {
       composable(Screen.NOTIFICATIONS) { NotificationScreen(navigationActions) }
+    }
+
+    navigation(
+        startDestination = Screen.PROFILE_EDIT,
+        route = Route.PROFILE_EDIT,
+    ) {
+      composable(Screen.PROFILE_EDIT) { ProfileEditingScreen(navigationActions) }
     }
   }
 }

--- a/app/src/main/java/com/github/se/icebreakrr/ui/navigation/TopLevelDestination.kt
+++ b/app/src/main/java/com/github/se/icebreakrr/ui/navigation/TopLevelDestination.kt
@@ -20,6 +20,7 @@ object Route {
   const val AROUND_YOU = "AroundYou"
   const val SETTINGS = "Settings"
   const val NOTIFICATIONS = "Notifications"
+  const val PROFILE_EDIT = "ProfileEdit"
 }
 
 object Screen {
@@ -27,6 +28,7 @@ object Screen {
   const val AROUND_YOU = "Around You Screen"
   const val SETTINGS = "Settings Screen"
   const val NOTIFICATIONS = "Notifications Screen"
+  const val PROFILE_EDIT = "Profile Edit Screen"
 }
 
 object TopLevelDestinations {

--- a/app/src/main/java/com/github/se/icebreakrr/ui/profile/ProfileEdit.kt
+++ b/app/src/main/java/com/github/se/icebreakrr/ui/profile/ProfileEdit.kt
@@ -1,0 +1,187 @@
+package com.github.se.icebreakrr.ui.profile
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.ArrowBack
+import androidx.compose.material.icons.filled.Check
+import androidx.compose.material3.*
+import androidx.compose.runtime.*
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.platform.LocalConfiguration
+import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.text.TextStyle
+import androidx.compose.ui.text.input.TextFieldValue
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import coil.compose.AsyncImage
+import com.github.se.icebreakrr.model.profile.Gender
+import com.github.se.icebreakrr.model.profile.Profile
+import com.github.se.icebreakrr.model.profile.ProfilesRepositoryFirestore
+import com.github.se.icebreakrr.ui.navigation.NavigationActions
+import com.google.firebase.Timestamp
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun ProfileEditingScreen(navigationActions: NavigationActions) {
+
+    val configuration = LocalConfiguration.current
+    val screenWidth = configuration.screenWidthDp.dp
+
+    // Define dynamic padding and text size based on screen size
+    val padding = screenWidth * 0.02f // 2% of screen width
+    val textSize = screenWidth * 0.06f // 6% of screen width
+
+    //TODO : make the padding and text size dynamic based on screen size
+
+    val user = Profile(
+        uid = "",
+        name = "",
+        gender = Gender.OTHER,
+        birthDate = Timestamp.now(),
+        catchPhrase = "",
+        description = "",
+        tags = listOf(),
+        profilePictureUrl = ""
+    )
+
+    val profilePicture by remember {
+        mutableStateOf(
+            user.profilePictureUrl)
+    }
+    var catchphrase by remember {
+        mutableStateOf(TextFieldValue(user.catchPhrase))
+    }
+    var description by remember { mutableStateOf(TextFieldValue(user.description)) }
+    var showDialog by remember { mutableStateOf(false) }
+    var searchQuery by remember { mutableStateOf("") }
+
+    // to POST the new profile, I will use Arthur's viewModel
+
+    // for tags display, I will use Samuel's tags viewProfile to load the tags
+
+    Scaffold(
+        modifier = Modifier.testTag("profileEditScreen"),
+        topBar = {
+            TopAppBar(
+                title = { Text("") },
+                navigationIcon = {
+                    IconButton(
+                        modifier = Modifier.testTag("goBackButton"),
+                        onClick = {
+                            // TODO : verify that the profile has been modified before showing the modal
+                            showDialog = true
+                        }) {
+                        Icon(Icons.Default.ArrowBack, contentDescription = "Back")
+                    }
+                },
+                actions = {
+                    IconButton(
+                        modifier = Modifier.testTag("checkButton"),
+                        onClick = {
+                            // TODO : handle save action
+                        }) {
+                        Icon(Icons.Default.Check, contentDescription = "Save")
+                    }
+                })
+        }) {
+        Column(
+            modifier = Modifier
+                .padding(it)
+                .padding(padding),
+            horizontalAlignment = Alignment.CenterHorizontally) {
+            AsyncImage( //TODO : implement image uploading
+                model = profilePicture,
+                contentDescription = "Profile Picture",
+                modifier =
+                Modifier
+                    .size(100.dp)
+                    .clip(CircleShape)
+                    .background(MaterialTheme.colorScheme.primary)
+                    .testTag("profilePicture")) // Added test tag
+
+            Spacer(modifier = Modifier.height(padding))
+
+            // Name Input
+            Text(
+                text = "${user.name}, ${user.calculateAge()}",
+                style = TextStyle(fontSize = textSize.value.sp),
+                modifier =
+                Modifier
+                    .fillMaxWidth()
+                    .wrapContentWidth(Alignment.CenterHorizontally)
+                    .testTag("nameAndAge"))
+            Spacer(modifier = Modifier.height(padding))
+
+            // Catchphrase Input
+            OutlinedTextField(
+                value = catchphrase,
+                onValueChange = { catchphrase = it },
+                label = { Text("Catchphrase") },
+                modifier =
+                Modifier
+                    .fillMaxWidth()
+                    .height(60.dp)
+                    .testTag("catchphrase"))
+
+            Spacer(modifier = Modifier.height(padding))
+
+            // Description Input
+            OutlinedTextField(
+                value = description,
+                onValueChange = { description = it },
+                label = { Text("Description") },
+                modifier =
+                Modifier
+                    .fillMaxWidth()
+                    .height(100.dp)
+                    .testTag("description"))
+            Spacer(modifier = Modifier.height(padding))
+
+            //TODO: This is temporary for tests and will be replaced with the actual tag selector of Maximo
+            OutlinedTextField(
+                value = searchQuery,
+                onValueChange = { searchQuery = it },
+                label = { Text("Search Tags") },
+                modifier =
+                Modifier
+                    .fillMaxWidth()
+                    .height(60.dp)
+                    .testTag("searchTags")
+            )
+            Spacer(modifier = Modifier.height(padding))
+
+            //TODO : This will be replaced by the actual tags
+            Text(
+                "Tags",
+                style = MaterialTheme.typography.titleMedium,
+                modifier =
+                Modifier
+                    .align(Alignment.Start)
+                    .testTag("userTags"))
+
+            //TODO: implement tags query and display with Maximo's tags UI and Samuel's viewProfile
+
+            // Modal for unsaved changes on leave page with back button
+            if (showDialog) {
+                AlertDialog(
+                    onDismissRequest = { showDialog = false },
+                    title = { Text("You are about to leave this page") },
+                    text = { Text("Do you want to save your changes?") },
+                    confirmButton = {
+                        TextButton(onClick = { navigationActions.goBack() }) {
+                            Text("Discard changes")
+                        }
+                    },
+                    dismissButton = {
+                        TextButton(onClick = { showDialog = false }) { Text("Cancel") }
+                    },
+                    modifier = Modifier.testTag("alertDialog")
+                )
+            }
+        }
+    }
+}

--- a/app/src/main/java/com/github/se/icebreakrr/ui/profile/ProfileEdit.kt
+++ b/app/src/main/java/com/github/se/icebreakrr/ui/profile/ProfileEdit.kt
@@ -20,7 +20,6 @@ import androidx.compose.ui.unit.sp
 import coil.compose.AsyncImage
 import com.github.se.icebreakrr.model.profile.Gender
 import com.github.se.icebreakrr.model.profile.Profile
-import com.github.se.icebreakrr.model.profile.ProfilesRepositoryFirestore
 import com.github.se.icebreakrr.ui.navigation.NavigationActions
 import com.google.firebase.Timestamp
 
@@ -28,160 +27,136 @@ import com.google.firebase.Timestamp
 @Composable
 fun ProfileEditingScreen(navigationActions: NavigationActions) {
 
-    val configuration = LocalConfiguration.current
-    val screenWidth = configuration.screenWidthDp.dp
+  val configuration = LocalConfiguration.current
+  val screenWidth = configuration.screenWidthDp.dp
 
-    // Define dynamic padding and text size based on screen size
-    val padding = screenWidth * 0.02f // 2% of screen width
-    val textSize = screenWidth * 0.06f // 6% of screen width
+  // Define dynamic padding and text size based on screen size
+  val padding = screenWidth * 0.02f // 2% of screen width
+  val textSize = screenWidth * 0.06f // 6% of screen width
 
-    //TODO : make the padding and text size dynamic based on screen size
+  // TODO : make the padding and text size dynamic based on screen size
 
-    val user = Profile(
-        uid = "",
-        name = "",
-        gender = Gender.OTHER,
-        birthDate = Timestamp.now(),
-        catchPhrase = "",
-        description = "",
-        tags = listOf(),
-        profilePictureUrl = ""
-    )
+  val user =
+      Profile(
+          uid = "",
+          name = "",
+          gender = Gender.OTHER,
+          birthDate = Timestamp.now(),
+          catchPhrase = "",
+          description = "",
+          tags = listOf(),
+          profilePictureUrl = "")
 
-    val profilePicture by remember {
-        mutableStateOf(
-            user.profilePictureUrl)
-    }
-    var catchphrase by remember {
-        mutableStateOf(TextFieldValue(user.catchPhrase))
-    }
-    var description by remember { mutableStateOf(TextFieldValue(user.description)) }
-    var showDialog by remember { mutableStateOf(false) }
-    var searchQuery by remember { mutableStateOf("") }
+  val profilePicture by remember { mutableStateOf(user.profilePictureUrl) }
+  var catchphrase by remember { mutableStateOf(TextFieldValue(user.catchPhrase)) }
+  var description by remember { mutableStateOf(TextFieldValue(user.description)) }
+  var showDialog by remember { mutableStateOf(false) }
+  var searchQuery by remember { mutableStateOf("") }
 
-    // to POST the new profile, I will use Arthur's viewModel
+  // to POST the new profile, I will use Arthur's viewModel
 
-    // for tags display, I will use Samuel's tags viewProfile to load the tags
+  // for tags display, I will use Samuel's tags viewProfile to load the tags
 
-    Scaffold(
-        modifier = Modifier.testTag("profileEditScreen"),
-        topBar = {
-            TopAppBar(
-                title = { Text("") },
-                navigationIcon = {
-                    IconButton(
-                        modifier = Modifier.testTag("goBackButton"),
-                        onClick = {
-                            // TODO : verify that the profile has been modified before showing the modal
-                            showDialog = true
-                        }) {
-                        Icon(Icons.Default.ArrowBack, contentDescription = "Back")
-                    }
-                },
-                actions = {
-                    IconButton(
-                        modifier = Modifier.testTag("checkButton"),
-                        onClick = {
-                            // TODO : handle save action
-                        }) {
-                        Icon(Icons.Default.Check, contentDescription = "Save")
-                    }
-                })
-        }) {
+  Scaffold(
+      modifier = Modifier.testTag("profileEditScreen"),
+      topBar = {
+        TopAppBar(
+            title = { Text("") },
+            navigationIcon = {
+              IconButton(
+                  modifier = Modifier.testTag("goBackButton"),
+                  onClick = {
+                    // TODO : verify that the profile has been modified before showing the modal
+                    showDialog = true
+                  }) {
+                    Icon(Icons.Default.ArrowBack, contentDescription = "Back")
+                  }
+            },
+            actions = {
+              IconButton(
+                  modifier = Modifier.testTag("checkButton"),
+                  onClick = {
+                    // TODO : handle save action
+                  }) {
+                    Icon(Icons.Default.Check, contentDescription = "Save")
+                  }
+            })
+      }) {
         Column(
-            modifier = Modifier
-                .padding(it)
-                .padding(padding),
+            modifier = Modifier.padding(it).padding(padding),
             horizontalAlignment = Alignment.CenterHorizontally) {
-            AsyncImage( //TODO : implement image uploading
-                model = profilePicture,
-                contentDescription = "Profile Picture",
-                modifier =
-                Modifier
-                    .size(100.dp)
-                    .clip(CircleShape)
-                    .background(MaterialTheme.colorScheme.primary)
-                    .testTag("profilePicture")) // Added test tag
+              AsyncImage( // TODO : implement image uploading
+                  model = profilePicture,
+                  contentDescription = "Profile Picture",
+                  modifier =
+                      Modifier.size(100.dp)
+                          .clip(CircleShape)
+                          .background(MaterialTheme.colorScheme.primary)
+                          .testTag("profilePicture")) // Added test tag
 
-            Spacer(modifier = Modifier.height(padding))
+              Spacer(modifier = Modifier.height(padding))
 
-            // Name Input
-            Text(
-                text = "${user.name}, ${user.calculateAge()}",
-                style = TextStyle(fontSize = textSize.value.sp),
-                modifier =
-                Modifier
-                    .fillMaxWidth()
-                    .wrapContentWidth(Alignment.CenterHorizontally)
-                    .testTag("nameAndAge"))
-            Spacer(modifier = Modifier.height(padding))
+              // Name Input
+              Text(
+                  text = "${user.name}, ${user.calculateAge()}",
+                  style = TextStyle(fontSize = textSize.value.sp),
+                  modifier =
+                      Modifier.fillMaxWidth()
+                          .wrapContentWidth(Alignment.CenterHorizontally)
+                          .testTag("nameAndAge"))
+              Spacer(modifier = Modifier.height(padding))
 
-            // Catchphrase Input
-            OutlinedTextField(
-                value = catchphrase,
-                onValueChange = { catchphrase = it },
-                label = { Text("Catchphrase") },
-                modifier =
-                Modifier
-                    .fillMaxWidth()
-                    .height(60.dp)
-                    .testTag("catchphrase"))
+              // Catchphrase Input
+              OutlinedTextField(
+                  value = catchphrase,
+                  onValueChange = { catchphrase = it },
+                  label = { Text("Catchphrase") },
+                  modifier = Modifier.fillMaxWidth().height(60.dp).testTag("catchphrase"))
 
-            Spacer(modifier = Modifier.height(padding))
+              Spacer(modifier = Modifier.height(padding))
 
-            // Description Input
-            OutlinedTextField(
-                value = description,
-                onValueChange = { description = it },
-                label = { Text("Description") },
-                modifier =
-                Modifier
-                    .fillMaxWidth()
-                    .height(100.dp)
-                    .testTag("description"))
-            Spacer(modifier = Modifier.height(padding))
+              // Description Input
+              OutlinedTextField(
+                  value = description,
+                  onValueChange = { description = it },
+                  label = { Text("Description") },
+                  modifier = Modifier.fillMaxWidth().height(100.dp).testTag("description"))
+              Spacer(modifier = Modifier.height(padding))
 
-            //TODO: This is temporary for tests and will be replaced with the actual tag selector of Maximo
-            OutlinedTextField(
-                value = searchQuery,
-                onValueChange = { searchQuery = it },
-                label = { Text("Search Tags") },
-                modifier =
-                Modifier
-                    .fillMaxWidth()
-                    .height(60.dp)
-                    .testTag("searchTags")
-            )
-            Spacer(modifier = Modifier.height(padding))
+              // TODO: This is temporary for tests and will be replaced with the actual tag selector
+              // of Maximo
+              OutlinedTextField(
+                  value = searchQuery,
+                  onValueChange = { searchQuery = it },
+                  label = { Text("Search Tags") },
+                  modifier = Modifier.fillMaxWidth().height(60.dp).testTag("searchTags"))
+              Spacer(modifier = Modifier.height(padding))
 
-            //TODO : This will be replaced by the actual tags
-            Text(
-                "Tags",
-                style = MaterialTheme.typography.titleMedium,
-                modifier =
-                Modifier
-                    .align(Alignment.Start)
-                    .testTag("userTags"))
+              // TODO : This will be replaced by the actual tags
+              Text(
+                  "Tags",
+                  style = MaterialTheme.typography.titleMedium,
+                  modifier = Modifier.align(Alignment.Start).testTag("userTags"))
 
-            //TODO: implement tags query and display with Maximo's tags UI and Samuel's viewProfile
+              // TODO: implement tags query and display with Maximo's tags UI and Samuel's
+              // viewProfile
 
-            // Modal for unsaved changes on leave page with back button
-            if (showDialog) {
+              // Modal for unsaved changes on leave page with back button
+              if (showDialog) {
                 AlertDialog(
                     onDismissRequest = { showDialog = false },
                     title = { Text("You are about to leave this page") },
                     text = { Text("Do you want to save your changes?") },
                     confirmButton = {
-                        TextButton(onClick = { navigationActions.goBack() }) {
-                            Text("Discard changes")
-                        }
+                      TextButton(onClick = { navigationActions.goBack() }) {
+                        Text("Discard changes")
+                      }
                     },
                     dismissButton = {
-                        TextButton(onClick = { showDialog = false }) { Text("Cancel") }
+                      TextButton(onClick = { showDialog = false }) { Text("Cancel") }
                     },
-                    modifier = Modifier.testTag("alertDialog")
-                )
+                    modifier = Modifier.testTag("alertDialog"))
+              }
             }
-        }
-    }
+      }
 }

--- a/app/src/main/java/com/github/se/icebreakrr/ui/profile/ProfileEdit.kt
+++ b/app/src/main/java/com/github/se/icebreakrr/ui/profile/ProfileEdit.kt
@@ -61,6 +61,7 @@ fun ProfileEditingScreen(navigationActions: NavigationActions) {
       modifier = Modifier.testTag("profileEditScreen"),
       topBar = {
         TopAppBar(
+            modifier = Modifier.testTag("topAppBar"),
             title = { Text("") },
             navigationIcon = {
               IconButton(
@@ -83,7 +84,7 @@ fun ProfileEditingScreen(navigationActions: NavigationActions) {
             })
       }) {
         Column(
-            modifier = Modifier.padding(it).padding(padding),
+            modifier = Modifier.padding(it).padding(padding).testTag("profileEditScreenContent"),
             horizontalAlignment = Alignment.CenterHorizontally) {
               AsyncImage( // TODO : implement image uploading
                   model = profilePicture,
@@ -110,7 +111,7 @@ fun ProfileEditingScreen(navigationActions: NavigationActions) {
               OutlinedTextField(
                   value = catchphrase,
                   onValueChange = { catchphrase = it },
-                  label = { Text("Catchphrase") },
+                  label = { Text("Catchphrase", modifier = Modifier.testTag("catchphraseLabel")) },
                   modifier = Modifier.fillMaxWidth().height(60.dp).testTag("catchphrase"))
 
               Spacer(modifier = Modifier.height(padding))

--- a/app/src/main/java/com/github/se/icebreakrr/ui/sections/Settings.kt
+++ b/app/src/main/java/com/github/se/icebreakrr/ui/sections/Settings.kt
@@ -2,14 +2,18 @@ package com.github.se.icebreakrr.ui.sections
 
 import android.annotation.SuppressLint
 import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.Button
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.unit.dp
 import com.github.se.icebreakrr.ui.navigation.BottomNavigationMenu
 import com.github.se.icebreakrr.ui.navigation.LIST_TOP_LEVEL_DESTINATIONS
 import com.github.se.icebreakrr.ui.navigation.NavigationActions
+import com.github.se.icebreakrr.ui.navigation.Screen
 
 /**
  * Composable function for displaying the profile screen.
@@ -30,10 +34,12 @@ fun SettingsScreen(navigationActions: NavigationActions) {
             selectedItem = navigationActions.currentRoute())
       },
       content = { innerPadding ->
-        // Use the innerPadding to apply padding around your content
-        Text(
-            text = "Settings screen", // TODO PLaceholder
-            modifier = Modifier.padding(innerPadding) // Applying the padding to the content
-            )
+        Button(
+            onClick = {
+              navigationActions.navigateTo(Screen.PROFILE_EDIT)
+            }, // Navigate to profile edit screen
+            modifier = Modifier.padding(8.dp).testTag("profileEditScreen")) {
+              Text(text = "Edit Profile", color = Color.White) // Button text
+        }
       })
 }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -2,6 +2,9 @@
 accompanistFlowlayout = "0.32.0"
 accompanistFlowlayoutVersion = "0.32.0"
 agp = "8.3.0"
+coilCompose = "2.1.0"
+firebaseBom = "33.4.0"
+firebaseBomVersion = "32.6.0"
 kotlin = "1.8.10"
 coreKtx = "1.12.0"
 ktfmt = "0.17.0"
@@ -16,6 +19,7 @@ composeViewModel = "2.7.0"
 lifecycleRuntimeKtx = "2.7.0"
 kaspresso = "1.5.5"
 mockitoAndroid = "5.13.0"
+playServicesLocation = "21.3.0"
 robolectric = "4.11.1"
 sonar = "4.4.1.3373"
 navigationCompose = "2.8.2"
@@ -32,6 +36,7 @@ firebaseAuthKtx = "23.0.0"
 firebaseDatabaseKtx = "21.0.0"
 firebaseFirestore = "25.1.0"
 firebaseUiAuth = "8.0.0"
+firebase = "31.0.0"
 
 [libraries]
 firebase-auth = { module = "com.google.firebase:firebase-auth", version.ref = "firebaseAuth" }
@@ -45,6 +50,9 @@ geofirestore = { module = "com.github.imperiumlabs:GeoFirestore-Android", versio
 accompanist-flowlayout = { module = "com.google.accompanist:accompanist-flowlayout", version.ref = "accompanistFlowlayout" }
 accompanist-flowlayout-vlatestversion = { module = "com.google.accompanist:accompanist-flowlayout", version.ref = "accompanistFlowlayoutVersion" }
 androidx-core-ktx = { group = "androidx.core", name = "core-ktx", version.ref = "coreKtx" }
+coil-compose = { module = "io.coil-kt:coil-compose", version.ref = "coilCompose" }
+firebase-bom = { module = "com.google.firebase:firebase-bom", version.ref = "firebaseBom" }
+firebase-bom-v3260 = { module = "com.google.firebase:firebase-bom", version.ref = "firebaseBomVersion" }
 junit = { group = "junit", name = "junit", version.ref = "junit" }
 androidx-junit = { group = "androidx.test.ext", name = "junit", version.ref = "junitVersion" }
 androidx-espresso-core = { group = "androidx.test.espresso", name = "espresso-core", version.ref = "espressoCore" }
@@ -68,6 +76,7 @@ kaspresso = { group = "com.kaspersky.android-components", name = "kaspresso", ve
 kaspresso-compose = { group = "com.kaspersky.android-components", name = "kaspresso-compose-support", version.ref = "kaspresso" }
 
 mockito-android = { module = "org.mockito:mockito-android", version.ref = "mockitoAndroid" }
+play-services-location = { module = "com.google.android.gms:play-services-location", version.ref = "playServicesLocation" }
 robolectric = { module = "org.robolectric:robolectric", version.ref = "robolectric" }
 
 androidx-navigation-compose = { group = "androidx.navigation", name = "navigation-compose", version.ref = "navigationCompose" }


### PR DESCRIPTION
### Profile Editing Feature:

* **New Profile Editing Screen**: Added `ProfileEditingScreen` with UI components for profile picture, name, age, catchphrase, description, and tags. Includes functionality for back and save buttons. (`app/src/main/java/com/github/se/icebreakrr/ui/profile/ProfileEdit.kt`)
Nevertheless, the tags are not yet displayed because I need the viewmodel for TagsView. It's the same for the Profile save and display (currently it's a mock one) because I need the ViewModel for Profile Data Class to get and update the profile.

* **Navigation Updates**: Integrated `ProfileEdit Screen` into the app's navigation. Added routes and navigation actions for the profile editing screen. (`app/src/main/java/com/github/se/icebreakrr/MainActivity.kt`, `app/src/main/java/com/github/se/icebreakrr/ui/navigation/TopLevelDestination.kt`) [[1]](diffhunk://#diff-db5af136504ab23c2dc4b1831d3b939f790ccf875a8821932eec2c7aaf49ca3aR17) [[2]](diffhunk://#diff-db5af136504ab23c2dc4b1831d3b939f790ccf875a8821932eec2c7aaf49ca3aR68-R74) [[3]](diffhunk://#diff-4512e3d33ea87a926a7dcc76df5797f694f1b94d9a2d75edaf06f4051fb07859R23-R31)
* **Settings Screen Update**: Added a temporary button in the `SettingsScreen` to navigate to the profile editing screen. (`app/src/main/java/com/github/se/icebreakrr/ui/sections/Settings.kt`) [[1]](diffhunk://#diff-f64acaf6e1dc6c0aa52389a94a1eb2640df301927f3d62c12ed981ed55bc455bR5-R16) [[2]](diffhunk://#diff-f64acaf6e1dc6c0aa52389a94a1eb2640df301927f3d62c12ed981ed55bc455bL33-R43)

### Testing:

* **Profile Editing Screen Tests**: Added comprehensive tests for the `ProfileEditingScreen` to verify UI components and edge cases. (`app/src/androidTest/java/com/github/se/icebreakrr/ui/profile/profileEditTest.kt`)

### Dependencies:

* **Dependency Additions**: Added new dependencies for `coil.compose` to support image loading. (`app/build.gradle.kts`, `gradle/libs.versions.toml`) [[1]](diffhunk://#diff-8cff73265af19c059547b76aca8882cbaa3209291406f52df1dafbbc78e80c46R144-R147) [[2]](diffhunk://#diff-697f70cdd88ba88fe77eebda60c7e143f6ad1286bca75017421e93ad84fb87dfR5-R7) [[3]](diffhunk://#diff-697f70cdd88ba88fe77eebda60c7e143f6ad1286bca75017421e93ad84fb87dfR22) [[4]](diffhunk://#diff-697f70cdd88ba88fe77eebda60c7e143f6ad1286bca75017421e93ad84fb87dfR39) [[5]](diffhunk://#diff-697f70cdd88ba88fe77eebda60c7e143f6ad1286bca75017421e93ad84fb87dfR53-R55) [[6]](diffhunk://#diff-697f70cdd88ba88fe77eebda60c7e143f6ad1286bca75017421e93ad84fb87dfR79)