### PR TITLE
Fix/notification screen

### DIFF
--- a/app/src/androidTest/java/com/github/se/icebreakrr/ui/sections/NotificationTest.kt
+++ b/app/src/androidTest/java/com/github/se/icebreakrr/ui/sections/NotificationTest.kt
@@ -13,7 +13,6 @@ import androidx.compose.ui.test.performScrollTo
 import com.github.se.icebreakrr.R
 import com.github.se.icebreakrr.model.profile.MockProfileViewModel
 import com.github.se.icebreakrr.ui.navigation.NavigationActions
-import com.github.se.icebreakrr.ui.navigation.Screen
 import com.github.se.icebreakrr.ui.navigation.TopLevelDestinations
 import org.junit.Before
 import org.junit.Rule

--- a/app/src/androidTest/java/com/github/se/icebreakrr/ui/sections/NotificationTest.kt
+++ b/app/src/androidTest/java/com/github/se/icebreakrr/ui/sections/NotificationTest.kt
@@ -48,7 +48,6 @@ class NotificationTest {
     composeTestRule.onNodeWithTag("notificationScroll").assertIsDisplayed()
     composeTestRule.onNodeWithTag("notificationFirstText").assertIsDisplayed()
     composeTestRule.onNodeWithTag("notificationSecondText").performScrollTo()
-    composeTestRule.onNodeWithTag("filterButton").assertIsDisplayed()
   }
 
   @Test
@@ -66,7 +65,7 @@ class NotificationTest {
   fun profilesListNotEmpty() {
     composeTestRule.setContent { NotificationScreen(navigationActionsMock, profileViewModel) }
     composeTestRule.onAllNodesWithTag("profileCard").onFirst().assertIsDisplayed()
-    composeTestRule.onAllNodesWithTag("profileCard").assertCountEquals(24)
+    composeTestRule.onAllNodesWithTag("profileCard").assertCountEquals(12)
   }
 
   @Test
@@ -77,13 +76,5 @@ class NotificationTest {
 
     composeTestRule.onNodeWithTag("navItem_${R.string.around_you}").performClick()
     verify(navigationActionsMock).navigateTo(TopLevelDestinations.AROUND_YOU)
-  }
-
-  @Test
-  fun clickOnCardEvent() {
-    composeTestRule.setContent { NotificationScreen(navigationActionsMock, profileViewModel) }
-    composeTestRule.onAllNodesWithTag("profileCard").onFirst().assertIsDisplayed()
-    composeTestRule.onAllNodesWithTag("profileCard").onFirst().performClick()
-    verify(navigationActionsMock).navigateTo(Screen.PROFILE_EDIT)
   }
 }

--- a/app/src/androidTest/java/com/github/se/icebreakrr/ui/sections/NotificationTest.kt
+++ b/app/src/androidTest/java/com/github/se/icebreakrr/ui/sections/NotificationTest.kt
@@ -52,14 +52,6 @@ class NotificationTest {
   }
 
   @Test
-  fun navigationToFilterWorks() {
-    composeTestRule.setContent { NotificationScreen(navigationActionsMock, profileViewModel) }
-    composeTestRule.onNodeWithTag("filterButton").assertIsDisplayed()
-    composeTestRule.onNodeWithTag("filterButton").performClick()
-    verify(navigationActionsMock).navigateTo(screen = Screen.FILTER)
-  }
-
-  @Test
   fun profilesListIsEmpty() {
     profileViewModel.clearProfiles()
     composeTestRule.setContent { NotificationScreen(navigationActionsMock, profileViewModel) }

--- a/app/src/main/java/com/github/se/icebreakrr/ui/sections/Notifications.kt
+++ b/app/src/main/java/com/github/se/icebreakrr/ui/sections/Notifications.kt
@@ -12,6 +12,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.collectAsState
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import com.github.se.icebreakrr.model.profile.MockProfileViewModel
 import com.github.se.icebreakrr.ui.navigation.BottomNavigationMenu
@@ -56,15 +57,17 @@ fun NotificationScreen(
           item {
             Text(
                 text = "Pending meeting requests",
-                modifier = Modifier.padding(innerPadding).testTag("notificationFirstText"))
+                fontWeight = FontWeight.Bold,
+                modifier = Modifier.padding(vertical = 16.dp).testTag("notificationFirstText"))
             Column(verticalArrangement = Arrangement.spacedBy(16.dp)) {
-              cardList.value.forEach { p -> ProfileCard(p, onclick = navFunction) }
+              cardList.value.take(4).forEach { p -> ProfileCard(p, onclick=navFunction) }
             }
             Text(
                 text = "Passed",
-                modifier = Modifier.padding(innerPadding).testTag("notificationSecondText"))
+                fontWeight = FontWeight.Bold,
+                modifier = Modifier.padding(vertical = 16.dp).testTag("notificationSecondText"))
             Column(verticalArrangement = Arrangement.spacedBy(16.dp)) {
-              cardList.value.forEach { p -> ProfileCard(p, onclick = navFunction) }
+              cardList.value.drop(4).forEach { p -> ProfileCard(p, onclick=navFunction) }
             }
           }
         }

--- a/app/src/main/java/com/github/se/icebreakrr/ui/sections/Notifications.kt
+++ b/app/src/main/java/com/github/se/icebreakrr/ui/sections/Notifications.kt
@@ -60,14 +60,14 @@ fun NotificationScreen(
                 fontWeight = FontWeight.Bold,
                 modifier = Modifier.padding(vertical = 16.dp).testTag("notificationFirstText"))
             Column(verticalArrangement = Arrangement.spacedBy(16.dp)) {
-              cardList.value.take(4).forEach { p -> ProfileCard(p, onclick=navFunction) }
+              cardList.value.take(4).forEach { p -> ProfileCard(p, onclick = navFunction) }
             }
             Text(
                 text = "Passed",
                 fontWeight = FontWeight.Bold,
                 modifier = Modifier.padding(vertical = 16.dp).testTag("notificationSecondText"))
             Column(verticalArrangement = Arrangement.spacedBy(16.dp)) {
-              cardList.value.drop(4).forEach { p -> ProfileCard(p, onclick=navFunction) }
+              cardList.value.drop(4).forEach { p -> ProfileCard(p, onclick = navFunction) }
             }
           }
         }

--- a/app/src/main/java/com/github/se/icebreakrr/ui/sections/Notifications.kt
+++ b/app/src/main/java/com/github/se/icebreakrr/ui/sections/Notifications.kt
@@ -52,7 +52,7 @@ fun NotificationScreen(
       },
       content = { innerPadding ->
         LazyColumn(
-            modifier = Modifier.padding(innerPadding).fillMaxSize().testTag("notificationScroll"),
+            modifier = Modifier.padding(innerPadding).padding(horizontal = 7.dp).testTag("notificationScroll"),
         ) {
           item {
             Text(
@@ -67,11 +67,9 @@ fun NotificationScreen(
                 fontWeight = FontWeight.Bold,
                 modifier = Modifier.padding(vertical = 16.dp).testTag("notificationSecondText"))
             Column(verticalArrangement = Arrangement.spacedBy(16.dp)) {
-              cardList.value.drop(4).forEach { p -> ProfileCard(p, onclick = navFunction) }
+              cardList.value.drop(4).forEach { p -> ProfileCard(p, onclick = navFunction, greyedOut = true) }
             }
           }
         }
-      },
-      floatingActionButton = { FilterFloatingActionButton(navigationActions) },
-  )
+      },)
 }

--- a/app/src/main/java/com/github/se/icebreakrr/ui/sections/Notifications.kt
+++ b/app/src/main/java/com/github/se/icebreakrr/ui/sections/Notifications.kt
@@ -4,7 +4,6 @@ import android.annotation.SuppressLint
 import android.widget.Toast
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.material3.Scaffold
@@ -21,8 +20,6 @@ import com.github.se.icebreakrr.ui.navigation.BottomNavigationMenu
 import com.github.se.icebreakrr.ui.navigation.LIST_TOP_LEVEL_DESTINATIONS
 import com.github.se.icebreakrr.ui.navigation.NavigationActions
 import com.github.se.icebreakrr.ui.navigation.Route
-import com.github.se.icebreakrr.ui.navigation.Screen
-import com.github.se.icebreakrr.ui.sections.shared.FilterFloatingActionButton
 import com.github.se.icebreakrr.ui.sections.shared.ProfileCard
 import com.github.se.icebreakrr.ui.sections.shared.TopBar
 
@@ -39,7 +36,7 @@ fun NotificationScreen(
     navigationActions: NavigationActions,
     profileViewModel: MockProfileViewModel
 ) {
-    val context = LocalContext.current
+  val context = LocalContext.current
   val cardList = profileViewModel.profiles.collectAsState()
   val navFunction = {
     Toast.makeText(context, "Requests are not implemented yet :)", Toast.LENGTH_SHORT).show()
@@ -55,7 +52,10 @@ fun NotificationScreen(
       },
       content = { innerPadding ->
         LazyColumn(
-            modifier = Modifier.padding(innerPadding).padding(horizontal = 7.dp).testTag("notificationScroll"),
+            modifier =
+                Modifier.padding(innerPadding)
+                    .padding(horizontal = 7.dp)
+                    .testTag("notificationScroll"),
         ) {
           item {
             Text(
@@ -70,9 +70,12 @@ fun NotificationScreen(
                 fontWeight = FontWeight.Bold,
                 modifier = Modifier.padding(vertical = 16.dp).testTag("notificationSecondText"))
             Column(verticalArrangement = Arrangement.spacedBy(16.dp)) {
-              cardList.value.drop(4).forEach { p -> ProfileCard(p, onclick = navFunction, greyedOut = true) }
+              cardList.value.drop(4).forEach { p ->
+                ProfileCard(p, onclick = navFunction, greyedOut = true)
+              }
             }
           }
         }
-      },)
+      },
+  )
 }

--- a/app/src/main/java/com/github/se/icebreakrr/ui/sections/Notifications.kt
+++ b/app/src/main/java/com/github/se/icebreakrr/ui/sections/Notifications.kt
@@ -1,6 +1,7 @@
 package com.github.se.icebreakrr.ui.sections
 
 import android.annotation.SuppressLint
+import android.widget.Toast
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxSize
@@ -11,6 +12,7 @@ import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.collectAsState
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
@@ -37,9 +39,10 @@ fun NotificationScreen(
     navigationActions: NavigationActions,
     profileViewModel: MockProfileViewModel
 ) {
+    val context = LocalContext.current
   val cardList = profileViewModel.profiles.collectAsState()
   val navFunction = {
-    navigationActions.navigateTo(Screen.PROFILE_EDIT)
+    Toast.makeText(context, "Requests are not implemented yet :)", Toast.LENGTH_SHORT).show()
   } // fixme : put Route.View instead
   Scaffold(
       modifier = Modifier.testTag("notificationScreen"),

--- a/app/src/main/java/com/github/se/icebreakrr/ui/sections/shared/ProfileCard.kt
+++ b/app/src/main/java/com/github/se/icebreakrr/ui/sections/shared/ProfileCard.kt
@@ -25,7 +25,12 @@ import com.github.se.icebreakrr.model.profile.Profile
 import com.github.se.icebreakrr.model.profile.getMockedProfiles
 
 @Composable
-fun ProfileCard(profile: Profile, isSettings: Boolean = false, onclick: () -> Unit) {
+fun ProfileCard(
+    profile: Profile,
+    isSettings: Boolean = false,
+    greyedOut: Boolean = false,
+    onclick: () -> Unit
+) {
   Card(
       onClick = onclick,
       shape = RoundedCornerShape(14.dp),
@@ -45,16 +50,21 @@ fun ProfileCard(profile: Profile, isSettings: Boolean = false, onclick: () -> Un
               verticalArrangement = Arrangement.Center,
               horizontalAlignment = Alignment.Start,
           ) {
-            Text(text = profile.name, fontSize = 24.sp, fontWeight = FontWeight.Bold)
+            val textColor = if (greyedOut) Color(0x88888888) else Color.Unspecified
+            Text(
+                text = profile.name,
+                color = textColor,
+                fontSize = 24.sp,
+                fontWeight = FontWeight.Bold)
 
-            Text(text = "\"${profile.catchPhrase}\"", fontSize = 16.sp)
+            Text(text = "\"${profile.catchPhrase}\"", color = textColor, fontSize = 16.sp)
 
             Spacer(modifier = Modifier.padding(6.dp))
 
             if (!isSettings) {
               // put the 5 first tags in a string
               val tags = profile.tags.take(5).joinToString(" ") { "#$it" }
-              Text(text = tags, fontSize = 16.sp)
+              Text(text = tags, fontSize = 16.sp, color = textColor)
             } else {
               Text(text = "Tap to preview profile")
             }


### PR DESCRIPTION
# Fix notification screen
This is a simple pull request that fixes the following issues in the notification screen:

- Wrong padding values
- Useless floating action button (added on figma by mistake)

It also adds a way to gray out passed request and a toast when clicking on request to show that the feature is not implemented yet