### PR TITLE
Feature/profile screen

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -165,6 +165,8 @@ dependencies {
     implementation("com.google.accompanist:accompanist-flowlayout:0.32.0")
 
     debugImplementation(libs.compose.tooling)
+    implementation(libs.coil.compose)
+
     // UI Tests
     globalTestImplementation(libs.compose.test.junit)
     debugImplementation(libs.compose.test.manifest)

--- a/app/src/androidTest/java/com/github/se/icebreakrr/ui/navigation/NavigationTest.kt
+++ b/app/src/androidTest/java/com/github/se/icebreakrr/ui/navigation/NavigationTest.kt
@@ -31,7 +31,9 @@ class NavigationTest {
     composeTestRule.onNodeWithTag("aroundYouScreen").assertIsDisplayed()
 
     composeTestRule.onNodeWithTag("navItem_${R.string.settings}").performClick()
-    composeTestRule.onNodeWithTag("settingsScreen").assertIsDisplayed()
+    composeTestRule.onNodeWithTag("profileScreen").assertIsDisplayed()
+
+    composeTestRule.onNodeWithTag("goBackButton").performClick()
 
     composeTestRule.onNodeWithTag("navItem_${R.string.notifications}").performClick()
     composeTestRule.onNodeWithTag("notificationScreen").assertIsDisplayed()

--- a/app/src/androidTest/java/com/github/se/icebreakrr/ui/navigation/NavigationTest.kt
+++ b/app/src/androidTest/java/com/github/se/icebreakrr/ui/navigation/NavigationTest.kt
@@ -2,6 +2,8 @@ package com.github.se.icebreakrr.ui.navigation
 
 import androidx.compose.ui.test.assertIsDisplayed
 import androidx.compose.ui.test.junit4.createAndroidComposeRule
+import androidx.compose.ui.test.onAllNodesWithTag
+import androidx.compose.ui.test.onFirst
 import androidx.compose.ui.test.onNodeWithTag
 import androidx.compose.ui.test.performClick
 import androidx.test.ext.junit.runners.AndroidJUnit4
@@ -33,6 +35,17 @@ class NavigationTest {
     composeTestRule.onNodeWithTag("navItem_${R.string.settings}").performClick()
     composeTestRule.onNodeWithTag("profileScreen").assertIsDisplayed()
 
+    composeTestRule.onNodeWithTag("editButton").performClick()
+    composeTestRule.onNodeWithTag("profileEditScreen").assertIsDisplayed()
+
+    composeTestRule.onNodeWithTag("goBackButton").performClick()
+    composeTestRule.onNodeWithTag("discardChangesOption").performClick()
+
+    composeTestRule.onNodeWithTag("profileScreen").assertIsDisplayed()
+    composeTestRule.onNodeWithTag("goBackButton").performClick()
+
+    composeTestRule.onAllNodesWithTag("profileCard").onFirst().performClick()
+    composeTestRule.onNodeWithTag("profileScreen").assertIsDisplayed()
     composeTestRule.onNodeWithTag("goBackButton").performClick()
 
     composeTestRule.onNodeWithTag("navItem_${R.string.notifications}").performClick()

--- a/app/src/androidTest/java/com/github/se/icebreakrr/ui/profile/ProfileTest.kt
+++ b/app/src/androidTest/java/com/github/se/icebreakrr/ui/profile/ProfileTest.kt
@@ -1,0 +1,103 @@
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.test.*
+import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.github.se.icebreakrr.ui.profile.ProfileView
+import com.github.se.icebreakrr.ui.tags.RowOfTags
+import com.github.se.icebreakrr.ui.navigation.NavigationActions
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.verify
+
+@RunWith(AndroidJUnit4::class)
+class ProfileViewTest {
+
+    @get:Rule
+    val composeTestRule = createComposeRule()
+
+    private lateinit var navigationActionsMock: NavigationActions
+
+    @Before
+    fun setUp() {
+        navigationActionsMock = mock()
+    }
+
+    @Test
+    fun testProfileHeaderDisplaysCorrectly() {
+        composeTestRule.setContent {
+            ProfileView(navigationActions = navigationActionsMock)
+        }
+
+        // Verify that the profile header and its elements are displayed
+        composeTestRule.onNodeWithTag("profileHeader").assertIsDisplayed()
+        composeTestRule.onNodeWithTag("profilePicture").assertIsDisplayed()
+        composeTestRule.onNodeWithTag("goBackButton").assertIsDisplayed()
+        composeTestRule.onNodeWithTag("editButton").assertIsDisplayed()
+        composeTestRule.onNodeWithTag("username").assertTextEquals("Jean Michelle")
+    }
+
+    @Test
+    fun testGoBackButtonFunctionality() {
+        composeTestRule.setContent {
+            ProfileView(navigationActions = navigationActionsMock)
+        }
+
+        composeTestRule.onNodeWithTag("goBackButton").assertIsDisplayed()
+        composeTestRule.onNodeWithTag("goBackButton").performClick()
+
+        verify(navigationActionsMock).goBack()
+    }
+
+    @Test
+    fun testEditButtonFunctionality() {
+        composeTestRule.setContent {
+            ProfileView(navigationActions = navigationActionsMock)
+        }
+
+        composeTestRule.onNodeWithTag("editButton").assertIsDisplayed()
+        composeTestRule.onNodeWithTag("editButton").performClick()
+
+        //Add edit profile navigation logic
+    }
+
+    @Test
+    fun testInfoSectionDisplaysCorrectly() {
+        composeTestRule.setContent {
+            ProfileView(navigationActions = navigationActionsMock)
+        }
+
+        // Verify that the info section is displayed
+        composeTestRule.onNodeWithTag("infoSection").assertIsDisplayed()
+
+        // Verify that the catchphrase is displayed
+        composeTestRule.onNodeWithText("This is my catchphrase, there are many like it but this one is mine!")
+            .assertIsDisplayed()
+
+        // Verify that all tags are displayed
+        composeTestRule.onNodeWithTag("tagSection").assertIsDisplayed()
+
+        // Verify that the description is displayed
+        composeTestRule.onNodeWithTag("profileDescription").assertIsDisplayed()
+    }
+
+    @Test
+    fun testProfileDescriptionDisplaysCorrectly() {
+        composeTestRule.setContent {
+            ProfileView(navigationActions = navigationActionsMock)
+        }
+
+        // Verify that the profile description is displayed correctly
+        composeTestRule.onNodeWithTag("profileDescription")
+            .assertTextContains("""
+                Hey there! I'm John Do, a bit of a tech geek who loves exploring all things digital. 
+                When I'm not deep into coding or working on new apps, I'm usually out cycling, discovering new trails, 
+                or whipping up something fun in the kitchen. I'm also a huge sci-fi fan—if you love talking about future 
+                worlds or cool ideas, we'll get along great. I'm always up for a good laugh, sharing ideas, and meeting new people. 
+                Let's connect, hang out, or chat about anything cool!
+            """.trimIndent())
+            .assertIsDisplayed()
+    }
+}

--- a/app/src/androidTest/java/com/github/se/icebreakrr/ui/profile/ProfileTest.kt
+++ b/app/src/androidTest/java/com/github/se/icebreakrr/ui/profile/ProfileTest.kt
@@ -1,10 +1,13 @@
-import androidx.compose.ui.graphics.Color
-import androidx.compose.ui.test.*
+import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.assertTextContains
+import androidx.compose.ui.test.assertTextEquals
 import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.compose.ui.test.onNodeWithTag
+import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.test.performClick
 import androidx.test.ext.junit.runners.AndroidJUnit4
-import com.github.se.icebreakrr.ui.profile.ProfileView
-import com.github.se.icebreakrr.ui.tags.RowOfTags
 import com.github.se.icebreakrr.ui.navigation.NavigationActions
+import com.github.se.icebreakrr.ui.profile.ProfileView
 import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
@@ -15,89 +18,82 @@ import org.mockito.kotlin.verify
 @RunWith(AndroidJUnit4::class)
 class ProfileViewTest {
 
-    @get:Rule
-    val composeTestRule = createComposeRule()
+  @get:Rule val composeTestRule = createComposeRule()
 
-    private lateinit var navigationActionsMock: NavigationActions
+  private lateinit var navigationActionsMock: NavigationActions
 
-    @Before
-    fun setUp() {
-        navigationActionsMock = mock()
-    }
+  @Before
+  fun setUp() {
+    navigationActionsMock = mock()
+  }
 
-    @Test
-    fun testProfileHeaderDisplaysCorrectly() {
-        composeTestRule.setContent {
-            ProfileView(navigationActions = navigationActionsMock)
-        }
+  @Test
+  fun testProfileHeaderDisplaysCorrectly() {
+    composeTestRule.setContent { ProfileView(navigationActions = navigationActionsMock) }
 
-        // Verify that the profile header and its elements are displayed
-        composeTestRule.onNodeWithTag("profileHeader").assertIsDisplayed()
-        composeTestRule.onNodeWithTag("profilePicture").assertIsDisplayed()
-        composeTestRule.onNodeWithTag("goBackButton").assertIsDisplayed()
-        composeTestRule.onNodeWithTag("editButton").assertIsDisplayed()
-        composeTestRule.onNodeWithTag("username").assertTextEquals("Jean Michelle")
-    }
+    // Verify that the profile header and its elements are displayed
+    composeTestRule.onNodeWithTag("profileHeader").assertIsDisplayed()
+    composeTestRule.onNodeWithTag("profilePicture").assertIsDisplayed()
+    composeTestRule.onNodeWithTag("goBackButton").assertIsDisplayed()
+    composeTestRule.onNodeWithTag("editButton").assertIsDisplayed()
+    composeTestRule.onNodeWithTag("username").assertTextEquals("Jean Michelle")
+  }
 
-    @Test
-    fun testGoBackButtonFunctionality() {
-        composeTestRule.setContent {
-            ProfileView(navigationActions = navigationActionsMock)
-        }
+  @Test
+  fun testGoBackButtonFunctionality() {
+    composeTestRule.setContent { ProfileView(navigationActions = navigationActionsMock) }
 
-        composeTestRule.onNodeWithTag("goBackButton").assertIsDisplayed()
-        composeTestRule.onNodeWithTag("goBackButton").performClick()
+    composeTestRule.onNodeWithTag("goBackButton").assertIsDisplayed()
+    composeTestRule.onNodeWithTag("goBackButton").performClick()
 
-        verify(navigationActionsMock).goBack()
-    }
+    verify(navigationActionsMock).goBack()
+  }
 
-    @Test
-    fun testEditButtonFunctionality() {
-        composeTestRule.setContent {
-            ProfileView(navigationActions = navigationActionsMock)
-        }
+  @Test
+  fun testEditButtonFunctionality() {
+    composeTestRule.setContent { ProfileView(navigationActions = navigationActionsMock) }
 
-        composeTestRule.onNodeWithTag("editButton").assertIsDisplayed()
-        composeTestRule.onNodeWithTag("editButton").performClick()
+    composeTestRule.onNodeWithTag("editButton").assertIsDisplayed()
+    composeTestRule.onNodeWithTag("editButton").performClick()
 
-        //Add edit profile navigation logic
-    }
+    // Add edit profile navigation logic
+  }
 
-    @Test
-    fun testInfoSectionDisplaysCorrectly() {
-        composeTestRule.setContent {
-            ProfileView(navigationActions = navigationActionsMock)
-        }
+  @Test
+  fun testInfoSectionDisplaysCorrectly() {
+    composeTestRule.setContent { ProfileView(navigationActions = navigationActionsMock) }
 
-        // Verify that the info section is displayed
-        composeTestRule.onNodeWithTag("infoSection").assertIsDisplayed()
+    // Verify that the info section is displayed
+    composeTestRule.onNodeWithTag("infoSection").assertIsDisplayed()
 
-        // Verify that the catchphrase is displayed
-        composeTestRule.onNodeWithText("This is my catchphrase, there are many like it but this one is mine!")
-            .assertIsDisplayed()
+    // Verify that the catchphrase is displayed
+    composeTestRule
+        .onNodeWithText("This is my catchphrase, there are many like it but this one is mine!")
+        .assertIsDisplayed()
 
-        // Verify that all tags are displayed
-        composeTestRule.onNodeWithTag("tagSection").assertIsDisplayed()
+    // Verify that all tags are displayed
+    composeTestRule.onNodeWithTag("tagSection").assertIsDisplayed()
 
-        // Verify that the description is displayed
-        composeTestRule.onNodeWithTag("profileDescription").assertIsDisplayed()
-    }
+    // Verify that the description is displayed
+    composeTestRule.onNodeWithTag("profileDescription").assertIsDisplayed()
+  }
 
-    @Test
-    fun testProfileDescriptionDisplaysCorrectly() {
-        composeTestRule.setContent {
-            ProfileView(navigationActions = navigationActionsMock)
-        }
+  @Test
+  fun testProfileDescriptionDisplaysCorrectly() {
+    composeTestRule.setContent { ProfileView(navigationActions = navigationActionsMock) }
 
-        // Verify that the profile description is displayed correctly
-        composeTestRule.onNodeWithTag("profileDescription")
-            .assertTextContains("""
+    // Verify that the profile description is displayed correctly
+    composeTestRule
+        .onNodeWithTag("profileDescription")
+        .assertTextContains(
+            """
                 Hey there! I'm John Do, a bit of a tech geek who loves exploring all things digital. 
                 When I'm not deep into coding or working on new apps, I'm usually out cycling, discovering new trails, 
                 or whipping up something fun in the kitchen. I'm also a huge sci-fi fan—if you love talking about future 
                 worlds or cool ideas, we'll get along great. I'm always up for a good laugh, sharing ideas, and meeting new people. 
                 Let's connect, hang out, or chat about anything cool!
-            """.trimIndent())
-            .assertIsDisplayed()
-    }
+            """
+                .trimIndent())
+        .assertIsDisplayed()
+  }
 }

--- a/app/src/main/java/com/github/se/icebreakrr/ui/profile/ProfileEdit.kt
+++ b/app/src/main/java/com/github/se/icebreakrr/ui/profile/ProfileEdit.kt
@@ -149,9 +149,11 @@ fun ProfileEditingScreen(navigationActions: NavigationActions) {
                     title = { Text("You are about to leave this page") },
                     text = { Text("Do you want to save your changes?") },
                     confirmButton = {
-                      TextButton(onClick = { navigationActions.goBack() }) {
-                        Text("Discard changes")
-                      }
+                      TextButton(
+                          onClick = { navigationActions.goBack() },
+                          modifier = Modifier.testTag("discardChangesOption")) {
+                            Text("Discard changes")
+                          }
                     },
                     dismissButton = {
                       TextButton(onClick = { showDialog = false }) { Text("Cancel") }

--- a/app/src/main/java/com/github/se/icebreakrr/ui/profile/ProfileView.kt
+++ b/app/src/main/java/com/github/se/icebreakrr/ui/profile/ProfileView.kt
@@ -42,83 +42,80 @@ import com.github.se.icebreakrr.ui.tags.RowOfTags
 import com.github.se.icebreakrr.ui.tags.TagStyle
 
 /**
- * Displays the main profile view with the profile header and information section.
- * The profile header shows the profile image, back button, and user name.
- * The information section contains a catchphrase, tags, and description.
+ * Displays the main profile view with the profile header and information section. The profile
+ * header shows the profile image, back button, and user name. The information section contains a
+ * catchphrase, tags, and description.
  *
  * @param navigationActions Actions to navigate between screens.
  */
 @Composable
 fun ProfileView(navigationActions: NavigationActions) {
-    
-    // Predefined user for UI testing
-    var name = "Jean-Michel"
-    var catchphrase = "This is my catchphrase, there are many like it but this one is mine!"
-    var description = """
-                Hey there! I'm John Do, a bit of a tech geek who loves exploring all things digital. 
-                When I'm not deep into coding or working on new apps, I'm usually out cycling, discovering new trails, 
-                or whipping up something fun in the kitchen. I'm also a huge sci-fi fan—if you love talking about future 
-                worlds or cool ideas, we'll get along great. I'm always up for a good laugh, sharing ideas, and meeting new people. 
-                Let's connect, hang out, or chat about anything cool!
-            """.trimIndent()
-    val userTags = remember {
-        listOf(
-            Pair("salsa", Color.Red),
-            Pair("pesto", Color.Green),
-            Pair("psto", Color.Blue),
-            Pair("pest", Color.Green),
-            Pair("peest", Color.Green)
-        )
-    }
 
-    Scaffold(
-        modifier = Modifier.testTag("profileScreen"),
-        content = { paddingValues ->
-            Column(
-                modifier = Modifier
-                    .fillMaxWidth()
-                    .padding(paddingValues),
-                horizontalAlignment = Alignment.CenterHorizontally
-            ) {
-                //2 sections one for the profile image with overlay and
-                //one for the information section
-                ProfileHeader(navigationActions)
-                InfoSection(
-                    catchPhrase = catchphrase,
-                    listOfTags = userTags,
-                    description = """
+  // Predefined user for UI testing
+  var name = "Jean-Michel"
+  var catchphrase = "This is my catchphrase, there are many like it but this one is mine!"
+  var description =
+      """
                 Hey there! I'm John Do, a bit of a tech geek who loves exploring all things digital. 
                 When I'm not deep into coding or working on new apps, I'm usually out cycling, discovering new trails, 
                 or whipping up something fun in the kitchen. I'm also a huge sci-fi fan—if you love talking about future 
                 worlds or cool ideas, we'll get along great. I'm always up for a good laugh, sharing ideas, and meeting new people. 
                 Let's connect, hang out, or chat about anything cool!
-                """.trimIndent()
-                )
+            """
+          .trimIndent()
+  val userTags = remember {
+    listOf(
+        Pair("salsa", Color.Red),
+        Pair("pesto", Color.Green),
+        Pair("psto", Color.Blue),
+        Pair("pest", Color.Green),
+        Pair("peest", Color.Green))
+  }
+
+  Scaffold(
+      modifier = Modifier.testTag("profileScreen"),
+      content = { paddingValues ->
+        Column(
+            modifier = Modifier.fillMaxWidth().padding(paddingValues),
+            horizontalAlignment = Alignment.CenterHorizontally) {
+              // 2 sections one for the profile image with overlay and
+              // one for the information section
+              ProfileHeader(navigationActions)
+              InfoSection(
+                  catchPhrase = catchphrase,
+                  listOfTags = userTags,
+                  description =
+                      """
+                Hey there! I'm John Do, a bit of a tech geek who loves exploring all things digital. 
+                When I'm not deep into coding or working on new apps, I'm usually out cycling, discovering new trails, 
+                or whipping up something fun in the kitchen. I'm also a huge sci-fi fan—if you love talking about future 
+                worlds or cool ideas, we'll get along great. I'm always up for a good laugh, sharing ideas, and meeting new people. 
+                Let's connect, hang out, or chat about anything cool!
+                """
+                          .trimIndent())
             }
-        }
-    )
+      })
 }
 
 /**
- * Displays the user's information section with a catchphrase, tags, and description.
- * The content is scrollable if it exceeds the available screen space.
+ * Displays the user's information section with a catchphrase, tags, and description. The content is
+ * scrollable if it exceeds the available screen space.
  *
  * @param catchPhrase The user's catchphrase.
  * @param listOfTags A list of tags related to the user, paired with colors.
  * @param description The user's detailed description.
  */
 @Composable
-fun InfoSection(catchPhrase: String, listOfTags : List<Pair<String, Color>>, description: String) {
+fun InfoSection(catchPhrase: String, listOfTags: List<Pair<String, Color>>, description: String) {
 
-    val scrollState = rememberScrollState()
+  val scrollState = rememberScrollState()
 
-    Column(
-        modifier = Modifier
-            .fillMaxWidth()
-            .padding(16.dp)
-            .verticalScroll(scrollState)
-            .testTag("infoSection")
-    ) {
+  Column(
+      modifier =
+          Modifier.fillMaxWidth()
+              .padding(16.dp)
+              .verticalScroll(scrollState)
+              .testTag("infoSection")) {
         // Catchphrase Section
         Spacer(modifier = Modifier.height(12.dp))
         ProfileCatchPhrase(catchPhrase)
@@ -130,84 +127,74 @@ fun InfoSection(catchPhrase: String, listOfTags : List<Pair<String, Color>>, des
         // Description Section
         Spacer(modifier = Modifier.height(16.dp))
         ProfileDescription(description)
-    }
+      }
 }
 
 /**
- * Displays the profile header section with a profile image, a back button, and an edit button.
- * It also shows the username in an overlay at the bottom of the profile image.
+ * Displays the profile header section with a profile image, a back button, and an edit button. It
+ * also shows the username in an overlay at the bottom of the profile image.
  *
  * @param navigationActions Actions to navigate between screens.
  */
 @Composable
 fun ProfileHeader(navigationActions: NavigationActions) {
-    Box(
-        modifier = Modifier
-            .fillMaxWidth() // Make the image take full width
-            .aspectRatio(1f) // Keep the aspect ratio 1:1 (height == width) => a square
-            .background(Color.LightGray)
-            .testTag("profileHeader")
-    ) {
+  Box(
+      modifier =
+          Modifier.fillMaxWidth() // Make the image take full width
+              .aspectRatio(1f) // Keep the aspect ratio 1:1 (height == width) => a square
+              .background(Color.LightGray)
+              .testTag("profileHeader")) {
         // Profile image
         Image(
             painter = painterResource(id = R.drawable.turtle),
             contentDescription = "Profile Image",
             contentScale = ContentScale.Crop,
-            modifier = Modifier.fillMaxSize().testTag("profilePicture")
-        )
+            modifier = Modifier.fillMaxSize().testTag("profilePicture"))
 
         // Back button
         IconButton(
             onClick = { navigationActions.goBack() },
-            modifier = Modifier
-                .align(Alignment.TopStart) // Align to the top start (top-left corner)
-                .padding(16.dp)
-                .testTag("goBackButton")
-        ) {
-            Icon(
-                imageVector = Icons.AutoMirrored.Filled.ArrowBack,
-                contentDescription = "Go Back",
-                tint = Color.White
-            )
-        }
+            modifier =
+                Modifier.align(Alignment.TopStart) // Align to the top start (top-left corner)
+                    .padding(16.dp)
+                    .testTag("goBackButton")) {
+              Icon(
+                  imageVector = Icons.AutoMirrored.Filled.ArrowBack,
+                  contentDescription = "Go Back",
+                  tint = Color.White)
+            }
 
         // Overlay with username and edit button
         Row(
-            modifier = Modifier
-                .align(Alignment.BottomStart) // Aligns this content to the bottom left
-                .fillMaxWidth()
-                .padding(16.dp),
+            modifier =
+                Modifier.align(Alignment.BottomStart) // Aligns this content to the bottom left
+                    .fillMaxWidth()
+                    .padding(16.dp),
             verticalAlignment = Alignment.CenterVertically,
-            horizontalArrangement = Arrangement.SpaceBetween
-        ) {
+            horizontalArrangement = Arrangement.SpaceBetween) {
 
-            // Username
-            Text(
-                text = "Jean Michelle",
-                fontSize = 24.sp,
-                fontWeight = FontWeight.Bold,
-                color = Color.White,
-                modifier = Modifier.testTag("username")
-            )
+              // Username
+              Text(
+                  text = "Jean Michelle",
+                  fontSize = 24.sp,
+                  fontWeight = FontWeight.Bold,
+                  color = Color.White,
+                  modifier = Modifier.testTag("username"))
 
-            // Edit Button
-            IconButton(
-                onClick = {
-                    //navController.navigate("editProfile")
-                },
-                modifier = Modifier
-                    .background(Color.White, CircleShape)
-                    .padding(4.dp)
-                    .testTag("editButton")
-            ) {
-                Icon(
-                    imageVector = Icons.Filled.Create,
-                    contentDescription = "Edit Profile",
-                    tint = Color.Gray
-                )
+              // Edit Button
+              IconButton(
+                  onClick = { navigationActions.navigateTo("Profile Edit Screen") },
+                  modifier =
+                      Modifier.background(Color.White, CircleShape)
+                          .padding(4.dp)
+                          .testTag("editButton")) {
+                    Icon(
+                        imageVector = Icons.Filled.Create,
+                        contentDescription = "Edit Profile",
+                        tint = Color.Gray)
+                  }
             }
-        }
-    }
+      }
 }
 
 /**
@@ -217,16 +204,15 @@ fun ProfileHeader(navigationActions: NavigationActions) {
  */
 @Composable
 fun ProfileCatchPhrase(catchPhrase: String) {
-    Text(
-        text = catchPhrase,
-        style = MaterialTheme.typography.bodyMedium,
-        color = Color.Black.copy(alpha = 0.8f),
-        fontWeight = FontWeight.Medium,
-        fontSize = 16.sp,
-        textAlign = TextAlign.Left,
-        maxLines = 2,
-        overflow = TextOverflow.Ellipsis
-    )
+  Text(
+      text = catchPhrase,
+      style = MaterialTheme.typography.bodyMedium,
+      color = Color.Black.copy(alpha = 0.8f),
+      fontWeight = FontWeight.Medium,
+      fontSize = 16.sp,
+      textAlign = TextAlign.Left,
+      maxLines = 2,
+      overflow = TextOverflow.Ellipsis)
 }
 
 /**
@@ -235,13 +221,10 @@ fun ProfileCatchPhrase(catchPhrase: String) {
  * @param listOfTags A list of tags, each paired with a color.
  */
 @Composable
-fun TagsSection(listOfTags : List<Pair<String, Color>>) {
-    Box(
-        modifier = Modifier.fillMaxWidth().height(80.dp).testTag("tagSection")
-
-    ) {
-        RowOfTags(listOfTags, TagStyle())
-    }
+fun TagsSection(listOfTags: List<Pair<String, Color>>) {
+  Box(modifier = Modifier.fillMaxWidth().height(80.dp).testTag("tagSection")) {
+    RowOfTags(listOfTags, TagStyle())
+  }
 }
 
 /**
@@ -251,12 +234,11 @@ fun TagsSection(listOfTags : List<Pair<String, Color>>) {
  */
 @Composable
 fun ProfileDescription(description: String) {
-    Text(
-        text = description,
-        style = MaterialTheme.typography.bodyMedium,
-        color = Color.Black.copy(alpha = 0.9f),
-        fontSize = 14.sp,
-        textAlign = TextAlign.Start,
-        modifier = Modifier.padding(8.dp).testTag("profileDescription")
-    )
+  Text(
+      text = description,
+      style = MaterialTheme.typography.bodyMedium,
+      color = Color.Black.copy(alpha = 0.9f),
+      fontSize = 14.sp,
+      textAlign = TextAlign.Start,
+      modifier = Modifier.padding(8.dp).testTag("profileDescription"))
 }

--- a/app/src/main/java/com/github/se/icebreakrr/ui/profile/ProfileView.kt
+++ b/app/src/main/java/com/github/se/icebreakrr/ui/profile/ProfileView.kt
@@ -1,0 +1,262 @@
+package com.github.se.icebreakrr.ui.profile
+
+import androidx.compose.foundation.Image
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.aspectRatio
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.ArrowBack
+import androidx.compose.material.icons.filled.Create
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import com.github.se.icebreakrr.R
+import com.github.se.icebreakrr.ui.navigation.NavigationActions
+import com.github.se.icebreakrr.ui.tags.RowOfTags
+import com.github.se.icebreakrr.ui.tags.TagStyle
+
+/**
+ * Displays the main profile view with the profile header and information section.
+ * The profile header shows the profile image, back button, and user name.
+ * The information section contains a catchphrase, tags, and description.
+ *
+ * @param navigationActions Actions to navigate between screens.
+ */
+@Composable
+fun ProfileView(navigationActions: NavigationActions) {
+    
+    // Predefined user for UI testing
+    var name = "Jean-Michel"
+    var catchphrase = "This is my catchphrase, there are many like it but this one is mine!"
+    var description = """
+                Hey there! I'm John Do, a bit of a tech geek who loves exploring all things digital. 
+                When I'm not deep into coding or working on new apps, I'm usually out cycling, discovering new trails, 
+                or whipping up something fun in the kitchen. I'm also a huge sci-fi fan—if you love talking about future 
+                worlds or cool ideas, we'll get along great. I'm always up for a good laugh, sharing ideas, and meeting new people. 
+                Let's connect, hang out, or chat about anything cool!
+            """.trimIndent()
+    val userTags = remember {
+        listOf(
+            Pair("salsa", Color.Red),
+            Pair("pesto", Color.Green),
+            Pair("psto", Color.Blue),
+            Pair("pest", Color.Green),
+            Pair("peest", Color.Green)
+        )
+    }
+
+    Scaffold(
+        modifier = Modifier.testTag("profileScreen"),
+        content = { paddingValues ->
+            Column(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(paddingValues),
+                horizontalAlignment = Alignment.CenterHorizontally
+            ) {
+                //2 sections one for the profile image with overlay and
+                //one for the information section
+                ProfileHeader(navigationActions)
+                InfoSection(
+                    catchPhrase = catchphrase,
+                    listOfTags = userTags,
+                    description = """
+                Hey there! I'm John Do, a bit of a tech geek who loves exploring all things digital. 
+                When I'm not deep into coding or working on new apps, I'm usually out cycling, discovering new trails, 
+                or whipping up something fun in the kitchen. I'm also a huge sci-fi fan—if you love talking about future 
+                worlds or cool ideas, we'll get along great. I'm always up for a good laugh, sharing ideas, and meeting new people. 
+                Let's connect, hang out, or chat about anything cool!
+                """.trimIndent()
+                )
+            }
+        }
+    )
+}
+
+/**
+ * Displays the user's information section with a catchphrase, tags, and description.
+ * The content is scrollable if it exceeds the available screen space.
+ *
+ * @param catchPhrase The user's catchphrase.
+ * @param listOfTags A list of tags related to the user, paired with colors.
+ * @param description The user's detailed description.
+ */
+@Composable
+fun InfoSection(catchPhrase: String, listOfTags : List<Pair<String, Color>>, description: String) {
+
+    val scrollState = rememberScrollState()
+
+    Column(
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(16.dp)
+            .verticalScroll(scrollState)
+            .testTag("infoSection")
+    ) {
+        // Catchphrase Section
+        Spacer(modifier = Modifier.height(12.dp))
+        ProfileCatchPhrase(catchPhrase)
+
+        // Tags Section
+        Spacer(modifier = Modifier.height(8.dp))
+        TagsSection(listOfTags)
+
+        // Description Section
+        Spacer(modifier = Modifier.height(16.dp))
+        ProfileDescription(description)
+    }
+}
+
+/**
+ * Displays the profile header section with a profile image, a back button, and an edit button.
+ * It also shows the username in an overlay at the bottom of the profile image.
+ *
+ * @param navigationActions Actions to navigate between screens.
+ */
+@Composable
+fun ProfileHeader(navigationActions: NavigationActions) {
+    Box(
+        modifier = Modifier
+            .fillMaxWidth() // Make the image take full width
+            .aspectRatio(1f) // Keep the aspect ratio 1:1 (height == width) => a square
+            .background(Color.LightGray)
+            .testTag("profileHeader")
+    ) {
+        // Profile image
+        Image(
+            painter = painterResource(id = R.drawable.turtle),
+            contentDescription = "Profile Image",
+            contentScale = ContentScale.Crop,
+            modifier = Modifier.fillMaxSize().testTag("profilePicture")
+        )
+
+        // Back button
+        IconButton(
+            onClick = { navigationActions.goBack() },
+            modifier = Modifier
+                .align(Alignment.TopStart) // Align to the top start (top-left corner)
+                .padding(16.dp)
+                .testTag("goBackButton")
+        ) {
+            Icon(
+                imageVector = Icons.AutoMirrored.Filled.ArrowBack,
+                contentDescription = "Go Back",
+                tint = Color.White
+            )
+        }
+
+        // Overlay with username and edit button
+        Row(
+            modifier = Modifier
+                .align(Alignment.BottomStart) // Aligns this content to the bottom left
+                .fillMaxWidth()
+                .padding(16.dp),
+            verticalAlignment = Alignment.CenterVertically,
+            horizontalArrangement = Arrangement.SpaceBetween
+        ) {
+
+            // Username
+            Text(
+                text = "Jean Michelle",
+                fontSize = 24.sp,
+                fontWeight = FontWeight.Bold,
+                color = Color.White,
+                modifier = Modifier.testTag("username")
+            )
+
+            // Edit Button
+            IconButton(
+                onClick = {
+                    //navController.navigate("editProfile")
+                },
+                modifier = Modifier
+                    .background(Color.White, CircleShape)
+                    .padding(4.dp)
+                    .testTag("editButton")
+            ) {
+                Icon(
+                    imageVector = Icons.Filled.Create,
+                    contentDescription = "Edit Profile",
+                    tint = Color.Gray
+                )
+            }
+        }
+    }
+}
+
+/**
+ * Displays the user's catchphrase in a medium-sized font with a maximum of two lines.
+ *
+ * @param catchPhrase The user's catchphrase.
+ */
+@Composable
+fun ProfileCatchPhrase(catchPhrase: String) {
+    Text(
+        text = catchPhrase,
+        style = MaterialTheme.typography.bodyMedium,
+        color = Color.Black.copy(alpha = 0.8f),
+        fontWeight = FontWeight.Medium,
+        fontSize = 16.sp,
+        textAlign = TextAlign.Left,
+        maxLines = 2,
+        overflow = TextOverflow.Ellipsis
+    )
+}
+
+/**
+ * Displays a section with a row of tags, each associated with a color.
+ *
+ * @param listOfTags A list of tags, each paired with a color.
+ */
+@Composable
+fun TagsSection(listOfTags : List<Pair<String, Color>>) {
+    Box(
+        modifier = Modifier.fillMaxWidth().height(80.dp).testTag("tagSection")
+
+    ) {
+        RowOfTags(listOfTags, TagStyle())
+    }
+}
+
+/**
+ * Displays the user's profile description in a medium-sized font, aligned to the start.
+ *
+ * @param description The user's description or bio.
+ */
+@Composable
+fun ProfileDescription(description: String) {
+    Text(
+        text = description,
+        style = MaterialTheme.typography.bodyMedium,
+        color = Color.Black.copy(alpha = 0.9f),
+        fontSize = 14.sp,
+        textAlign = TextAlign.Start,
+        modifier = Modifier.padding(8.dp).testTag("profileDescription")
+    )
+}

--- a/app/src/main/java/com/github/se/icebreakrr/ui/sections/AroundYou.kt
+++ b/app/src/main/java/com/github/se/icebreakrr/ui/sections/AroundYou.kt
@@ -68,9 +68,7 @@ fun AroundYouScreen(
                 items(profiles.value.size) { index ->
                   ProfileCard(
                       profile = profiles.value[index],
-                      onclick = {
-                        Toast.makeText(context, "Profile clicked", Toast.LENGTH_SHORT).show()
-                      })
+                      onclick = { navigationActions.navigateTo("Settings Screen") })
                 }
               }
         } else {

--- a/app/src/main/java/com/github/se/icebreakrr/ui/sections/Settings.kt
+++ b/app/src/main/java/com/github/se/icebreakrr/ui/sections/Settings.kt
@@ -10,6 +10,7 @@ import androidx.compose.ui.platform.testTag
 import com.github.se.icebreakrr.ui.navigation.BottomNavigationMenu
 import com.github.se.icebreakrr.ui.navigation.LIST_TOP_LEVEL_DESTINATIONS
 import com.github.se.icebreakrr.ui.navigation.NavigationActions
+import com.github.se.icebreakrr.ui.profile.ProfileView
 
 /**
  * Composable function for displaying the profile screen.
@@ -21,19 +22,20 @@ import com.github.se.icebreakrr.ui.navigation.NavigationActions
 @SuppressLint("UnusedMaterial3ScaffoldPaddingParameter")
 @Composable
 fun SettingsScreen(navigationActions: NavigationActions) {
-  Scaffold(
-      modifier = Modifier.testTag("settingsScreen"),
-      bottomBar = {
-        BottomNavigationMenu(
-            onTabSelect = { route -> navigationActions.navigateTo(route) },
-            tabList = LIST_TOP_LEVEL_DESTINATIONS,
-            selectedItem = navigationActions.currentRoute())
-      },
-      content = { innerPadding ->
-        // Use the innerPadding to apply padding around your content
-        Text(
-            text = "Settings screen", // TODO PLaceholder
-            modifier = Modifier.padding(innerPadding) // Applying the padding to the content
-            )
-      })
+  //Scaffold(
+  //    modifier = Modifier.testTag("settingsScreen"),
+  //    bottomBar = {
+  //      BottomNavigationMenu(
+  //          onTabSelect = { route -> navigationActions.navigateTo(route) },
+  //          tabList = LIST_TOP_LEVEL_DESTINATIONS,
+  //          selectedItem = navigationActions.currentRoute())
+  //    },
+  //    content = { innerPadding ->
+  //      // Use the innerPadding to apply padding around your content
+  //      Text(
+  //          text = "Settings screen", // TODO PLaceholder
+  //          modifier = Modifier.padding(innerPadding) // Applying the padding to the content
+  //          )
+  //    })
+    ProfileView(navigationActions)
 }

--- a/app/src/main/java/com/github/se/icebreakrr/ui/sections/Settings.kt
+++ b/app/src/main/java/com/github/se/icebreakrr/ui/sections/Settings.kt
@@ -1,17 +1,7 @@
 package com.github.se.icebreakrr.ui.sections
 
 import android.annotation.SuppressLint
-import androidx.compose.foundation.layout.padding
-import androidx.compose.material3.Button
-import androidx.compose.material3.Scaffold
-import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
-import androidx.compose.ui.Modifier
-import androidx.compose.ui.graphics.Color
-import androidx.compose.ui.platform.testTag
-import androidx.compose.ui.unit.dp
-import com.github.se.icebreakrr.ui.navigation.BottomNavigationMenu
-import com.github.se.icebreakrr.ui.navigation.LIST_TOP_LEVEL_DESTINATIONS
 import com.github.se.icebreakrr.ui.navigation.NavigationActions
 import com.github.se.icebreakrr.ui.profile.ProfileView
 
@@ -25,7 +15,7 @@ import com.github.se.icebreakrr.ui.profile.ProfileView
 @SuppressLint("UnusedMaterial3ScaffoldPaddingParameter")
 @Composable
 fun SettingsScreen(navigationActions: NavigationActions) {
-  //Scaffold(
+  // Scaffold(
   //    modifier = Modifier.testTag("settingsScreen"),
   //    bottomBar = {
   //      BottomNavigationMenu(
@@ -40,5 +30,5 @@ fun SettingsScreen(navigationActions: NavigationActions) {
   //          modifier = Modifier.padding(innerPadding) // Applying the padding to the content
   //          )
   //    })
-    ProfileView(navigationActions)
+  ProfileView(navigationActions)
 }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -16,7 +16,6 @@ material = "1.11.0"
 composeBom = "2024.02.02"
 composeActivity = "1.8.2"
 composeViewModel = "2.7.0"
-coilCompose = "2.1.0"
 lifecycleRuntimeKtx = "2.7.0"
 kaspresso = "1.5.5"
 mockitoAndroid = "5.13.0"
@@ -72,7 +71,6 @@ compose-activity = { group = "androidx.activity", name = "activity-compose", ver
 compose-viewmodel = { group = "androidx.lifecycle", name = "lifecycle-viewmodel-compose", version.ref = "composeViewModel" }
 compose-test-junit = { group = "androidx.compose.ui", name = "ui-test-junit4" }
 compose-test-manifest = { group = "androidx.compose.ui", name = "ui-test-manifest" }
-coil-compose = { module = "io.coil-kt:coil-compose", version.ref = "coilCompose" }
 
 kaspresso = { group = "com.kaspersky.android-components", name = "kaspresso", version.ref = "kaspresso" }
 kaspresso-compose = { group = "com.kaspersky.android-components", name = "kaspresso-compose-support", version.ref = "kaspresso" }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -13,6 +13,7 @@ material = "1.11.0"
 composeBom = "2024.02.02"
 composeActivity = "1.8.2"
 composeViewModel = "2.7.0"
+coilCompose = "2.1.0"
 lifecycleRuntimeKtx = "2.7.0"
 kaspresso = "1.5.5"
 mockitoAndroid = "5.13.0"
@@ -48,6 +49,7 @@ compose-activity = { group = "androidx.activity", name = "activity-compose", ver
 compose-viewmodel = { group = "androidx.lifecycle", name = "lifecycle-viewmodel-compose", version.ref = "composeViewModel" }
 compose-test-junit = { group = "androidx.compose.ui", name = "ui-test-junit4" }
 compose-test-manifest = { group = "androidx.compose.ui", name = "ui-test-manifest" }
+coil-compose = { module = "io.coil-kt:coil-compose", version.ref = "coilCompose" }
 
 kaspresso = { group = "com.kaspersky.android-components", name = "kaspresso", version.ref = "kaspresso" }
 kaspresso-compose = { group = "com.kaspersky.android-components", name = "kaspresso-compose-support", version.ref = "kaspresso" }


### PR DESCRIPTION
### The profile screen

summary : Added the profile screen and merged it with other features

**profile**

- As for now added a false user with predefined data with two sections : the `header` and the `info`. In the header there is the profile picture, the username, the edit button and the go back button. In the info section there is the catch phrase, the tags and the description.
- As for now the `settings` screen is replaced by the `profile screen`. When you click on a `profile card` in the `around you` screen it redirects to the fake profile.

![profileScreen](https://github.com/user-attachments/assets/66e4915d-e2ad-45b5-aa5f-07755befaeab)

**testing**

I reworked the navigation testing to take into account the new user flow for the settings `screen` and the `profile cards`