### PR TITLE
fix: add env for the build

### DIFF
--- a/.github/workflows/build-apk.yml
+++ b/.github/workflows/build-apk.yml
@@ -54,6 +54,10 @@ jobs:
 
       - name: Build the project
         run: ./gradlew assembleDebug
+        env:
+          KEYSTORE_PASSWORD: ${{ secrets.KEYSTORE_PASSWORD }}
+          KEY_ALIAS: ${{ secrets.KEY_ALIAS }}
+          KEY_PASSWORD: ${{ secrets.KEY_PASSWORD }}
 
       - name: Upload APK
         uses: actions/upload-artifact@v3


### PR DESCRIPTION
Again, micro-PR because we can test the apk-builder only in the main.
(should work this time I promise)