### PR TITLE
feature: Connect tags backend to UI

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -156,6 +156,7 @@ dependencies {
     testImplementation(libs.junit)
     globalTestImplementation(libs.androidx.junit)
     globalTestImplementation(libs.androidx.espresso.core)
+    testImplementation(libs.mockito.inline)
 
     // Firebase
     implementation(libs.firebase.database.ktx)

--- a/app/src/androidTest/java/com/github/se/icebreakrr/ui/sections/FilterScreenTest.kt
+++ b/app/src/androidTest/java/com/github/se/icebreakrr/ui/sections/FilterScreenTest.kt
@@ -2,22 +2,16 @@ package com.github.se.icebreakrr.ui.sections
 
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.ui.test.assert
-import androidx.compose.ui.test.assertCountEquals
 import androidx.compose.ui.test.assertHasClickAction
 import androidx.compose.ui.test.assertIsDisplayed
 import androidx.compose.ui.test.assertIsNotSelected
 import androidx.compose.ui.test.assertIsSelected
 import androidx.compose.ui.test.assertTextContains
 import androidx.compose.ui.test.assertTextEquals
-import androidx.compose.ui.test.filterToOne
 import androidx.compose.ui.test.hasText
-import androidx.compose.ui.test.hasTextExactly
 import androidx.compose.ui.test.junit4.createComposeRule
-import androidx.compose.ui.test.onAllNodesWithTag
-import androidx.compose.ui.test.onAllNodesWithText
 import androidx.compose.ui.test.onChildAt
 import androidx.compose.ui.test.onNodeWithTag
-import androidx.compose.ui.test.onNodeWithText
 import androidx.compose.ui.test.performClick
 import androidx.compose.ui.test.performTextClearance
 import androidx.compose.ui.test.performTextInput
@@ -309,41 +303,5 @@ class FilterScreenTest {
     // Test empty label
     label.value = ""
     composeTestRule.onNodeWithTag("GenderButton").assertIsDisplayed().assertTextEquals(label.value)
-  }
-
-  @Test
-  fun testTagSelectionAndRemoval() {
-    composeTestRule.setContent { FilterScreen(navigationActions = navigationActionsMock) }
-
-    composeTestRule.onNodeWithText("#salsa x").assertIsDisplayed()
-    composeTestRule.onNodeWithText("#pesto x").assertDoesNotExist()
-
-    // Test adding tags
-    listOf("salsa", "pesto").forEach { tag -> addTag(tag) }
-
-    // Verify both tags are displayed
-    composeTestRule.onNodeWithText("#salsa x").assertIsDisplayed()
-    composeTestRule.onNodeWithText("#pesto x").assertIsDisplayed()
-
-    // Test removing a tag
-    composeTestRule.onNodeWithText("#salsa x").performClick()
-
-    // Verify the removed tag is no longer displayed, but the other tag remains
-    composeTestRule.onNodeWithText("#salsa x").assertDoesNotExist()
-    composeTestRule.onNodeWithText("#pesto x").assertIsDisplayed()
-
-    // Verify that the tag wasn't added again (no duplicate)
-    composeTestRule.onAllNodesWithText("#pesto x").assertCountEquals(1)
-  }
-
-  private fun addTag(tag: String) {
-    // Input the tag
-    composeTestRule.onNodeWithTag("inputTagSelector").performTextInput(tag)
-
-    // Try to find and click the dropdown item
-    composeTestRule
-        .onAllNodesWithTag("tagSelectorDropDownMenuItem")
-        .filterToOne(hasTextExactly("#$tag"))
-        .performClick()
   }
 }

--- a/app/src/androidTest/java/com/github/se/icebreakrr/ui/tags/TagViewTest.kt
+++ b/app/src/androidTest/java/com/github/se/icebreakrr/ui/tags/TagViewTest.kt
@@ -29,9 +29,9 @@ import org.mockito.kotlin.mock
 import org.mockito.kotlin.verify
 
 class TagViewTest {
-  private lateinit var selectedTag: MutableState<List<Pair<String, Color>>>
-  private lateinit var outputTag: MutableState<List<Pair<String, Color>>>
-  private lateinit var stringQuery: MutableState<String>
+  private lateinit var selectedTag: List<Pair<String, Color>>
+  private lateinit var outputTag: List<Pair<String, Color>>
+  private lateinit var stringQuery: String
   private lateinit var expanded: MutableState<Boolean>
   private lateinit var onClickMock: () -> Unit
   private lateinit var tagSelectorOnClickMock: (String) -> Unit
@@ -48,22 +48,20 @@ class TagViewTest {
   fun setUp() {
 
     selectedTag =
-        mutableStateOf(
-            listOf(
-                Pair("salsa", Color.Red),
-                Pair("pizza", Color.Red),
-                Pair("coca-cola", Color.Red),
-                Pair("pepsi", Color.Red),
-                Pair("fanta", Color.Red)))
+        listOf(
+            Pair("salsa", Color.Red),
+            Pair("pizza", Color.Red),
+            Pair("coca-cola", Color.Red),
+            Pair("pepsi", Color.Red),
+            Pair("fanta", Color.Red))
     outputTag =
-        mutableStateOf(
-            listOf(
-                Pair("pesto", Color.Green),
-                Pair("broccoli", Color.Green),
-                Pair("beans", Color.Green),
-                Pair("peanut", Color.Green),
-                Pair("butter", Color.Green)))
-    stringQuery = mutableStateOf("")
+        listOf(
+            Pair("pesto", Color.Green),
+            Pair("broccoli", Color.Green),
+            Pair("beans", Color.Green),
+            Pair("peanut", Color.Green),
+            Pair("butter", Color.Green))
+    stringQuery = ""
     expanded = mutableStateOf(false)
     onClickMock = mock<() -> Unit>()
     tagSelectorOnClickMock = mock<(String) -> Unit>()
@@ -260,7 +258,7 @@ class TagViewTest {
 
   @Test
   fun testRowOfTags1() {
-    composeTestRule.setContent { RowOfTags(selectedTag.value, TagStyle()) }
+    composeTestRule.setContent { RowOfTags(selectedTag, TagStyle()) }
     composeTestRule.onAllNodesWithTag("testTag").onFirst().assertIsDisplayed()
     composeTestRule.onNodeWithTag("testExtendTag").assertIsDisplayed()
     composeTestRule.onNodeWithTag("testExtendTag").assertTextEquals("...")
@@ -437,7 +435,7 @@ class TagViewTest {
     val textSize = 16.sp
     val userInput = "input"
 
-    val emptyList = mutableStateOf(listOf<Pair<String, Color>>())
+    val emptyList = listOf<Pair<String, Color>>()
 
     composeTestRule.setContent {
       TagSelector(
@@ -468,7 +466,7 @@ class TagViewTest {
     val textColor = Color.White
     val textSize = 16.sp
 
-    val emptyList = mutableStateOf(listOf<Pair<String, Color>>())
+    val emptyList = listOf<Pair<String, Color>>()
 
     composeTestRule.setContent {
       TagSelector(

--- a/app/src/main/java/com/github/se/icebreakrr/MainActivity.kt
+++ b/app/src/main/java/com/github/se/icebreakrr/MainActivity.kt
@@ -8,12 +8,14 @@ import androidx.compose.material3.Surface
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.ui.Modifier
+import androidx.lifecycle.viewmodel.compose.viewModel
 import androidx.navigation.compose.NavHost
 import androidx.navigation.compose.composable
 import androidx.navigation.compose.navigation
 import androidx.navigation.compose.rememberNavController
 import com.github.se.icebreakrr.config.LocalIsTesting
 import com.github.se.icebreakrr.model.profile.MockProfileViewModel
+import com.github.se.icebreakrr.model.tags.TagsViewModel
 import com.github.se.icebreakrr.ui.authentication.SignInScreen
 import com.github.se.icebreakrr.ui.navigation.NavigationActions
 import com.github.se.icebreakrr.ui.navigation.Route
@@ -71,6 +73,7 @@ fun IcebreakrrApp() {
   val navController = rememberNavController()
   val navigationActions = NavigationActions(navController)
   val profileViewModel = MockProfileViewModel()
+  val tagsViewModel: TagsViewModel = viewModel(factory = TagsViewModel.Factory)
 
   NavHost(navController = navController, startDestination = Route.AUTH) {
     navigation(
@@ -106,14 +109,14 @@ fun IcebreakrrApp() {
         startDestination = Screen.PROFILE_EDIT,
         route = Route.PROFILE_EDIT,
     ) {
-      composable(Screen.PROFILE_EDIT) { ProfileEditingScreen(navigationActions) }
+      composable(Screen.PROFILE_EDIT) { ProfileEditingScreen(navigationActions, tagsViewModel) }
     }
 
     navigation(
         startDestination = Screen.FILTER,
         route = Route.FILTER,
     ) {
-      composable(Screen.FILTER) { FilterScreen(navigationActions) }
+      composable(Screen.FILTER) { FilterScreen(navigationActions, tagsViewModel) }
     }
   }
 }

--- a/app/src/main/java/com/github/se/icebreakrr/model/tags/TagsRepository.kt
+++ b/app/src/main/java/com/github/se/icebreakrr/model/tags/TagsRepository.kt
@@ -7,7 +7,7 @@ import com.google.firebase.firestore.DocumentSnapshot
 import com.google.firebase.firestore.FirebaseFirestore
 import com.google.firebase.firestore.QuerySnapshot
 
-class TagsRepository(private val db: FirebaseFirestore) {
+open class TagsRepository(private val db: FirebaseFirestore) {
   private val collectionPath = "Tags"
 
   fun init(onSuccess: () -> Unit) {

--- a/app/src/main/java/com/github/se/icebreakrr/model/tags/TagsViewModel.kt
+++ b/app/src/main/java/com/github/se/icebreakrr/model/tags/TagsViewModel.kt
@@ -28,6 +28,7 @@ data class TagsViewModel(private val repository: TagsRepository) : ViewModel() {
   val filteredTags: StateFlow<List<String>> = filteredTags_
 
   // observable variable containing the tags from which you want to filter
+  // or the selected tags in the edit profile
   private var filteringTags_ = MutableStateFlow(emptyList<String>())
   val filteringTags: StateFlow<List<String>> = filteringTags_
 
@@ -151,5 +152,6 @@ data class TagsViewModel(private val repository: TagsRepository) : ViewModel() {
   fun leaveUI() {
     query_.value = ""
     tagsSuggestions_.value = emptyList()
+    filteringTags_.value = emptyList()
   }
 }

--- a/app/src/main/java/com/github/se/icebreakrr/ui/tags/TagView.kt
+++ b/app/src/main/java/com/github/se/icebreakrr/ui/tags/TagView.kt
@@ -201,9 +201,9 @@ fun RowOfClickTags(l: List<Pair<String, Color>>, tagStyle: TagStyle, onClick: (S
  */
 @Composable
 fun TagSelector(
-    selectedTag: MutableState<List<Pair<String, Color>>>,
-    outputTag: MutableState<List<Pair<String, Color>>>,
-    stringQuery: MutableState<String>,
+    selectedTag: List<Pair<String, Color>>,
+    outputTag: List<Pair<String, Color>>,
+    stringQuery: String,
     expanded: MutableState<Boolean>,
     onTagClick: (String) -> Unit,
     onDropDownItemClicked: (String) -> Unit,
@@ -217,10 +217,9 @@ fun TagSelector(
   Box(modifier = Modifier.size(width, height).testTag("sizeTagSelector")) {
     Column(modifier = Modifier.fillMaxWidth().wrapContentHeight()) {
       OutlinedTextField(
-          value = stringQuery.value,
+          value = stringQuery,
           onValueChange = {
-            stringQuery.value = it
-            onStringChanged(stringQuery.value)
+            onStringChanged(it)
             expanded.value = true
           },
           label = { Text("Tags", modifier = Modifier.testTag("labelTagSelector")) },
@@ -235,11 +234,9 @@ fun TagSelector(
             onDismissRequest = { expanded.value = false },
             properties = PopupProperties(focusable = false),
             modifier = Modifier.align(Alignment.TopStart)) {
-              val tagsList = outputTag.value
-              tagsList.forEach { tag ->
+              outputTag.forEach { tag ->
                 DropdownMenuItem(
                     onClick = {
-                      stringQuery.value = ""
                       expanded.value = false
                       onDropDownItemClicked(tag.first)
                     },
@@ -248,9 +245,7 @@ fun TagSelector(
               }
             }
       }
-      RowOfClickTags(selectedTag.value, TagStyle(textColor, Color.Red, textSize)) { s ->
-        onTagClick(s)
-      }
+      RowOfClickTags(selectedTag, TagStyle(textColor, Color.Red, textSize)) { s -> onTagClick(s) }
     }
   }
 }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,6 +1,7 @@
 [versions]
 #Google
 googleServices = "4.4.2"
+mockitoInline = "4.0.0"
 playServicesAuth = "21.2.0"
 playServicesLocation = "21.3.0"
 
@@ -49,6 +50,7 @@ ktfmt = "0.17.0"
 
 [libraries]
 #Google
+mockito-inline = { module = "org.mockito:mockito-inline", version.ref = "mockitoInline" }
 play-services-auth = { module = "com.google.android.gms:play-services-auth", version.ref = "playServicesAuth" }
 play-services-location = { module = "com.google.android.gms:play-services-location", version.ref = "playServicesLocation" }
 google-services = { module = "com.google.gms:google-services", version.ref = "googleServices" }


### PR DESCRIPTION
Mini PR to connect the backend to the UI for the tags. Only for when you search for tags in `Filter` and `ProfileEdit`. 

in `TagView` file :
- Change `TagSelector` arguments to fit my viewModel

in `TagViewTest` file : 
- Change the tests to fit the changes I did in `TagSelector`

in `MainActivity` : 
- Add a `TagViewModel` used in `Filter` and `ProfileEdit` UI (the same `TagViewModel` needs to be used since it has been designed to have one `TagsViewModel` per session)

in `ProfileEdit` and `Filter` : 
- Make necessary changes to connect the backend of the tags to the `TagSelector`