### PR TITLE
Feature/update navigation

### DIFF
--- a/app/src/androidTest/java/com/github/se/icebreakrr/ui/sections/AroundYouTest.kt
+++ b/app/src/androidTest/java/com/github/se/icebreakrr/ui/sections/AroundYouTest.kt
@@ -52,8 +52,6 @@ class AroundYouTest {
     verify(navigationActions).navigateTo(screen = Screen.FILTER)
   }
 
-
-
   @Test
   fun hasRequiredComponents() {
     composeTestRule.onNodeWithTag("aroundYouScreen").assertIsDisplayed()

--- a/app/src/androidTest/java/com/github/se/icebreakrr/ui/sections/AroundYouTest.kt
+++ b/app/src/androidTest/java/com/github/se/icebreakrr/ui/sections/AroundYouTest.kt
@@ -5,14 +5,17 @@ import androidx.compose.ui.test.junit4.createComposeRule
 import androidx.compose.ui.test.onAllNodesWithTag
 import androidx.compose.ui.test.onFirst
 import androidx.compose.ui.test.onNodeWithTag
+import androidx.compose.ui.test.performClick
 import com.github.se.icebreakrr.model.profile.MockProfileViewModel
 import com.github.se.icebreakrr.ui.navigation.NavigationActions
 import com.github.se.icebreakrr.ui.navigation.Route
+import com.github.se.icebreakrr.ui.navigation.Screen
 import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
 import org.mockito.Mockito.mock
 import org.mockito.Mockito.`when`
+import org.mockito.kotlin.verify
 
 class AroundYouTest {
   private lateinit var navigationActions: NavigationActions
@@ -34,6 +37,22 @@ class AroundYouTest {
     mockProfileViewModel.clearProfiles()
     composeTestRule.onNodeWithTag("emptyProfilePrompt").assertIsDisplayed()
   }
+
+  @Test
+  fun navigationOnCardClick() {
+    composeTestRule.onAllNodesWithTag("profileCard").onFirst().assertIsDisplayed()
+    composeTestRule.onAllNodesWithTag("profileCard").onFirst().performClick()
+    verify(navigationActions).navigateTo(screen = Screen.PROFILE_DISPLAY)
+  }
+
+  @Test
+  fun navigationOnFabClick() {
+    composeTestRule.onAllNodesWithTag("filterButton").onFirst().assertIsDisplayed()
+    composeTestRule.onAllNodesWithTag("filterButton").onFirst().performClick()
+    verify(navigationActions).navigateTo(screen = Screen.FILTER)
+  }
+
+
 
   @Test
   fun hasRequiredComponents() {

--- a/app/src/main/java/com/github/se/icebreakrr/MainActivity.kt
+++ b/app/src/main/java/com/github/se/icebreakrr/MainActivity.kt
@@ -18,6 +18,7 @@ import com.github.se.icebreakrr.ui.navigation.NavigationActions
 import com.github.se.icebreakrr.ui.navigation.Route
 import com.github.se.icebreakrr.ui.navigation.Screen
 import com.github.se.icebreakrr.ui.profile.ProfileEditingScreen
+import com.github.se.icebreakrr.ui.profile.ProfileView
 import com.github.se.icebreakrr.ui.sections.AroundYouScreen
 import com.github.se.icebreakrr.ui.sections.FilterScreen
 import com.github.se.icebreakrr.ui.sections.NotificationScreen
@@ -83,6 +84,7 @@ fun IcebreakrrApp() {
     ) {
       composable(Screen.AROUND_YOU) { AroundYouScreen(navigationActions) }
       composable(Screen.FILTER) { FilterScreen(navigationActions) }
+      composable(Screen.PROFILE_DISPLAY) { ProfileView(navigationActions) }
     }
 
     navigation(

--- a/app/src/main/java/com/github/se/icebreakrr/ui/navigation/TopLevelDestination.kt
+++ b/app/src/main/java/com/github/se/icebreakrr/ui/navigation/TopLevelDestination.kt
@@ -30,6 +30,7 @@ object Screen {
   const val NOTIFICATIONS = "Notifications Screen"
   const val FILTER = "Filter Screen"
   const val PROFILE_EDIT = "Profile Edit Screen"
+  const val PROFILE_DISPLAY = "Profile display Screen"
 }
 
 object TopLevelDestinations {

--- a/app/src/main/java/com/github/se/icebreakrr/ui/sections/AroundYou.kt
+++ b/app/src/main/java/com/github/se/icebreakrr/ui/sections/AroundYou.kt
@@ -30,6 +30,7 @@ import com.github.se.icebreakrr.model.profile.MockProfileViewModel
 import com.github.se.icebreakrr.ui.navigation.BottomNavigationMenu
 import com.github.se.icebreakrr.ui.navigation.LIST_TOP_LEVEL_DESTINATIONS
 import com.github.se.icebreakrr.ui.navigation.NavigationActions
+import com.github.se.icebreakrr.ui.navigation.Screen
 import com.github.se.icebreakrr.ui.sections.shared.ProfileCard
 import com.github.se.icebreakrr.ui.sections.shared.TopBar
 
@@ -59,7 +60,6 @@ fun AroundYouScreen(
       },
       topBar = { TopBar() },
       content = { innerPadding ->
-        val context = LocalContext.current
         if (profiles.value.isNotEmpty()) {
           LazyColumn(
               contentPadding = PaddingValues(vertical = 16.dp),
@@ -68,7 +68,7 @@ fun AroundYouScreen(
                 items(profiles.value.size) { index ->
                   ProfileCard(
                       profile = profiles.value[index],
-                      onclick = { navigationActions.navigateTo("Settings Screen") })
+                      onclick = { navigationActions.navigateTo(Screen.PROFILE_DISPLAY) })
                 }
               }
         } else {
@@ -85,10 +85,9 @@ fun AroundYouScreen(
         }
       },
       floatingActionButton = {
-        val context = LocalContext.current
         FloatingActionButton(
             onClick = {
-              Toast.makeText(context, "Filter button clicked", Toast.LENGTH_SHORT).show()
+              navigationActions.navigateTo(Screen.FILTER)
             },
             containerColor = Color(0xFF1FAEF0), // fixme: use icebreakrr blue
             contentColor = Color.White,

--- a/app/src/main/java/com/github/se/icebreakrr/ui/sections/AroundYou.kt
+++ b/app/src/main/java/com/github/se/icebreakrr/ui/sections/AroundYou.kt
@@ -1,7 +1,6 @@
 package com.github.se.icebreakrr.ui.sections
 
 import android.annotation.SuppressLint
-import android.widget.Toast
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.PaddingValues
@@ -18,7 +17,6 @@ import androidx.compose.runtime.collectAsState
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
-import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.text.font.FontWeight
@@ -86,9 +84,7 @@ fun AroundYouScreen(
       },
       floatingActionButton = {
         FloatingActionButton(
-            onClick = {
-              navigationActions.navigateTo(Screen.FILTER)
-            },
+            onClick = { navigationActions.navigateTo(Screen.FILTER) },
             containerColor = Color(0xFF1FAEF0), // fixme: use icebreakrr blue
             contentColor = Color.White,
             modifier = Modifier.testTag("filterButton")) {


### PR DESCRIPTION
# Navigation Update (for Profile display screen)
This pull request includes several changes to enhance navigation functionality and clean up the code in the `Icebreakrr` app. The most important changes include adding new navigation actions, updating test cases, and removing unused imports.

### Navigation Enhancements:
* [`app/src/main/java/com/github/se/icebreakrr/MainActivity.kt`](diffhunk://#diff-db5af136504ab23c2dc4b1831d3b939f790ccf875a8821932eec2c7aaf49ca3aR87): Added new navigation action `Screen.PROFILE_DISPLAY` to the `IcebreakrrApp` function.
* [`app/src/main/java/com/github/se/icebreakrr/ui/navigation/TopLevelDestination.kt`](diffhunk://#diff-4512e3d33ea87a926a7dcc76df5797f694f1b94d9a2d75edaf06f4051fb07859R33): Added `PROFILE_DISPLAY` to the `Screen` object.
* [`app/src/main/java/com/github/se/icebreakrr/ui/sections/AroundYou.kt`](diffhunk://#diff-239df64079fc273bfbbaca6f5584cef7b7d832c06b62d2c706f26382d14b12cdL71-R69): Updated `AroundYouScreen` to navigate to `Screen.PROFILE_DISPLAY` on profile card click and to `Screen.FILTER` on FAB click. [[1]](diffhunk://#diff-239df64079fc273bfbbaca6f5584cef7b7d832c06b62d2c706f26382d14b12cdL71-R69) [[2]](diffhunk://#diff-239df64079fc273bfbbaca6f5584cef7b7d832c06b62d2c706f26382d14b12cdL88-R87)

### Test Case Updates:
* [`app/src/androidTest/java/com/github/se/icebreakrr/ui/sections/AroundYouTest.kt`](diffhunk://#diff-a1e6284c2f712f779440c996db75a136ba136f8fef1543ece498997a3e245dd1R41-R54): Added test cases to verify navigation on profile card and FAB clicks.

### Code Cleanup:
* [`app/src/main/java/com/github/se/icebreakrr/ui/sections/AroundYou.kt`](diffhunk://#diff-239df64079fc273bfbbaca6f5584cef7b7d832c06b62d2c706f26382d14b12cdL4): Removed unused imports and redundant code. [[1]](diffhunk://#diff-239df64079fc273bfbbaca6f5584cef7b7d832c06b62d2c706f26382d14b12cdL4) [[2]](diffhunk://#diff-239df64079fc273bfbbaca6f5584cef7b7d832c06b62d2c706f26382d14b12cdL21) [[3]](diffhunk://#diff-239df64079fc273bfbbaca6f5584cef7b7d832c06b62d2c706f26382d14b12cdR31) [[4]](diffhunk://#diff-239df64079fc273bfbbaca6f5584cef7b7d832c06b62d2c706f26382d14b12cdL62)