### PR TITLE
fix: copy the kestore and google-services from secrets

### DIFF
--- a/.github/workflows/build-apk.yml
+++ b/.github/workflows/build-apk.yml
@@ -18,6 +18,16 @@ jobs:
           distribution: 'temurin'
           java-version: '17'
 
+        # Create and populate google-services.json file
+      - name: Create and populate google-services.json
+        run: echo ${{ secrets.GOOGLE_SERVICES }} | base64 --decode > ./app/google-services.json
+
+      # Create keystore/debug.keystore file
+      - name: Create file debug keystore
+        run: |
+          mkdir -p ./keystore
+          echo "${{ secrets.DEBUG_KEYSTORE }}" | base64 --decode > ./keystore/debug.keystore
+
       - name: Grant execute permission for Gradle wrapper
         run: chmod +x ./gradlew
 


### PR DESCRIPTION
Again, micro-PR because we can test the apk-builder only in the main.
> [!NOTE]
> I want the readers to read it carefully as it contains many important docs.
