### PR TITLE
fix: add env for the tests

### DIFF
--- a/.github/workflows/build-apk.yml
+++ b/.github/workflows/build-apk.yml
@@ -31,6 +31,10 @@ jobs:
 
       - name: Run tests
         run: ./gradlew test
+        env:
+          KEYSTORE_PASSWORD: ${{ secrets.KEYSTORE_PASSWORD }}
+          KEY_ALIAS: ${{ secrets.KEY_ALIAS }}
+          KEY_PASSWORD: ${{ secrets.KEY_PASSWORD }}
 
       - name: Upload Test Results
         uses: actions/upload-artifact@v3


### PR DESCRIPTION
Again, micro-PR because we can test the apk-builder only in the main.