### PR TITLE
Feature/pp backend

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -153,6 +153,7 @@ dependencies {
     implementation(libs.coil.compose)
 
     implementation(libs.firebase.firestore.ktx)
+    implementation(libs.firebase.storage.ktx)
     testImplementation(libs.junit)
     globalTestImplementation(libs.androidx.junit)
     globalTestImplementation(libs.androidx.espresso.core)

--- a/app/src/androidTest/java/com/github/se/endToEnd/M1_Test.kt
+++ b/app/src/androidTest/java/com/github/se/endToEnd/M1_Test.kt
@@ -17,6 +17,7 @@ import com.github.se.icebreakrr.MainActivity
 import com.github.se.icebreakrr.R
 import com.github.se.icebreakrr.model.profile.Gender
 import com.github.se.icebreakrr.model.profile.Profile
+import com.github.se.icebreakrr.model.profile.ProfilePicRepository
 import com.github.se.icebreakrr.model.profile.ProfilesRepository
 import com.github.se.icebreakrr.model.profile.ProfilesViewModel
 import com.github.se.icebreakrr.ui.navigation.NavigationActions
@@ -36,6 +37,7 @@ class M1_Test {
 
   private lateinit var navigationActions: NavigationActions
   private lateinit var mockProfilesRepository: ProfilesRepository
+    private lateinit var mockPPRepository: ProfilePicRepository
   private lateinit var profilesViewModel: ProfilesViewModel
 
   @get:Rule val composeTestRule = createAndroidComposeRule<MainActivity>()
@@ -44,7 +46,8 @@ class M1_Test {
   fun setup() {
     navigationActions = mock(NavigationActions::class.java)
     mockProfilesRepository = mock(ProfilesRepository::class.java)
-    profilesViewModel = ProfilesViewModel(mockProfilesRepository)
+    mockPPRepository = mock(ProfilePicRepository::class.java)
+    profilesViewModel = ProfilesViewModel(mockProfilesRepository, mockPPRepository)
 
     // Creating a custom flag to disable the sign in to correctly test navigation
     val intent =

--- a/app/src/androidTest/java/com/github/se/endToEnd/M1_Test.kt
+++ b/app/src/androidTest/java/com/github/se/endToEnd/M1_Test.kt
@@ -37,7 +37,7 @@ class M1_Test {
 
   private lateinit var navigationActions: NavigationActions
   private lateinit var mockProfilesRepository: ProfilesRepository
-    private lateinit var mockPPRepository: ProfilePicRepository
+  private lateinit var mockPPRepository: ProfilePicRepository
   private lateinit var profilesViewModel: ProfilesViewModel
 
   @get:Rule val composeTestRule = createAndroidComposeRule<MainActivity>()

--- a/app/src/androidTest/java/com/github/se/icebreakrr/ui/navigation/NavigationTest.kt
+++ b/app/src/androidTest/java/com/github/se/icebreakrr/ui/navigation/NavigationTest.kt
@@ -10,10 +10,13 @@ import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.github.se.icebreakrr.MainActivity
 import com.github.se.icebreakrr.R
 import com.github.se.icebreakrr.mock.MockProfileViewModel
+import com.github.se.icebreakrr.model.profile.ProfilePicRepositoryStorage
 import com.github.se.icebreakrr.model.profile.ProfilesRepository
 import com.github.se.icebreakrr.model.profile.ProfilesViewModel
 import com.github.se.icebreakrr.model.tags.TagsRepository
 import com.github.se.icebreakrr.model.tags.TagsViewModel
+import com.google.firebase.Firebase
+import com.google.firebase.storage.storage
 import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
@@ -42,7 +45,8 @@ class NavigationTest {
 
     tagsViewModel = TagsViewModel(mockTagsRepository)
 
-    profilesViewModel = ProfilesViewModel(mockProfilesRepository)
+    profilesViewModel =
+        ProfilesViewModel(mockProfilesRepository, ProfilePicRepositoryStorage(Firebase.storage))
 
     // Creating a custom flag to disable the sign in to correctly test navigation
     val intent =

--- a/app/src/androidTest/java/com/github/se/icebreakrr/ui/profile/ProfileViewTest.kt
+++ b/app/src/androidTest/java/com/github/se/icebreakrr/ui/profile/ProfileViewTest.kt
@@ -11,11 +11,14 @@ import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.github.se.icebreakrr.mock.MockProfileViewModel
 import com.github.se.icebreakrr.mock.getMockedProfiles
 import com.github.se.icebreakrr.model.profile.Profile
+import com.github.se.icebreakrr.model.profile.ProfilePicRepositoryStorage
 import com.github.se.icebreakrr.model.profile.ProfilesRepository
 import com.github.se.icebreakrr.model.profile.ProfilesViewModel
 import com.github.se.icebreakrr.model.tags.TagsRepository
 import com.github.se.icebreakrr.model.tags.TagsViewModel
 import com.github.se.icebreakrr.ui.navigation.NavigationActions
+import com.google.firebase.Firebase
+import com.google.firebase.storage.storage
 import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
@@ -44,7 +47,8 @@ class ProfileViewTest {
 
     tagsViewModel = TagsViewModel(mockTagsRepository)
 
-    profilesViewModel = ProfilesViewModel(mockProfilesRepository)
+    profilesViewModel =
+        ProfilesViewModel(mockProfilesRepository, ProfilePicRepositoryStorage(Firebase.storage))
     fakeProfilesViewModel = MockProfileViewModel()
   }
 

--- a/app/src/androidTest/java/com/github/se/icebreakrr/ui/sections/AroundYouTest.kt
+++ b/app/src/androidTest/java/com/github/se/icebreakrr/ui/sections/AroundYouTest.kt
@@ -12,6 +12,7 @@ import androidx.test.espresso.action.ViewActions.swipeDown
 import com.github.se.icebreakrr.model.filter.FilterViewModel
 import com.github.se.icebreakrr.model.profile.Gender
 import com.github.se.icebreakrr.model.profile.Profile
+import com.github.se.icebreakrr.model.profile.ProfilePicRepository
 import com.github.se.icebreakrr.model.profile.ProfilesRepository
 import com.github.se.icebreakrr.model.profile.ProfilesViewModel
 import com.github.se.icebreakrr.model.tags.TagsViewModel
@@ -33,6 +34,7 @@ class AroundYouScreenTest {
 
   private lateinit var navigationActions: NavigationActions
   private lateinit var mockProfilesRepository: ProfilesRepository
+  private lateinit var mockPPRepository: ProfilePicRepository
   private lateinit var profilesViewModel: ProfilesViewModel
 
   @get:Rule val composeTestRule = createComposeRule()
@@ -41,7 +43,7 @@ class AroundYouScreenTest {
   fun setUp() {
     navigationActions = mock(NavigationActions::class.java)
     mockProfilesRepository = mock(ProfilesRepository::class.java)
-    profilesViewModel = ProfilesViewModel(mockProfilesRepository)
+    profilesViewModel = ProfilesViewModel(mockProfilesRepository, mockPPRepository)
 
     // Mock initial behavior of repository
     `when`(navigationActions.currentRoute()).thenReturn(Route.AROUND_YOU)

--- a/app/src/androidTest/java/com/github/se/icebreakrr/ui/sections/AroundYouTest.kt
+++ b/app/src/androidTest/java/com/github/se/icebreakrr/ui/sections/AroundYouTest.kt
@@ -43,6 +43,7 @@ class AroundYouScreenTest {
   fun setUp() {
     navigationActions = mock(NavigationActions::class.java)
     mockProfilesRepository = mock(ProfilesRepository::class.java)
+    mockPPRepository = mock(ProfilePicRepository::class.java)
     profilesViewModel = ProfilesViewModel(mockProfilesRepository, mockPPRepository)
 
     // Mock initial behavior of repository

--- a/app/src/androidTest/java/com/github/se/icebreakrr/ui/sections/FilterScreenTest.kt
+++ b/app/src/androidTest/java/com/github/se/icebreakrr/ui/sections/FilterScreenTest.kt
@@ -16,9 +16,12 @@ import androidx.compose.ui.test.performClick
 import androidx.compose.ui.test.performTextClearance
 import androidx.compose.ui.test.performTextInput
 import com.github.se.icebreakrr.model.filter.FilterViewModel
+import com.github.se.icebreakrr.model.profile.ProfilePicRepositoryStorage
 import com.github.se.icebreakrr.model.profile.ProfilesRepository
 import com.github.se.icebreakrr.model.profile.ProfilesViewModel
 import com.github.se.icebreakrr.ui.navigation.NavigationActions
+import com.google.firebase.Firebase
+import com.google.firebase.storage.storage
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNull
 import org.junit.Before
@@ -41,7 +44,8 @@ class FilterScreenTest {
   fun setUp() {
     navigationActionsMock = mock()
     profilesRepositoryMock = mock()
-    profilesViewModelMock = ProfilesViewModel(profilesRepositoryMock)
+    profilesViewModelMock =
+        ProfilesViewModel(profilesRepositoryMock, ProfilePicRepositoryStorage(Firebase.storage))
     filterViewModel = FilterViewModel()
   }
 

--- a/app/src/androidTest/java/com/github/se/icebreakrr/ui/sections/NotificationTest.kt
+++ b/app/src/androidTest/java/com/github/se/icebreakrr/ui/sections/NotificationTest.kt
@@ -32,7 +32,7 @@ import org.mockito.kotlin.verify
 class NotificationTest {
   private lateinit var navigationActions: NavigationActions
   private lateinit var mockProfilesRepository: ProfilesRepository
-    private lateinit var mockPPRepository: ProfilePicRepository
+  private lateinit var mockPPRepository: ProfilePicRepository
   private lateinit var profilesViewModel: ProfilesViewModel
 
   @get:Rule val composeTestRule = createComposeRule()

--- a/app/src/androidTest/java/com/github/se/icebreakrr/ui/sections/NotificationTest.kt
+++ b/app/src/androidTest/java/com/github/se/icebreakrr/ui/sections/NotificationTest.kt
@@ -13,6 +13,7 @@ import androidx.compose.ui.test.performScrollTo
 import com.github.se.icebreakrr.R
 import com.github.se.icebreakrr.model.profile.Gender
 import com.github.se.icebreakrr.model.profile.Profile
+import com.github.se.icebreakrr.model.profile.ProfilePicRepository
 import com.github.se.icebreakrr.model.profile.ProfilesRepository
 import com.github.se.icebreakrr.model.profile.ProfilesViewModel
 import com.github.se.icebreakrr.ui.navigation.NavigationActions
@@ -31,6 +32,7 @@ import org.mockito.kotlin.verify
 class NotificationTest {
   private lateinit var navigationActions: NavigationActions
   private lateinit var mockProfilesRepository: ProfilesRepository
+    private lateinit var mockPPRepository: ProfilePicRepository
   private lateinit var profilesViewModel: ProfilesViewModel
 
   @get:Rule val composeTestRule = createComposeRule()
@@ -39,7 +41,8 @@ class NotificationTest {
   fun setUp() {
     navigationActions = Mockito.mock(NavigationActions::class.java)
     mockProfilesRepository = Mockito.mock(ProfilesRepository::class.java)
-    profilesViewModel = ProfilesViewModel(mockProfilesRepository)
+
+    profilesViewModel = ProfilesViewModel(mockProfilesRepository, mockPPRepository)
   }
 
   @Test

--- a/app/src/androidTest/java/com/github/se/icebreakrr/ui/sections/NotificationTest.kt
+++ b/app/src/androidTest/java/com/github/se/icebreakrr/ui/sections/NotificationTest.kt
@@ -41,7 +41,7 @@ class NotificationTest {
   fun setUp() {
     navigationActions = Mockito.mock(NavigationActions::class.java)
     mockProfilesRepository = Mockito.mock(ProfilesRepository::class.java)
-
+    mockPPRepository = Mockito.mock(ProfilePicRepository::class.java)
     profilesViewModel = ProfilesViewModel(mockProfilesRepository, mockPPRepository)
   }
 

--- a/app/src/androidTest/java/com/github/se/icebreakrr/ui/sections/SettingsTest.kt
+++ b/app/src/androidTest/java/com/github/se/icebreakrr/ui/sections/SettingsTest.kt
@@ -6,11 +6,14 @@ import androidx.compose.ui.test.assertIsOn
 import androidx.compose.ui.test.junit4.createComposeRule
 import androidx.compose.ui.test.onNodeWithTag
 import androidx.compose.ui.test.performClick
+import com.github.se.icebreakrr.model.profile.ProfilePicRepositoryStorage
 import com.github.se.icebreakrr.model.profile.ProfilesRepository
 import com.github.se.icebreakrr.model.profile.ProfilesViewModel
 import com.github.se.icebreakrr.ui.navigation.NavigationActions
 import com.github.se.icebreakrr.ui.navigation.Route
 import com.github.se.icebreakrr.ui.navigation.Screen
+import com.google.firebase.Firebase
+import com.google.firebase.storage.storage
 import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
@@ -31,7 +34,8 @@ class SettingsTest {
   fun setUp() {
     navigationActionsMock = mock()
     mockProfilesRepository = Mockito.mock(ProfilesRepository::class.java)
-    profilesViewModel = ProfilesViewModel(mockProfilesRepository)
+    profilesViewModel =
+        ProfilesViewModel(mockProfilesRepository, ProfilePicRepositoryStorage(Firebase.storage))
 
     `when`(navigationActionsMock.currentRoute()).thenReturn(Route.SETTINGS)
   }

--- a/app/src/main/java/com/github/se/icebreakrr/mock/MockProfiles.kt
+++ b/app/src/main/java/com/github/se/icebreakrr/mock/MockProfiles.kt
@@ -4,10 +4,13 @@ import androidx.lifecycle.ViewModel
 import androidx.lifecycle.ViewModelProvider
 import com.github.se.icebreakrr.model.profile.Gender
 import com.github.se.icebreakrr.model.profile.Profile
+import com.github.se.icebreakrr.model.profile.ProfilePicRepositoryStorage
 import com.github.se.icebreakrr.model.profile.ProfilesRepository
 import com.github.se.icebreakrr.model.profile.ProfilesViewModel
+import com.google.firebase.Firebase
 import com.google.firebase.Timestamp
 import com.google.firebase.firestore.GeoPoint
+import com.google.firebase.storage.storage
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
@@ -72,7 +75,8 @@ open class MockProfileRepository : ProfilesRepository {
   }
 }
 
-open class MockProfileViewModel : ProfilesViewModel(MockProfileRepository()) {
+open class MockProfileViewModel :
+    ProfilesViewModel(MockProfileRepository(), ProfilePicRepositoryStorage(Firebase.storage)) {
   private val _profiles = MutableStateFlow<List<Profile>>(emptyList())
   override val profiles: StateFlow<List<Profile>> = _profiles.asStateFlow()
 

--- a/app/src/main/java/com/github/se/icebreakrr/model/profile/ProfilePicRepository.kt
+++ b/app/src/main/java/com/github/se/icebreakrr/model/profile/ProfilePicRepository.kt
@@ -1,25 +1,18 @@
 package com.github.se.icebreakrr.model.profile
 
-import android.net.Uri
-
-
 interface ProfilePicRepository {
-    fun uploadProfilePicture(
-        userId: String,
-        imageData: ByteArray,
-        onSuccess: (url: String?) -> Unit,
-        onFailure: (Exception) -> Unit
-    )
+  fun uploadProfilePicture(
+      userId: String,
+      imageData: ByteArray,
+      onSuccess: (url: String?) -> Unit,
+      onFailure: (Exception) -> Unit
+  )
 
-    fun getProfilePictureByUid(
-        userId: String,
-        onSuccess: (url: String?) -> Unit,
-        onFailure: (Exception) -> Unit
-    )
+  fun getProfilePictureByUid(
+      userId: String,
+      onSuccess: (url: String?) -> Unit,
+      onFailure: (Exception) -> Unit
+  )
 
-    fun deleteProfilePicture(
-        userId: String,
-        onSuccess: () -> Unit,
-        onFailure: (Exception) -> Unit
-    )
+  fun deleteProfilePicture(userId: String, onSuccess: () -> Unit, onFailure: (Exception) -> Unit)
 }

--- a/app/src/main/java/com/github/se/icebreakrr/model/profile/ProfilePicRepository.kt
+++ b/app/src/main/java/com/github/se/icebreakrr/model/profile/ProfilePicRepository.kt
@@ -1,0 +1,25 @@
+package com.github.se.icebreakrr.model.profile
+
+import android.net.Uri
+
+
+interface ProfilePicRepository {
+    fun uploadProfilePicture(
+        userId: String,
+        imageData: ByteArray,
+        onSuccess: (url: String?) -> Unit,
+        onFailure: (Exception) -> Unit
+    )
+
+    fun getProfilePictureByUid(
+        userId: String,
+        onSuccess: (url: String?) -> Unit,
+        onFailure: (Exception) -> Unit
+    )
+
+    fun deleteProfilePicture(
+        userId: String,
+        onSuccess: () -> Unit,
+        onFailure: (Exception) -> Unit
+    )
+}

--- a/app/src/main/java/com/github/se/icebreakrr/model/profile/ProfilePicRepositoryStorage.kt
+++ b/app/src/main/java/com/github/se/icebreakrr/model/profile/ProfilePicRepositoryStorage.kt
@@ -3,98 +3,97 @@ package com.github.se.icebreakrr.model.profile
 import com.google.firebase.storage.FirebaseStorage
 import com.google.firebase.storage.StorageReference
 
-class ProfilePicRepositoryStorage(private val firebaseStorage: FirebaseStorage) : ProfilePicRepository {
+class ProfilePicRepositoryStorage(private val firebaseStorage: FirebaseStorage) :
+    ProfilePicRepository {
 
-    /**
-     * Retrieves a reference to the profile picture storage location for a given user.
-     *
-     * @param userId The ID of the user whose profile picture reference is to be retrieved.
-     * @return A StorageReference pointing to the user's profile picture location in Firebase Storage.
-     */
-    private fun getProfilePictureReference(userId: String): StorageReference {
-        return firebaseStorage.reference.child("profile_pictures/$userId.jpg")
+  /**
+   * Retrieves a reference to the profile picture storage location for a given user.
+   *
+   * @param userId The ID of the user whose profile picture reference is to be retrieved.
+   * @return A StorageReference pointing to the user's profile picture location in Firebase Storage.
+   */
+  private fun getProfilePictureReference(userId: String): StorageReference {
+    return firebaseStorage.reference.child("profile_pictures/$userId.jpg")
+  }
+
+  /**
+   * Checks if the given byte array represents a JPG image.
+   *
+   * @param imageData The byte array to check.
+   * @return True if the byte array is a JPG image, false otherwise.
+   */
+  private fun isJpgImage(imageData: ByteArray): Boolean {
+    return imageData.size >= 4 &&
+        imageData[0] == 0xFF.toByte() &&
+        imageData[1] == 0xD8.toByte() &&
+        imageData[imageData.size - 2] == 0xFF.toByte() &&
+        imageData[imageData.size - 1] == 0xD9.toByte()
+  }
+
+  /**
+   * Uploads a profile picture to Firebase Storage.
+   *
+   * @param userId The ID of the user whose profile picture is to be uploaded.
+   * @param imageData The byte array of the jpg (!!!) image file to be uploaded.
+   * @param onSuccess A callback function to be invoked with the URL of the uploaded file if the
+   *   upload is successful.
+   * @param onFailure A callback function to be invoked with the exception if the upload fails.
+   */
+  override fun uploadProfilePicture(
+      userId: String,
+      imageData: ByteArray,
+      onSuccess: (url: String?) -> Unit,
+      onFailure: (Exception) -> Unit
+  ) {
+    if (!isJpgImage(imageData)) {
+      onFailure(IllegalArgumentException("Only JPG images are allowed"))
+      return
     }
 
-    /**
-     * Checks if the given byte array represents a JPG image.
-     *
-     * @param imageData The byte array to check.
-     * @return True if the byte array is a JPG image, false otherwise.
-     */
-    private fun isJpgImage(imageData: ByteArray): Boolean {
-        return imageData.size >= 4 &&
-               imageData[0] == 0xFF.toByte() && imageData[1] == 0xD8.toByte() &&
-               imageData[imageData.size - 2] == 0xFF.toByte() && imageData[imageData.size - 1] == 0xD9.toByte()
-    }
-
-    /**
-     * Uploads a profile picture to Firebase Storage.
-     *
-     * @param userId The ID of the user whose profile picture is to be uploaded.
-     * @param imageData The byte array of the jpg (!!!) image file to be uploaded.
-     * @param onSuccess A callback function to be invoked with the URL of the uploaded file if the upload is successful.
-     * @param onFailure A callback function to be invoked with the exception if the upload fails.
-     */
-    override fun uploadProfilePicture(
-        userId: String,
-        imageData: ByteArray,
-        onSuccess: (url: String?) -> Unit,
-        onFailure: (Exception) -> Unit
-    ) {
-        if (!isJpgImage(imageData)) {
-            onFailure(IllegalArgumentException("Only JPG images are allowed"))
-            return
+    val storageRef = getProfilePictureReference(userId)
+    storageRef
+        .putBytes(imageData)
+        .addOnSuccessListener {
+          storageRef.downloadUrl
+              .addOnSuccessListener { uri -> onSuccess(uri.toString()) }
+              .addOnFailureListener { onFailure(it) }
         }
+        .addOnFailureListener { onFailure(it) }
+  }
 
-        val storageRef = getProfilePictureReference(userId)
-        storageRef.putBytes(imageData).addOnSuccessListener {
-            storageRef.downloadUrl.addOnSuccessListener { uri ->
-                onSuccess(uri.toString())
-            }.addOnFailureListener {
-                onFailure(it)
-            }
-        }.addOnFailureListener {
-            onFailure(it)
-        }
-    }
+  /**
+   * Retrieves the profile picture URL of a user from Firebase Storage.
+   *
+   * @param userId The ID of the user whose profile picture is to be retrieved.
+   * @param onSuccess A callback function to be invoked with the URL of the profile picture if the
+   *   retrieval is successful.
+   * @param onFailure A callback function to be invoked with the exception if the retrieval fails.
+   */
+  override fun getProfilePictureByUid(
+      userId: String,
+      onSuccess: (url: String?) -> Unit,
+      onFailure: (Exception) -> Unit
+  ) {
+    val storageRef = getProfilePictureReference(userId)
+    storageRef.downloadUrl
+        .addOnSuccessListener { onSuccess(it.toString()) }
+        .addOnFailureListener { onFailure(it) }
+  }
 
-    /**
-     * Retrieves the profile picture URL of a user from Firebase Storage.
-     *
-     * @param userId The ID of the user whose profile picture is to be retrieved.
-     * @param onSuccess A callback function to be invoked with the URL of the profile picture if the retrieval is successful.
-     * @param onFailure A callback function to be invoked with the exception if the retrieval fails.
-     */
-    override fun getProfilePictureByUid(
-        userId: String,
-        onSuccess: (url: String?) -> Unit,
-        onFailure: (Exception) -> Unit
-    ) {
-        val storageRef = getProfilePictureReference(userId)
-        storageRef.downloadUrl.addOnSuccessListener {
-            onSuccess(it.toString())
-        }.addOnFailureListener {
-            onFailure(it)
-        }
-    }
-
-    /**
-     * Deletes the profile picture of a user from Firebase Storage.
-     *
-     * @param userId The ID of the user whose profile picture is to be deleted.
-     * @param onSuccess A callback function to be invoked if the deletion is successful.
-     * @param onFailure A callback function to be invoked if the deletion fails, with the exception as a parameter.
-     */
-    override fun deleteProfilePicture(
-        userId: String,
-        onSuccess: () -> Unit,
-        onFailure: (Exception) -> Unit
-    ) {
-        val storageRef = getProfilePictureReference(userId)
-        storageRef.delete().addOnSuccessListener {
-            onSuccess()
-        }.addOnFailureListener {
-            onFailure(it)
-        }
-    }
+  /**
+   * Deletes the profile picture of a user from Firebase Storage.
+   *
+   * @param userId The ID of the user whose profile picture is to be deleted.
+   * @param onSuccess A callback function to be invoked if the deletion is successful.
+   * @param onFailure A callback function to be invoked if the deletion fails, with the exception as
+   *   a parameter.
+   */
+  override fun deleteProfilePicture(
+      userId: String,
+      onSuccess: () -> Unit,
+      onFailure: (Exception) -> Unit
+  ) {
+    val storageRef = getProfilePictureReference(userId)
+    storageRef.delete().addOnSuccessListener { onSuccess() }.addOnFailureListener { onFailure(it) }
+  }
 }

--- a/app/src/main/java/com/github/se/icebreakrr/model/profile/ProfilePicRepositoryStorage.kt
+++ b/app/src/main/java/com/github/se/icebreakrr/model/profile/ProfilePicRepositoryStorage.kt
@@ -1,0 +1,100 @@
+package com.github.se.icebreakrr.model.profile
+
+import com.google.firebase.storage.FirebaseStorage
+import com.google.firebase.storage.StorageReference
+
+class ProfilePicRepositoryStorage(private val firebaseStorage: FirebaseStorage) : ProfilePicRepository {
+
+    /**
+     * Retrieves a reference to the profile picture storage location for a given user.
+     *
+     * @param userId The ID of the user whose profile picture reference is to be retrieved.
+     * @return A StorageReference pointing to the user's profile picture location in Firebase Storage.
+     */
+    private fun getProfilePictureReference(userId: String): StorageReference {
+        return firebaseStorage.reference.child("profile_pictures/$userId.jpg")
+    }
+
+    /**
+     * Checks if the given byte array represents a JPG image.
+     *
+     * @param imageData The byte array to check.
+     * @return True if the byte array is a JPG image, false otherwise.
+     */
+    private fun isJpgImage(imageData: ByteArray): Boolean {
+        return imageData.size >= 4 &&
+               imageData[0] == 0xFF.toByte() && imageData[1] == 0xD8.toByte() &&
+               imageData[imageData.size - 2] == 0xFF.toByte() && imageData[imageData.size - 1] == 0xD9.toByte()
+    }
+
+    /**
+     * Uploads a profile picture to Firebase Storage.
+     *
+     * @param userId The ID of the user whose profile picture is to be uploaded.
+     * @param imageData The byte array of the jpg (!!!) image file to be uploaded.
+     * @param onSuccess A callback function to be invoked with the URL of the uploaded file if the upload is successful.
+     * @param onFailure A callback function to be invoked with the exception if the upload fails.
+     */
+    override fun uploadProfilePicture(
+        userId: String,
+        imageData: ByteArray,
+        onSuccess: (url: String?) -> Unit,
+        onFailure: (Exception) -> Unit
+    ) {
+        if (!isJpgImage(imageData)) {
+            onFailure(IllegalArgumentException("Only JPG images are allowed"))
+            return
+        }
+
+        val storageRef = getProfilePictureReference(userId)
+        storageRef.putBytes(imageData).addOnSuccessListener {
+            storageRef.downloadUrl.addOnSuccessListener { uri ->
+                onSuccess(uri.toString())
+            }.addOnFailureListener {
+                onFailure(it)
+            }
+        }.addOnFailureListener {
+            onFailure(it)
+        }
+    }
+
+    /**
+     * Retrieves the profile picture URL of a user from Firebase Storage.
+     *
+     * @param userId The ID of the user whose profile picture is to be retrieved.
+     * @param onSuccess A callback function to be invoked with the URL of the profile picture if the retrieval is successful.
+     * @param onFailure A callback function to be invoked with the exception if the retrieval fails.
+     */
+    override fun getProfilePictureByUid(
+        userId: String,
+        onSuccess: (url: String?) -> Unit,
+        onFailure: (Exception) -> Unit
+    ) {
+        val storageRef = getProfilePictureReference(userId)
+        storageRef.downloadUrl.addOnSuccessListener {
+            onSuccess(it.toString())
+        }.addOnFailureListener {
+            onFailure(it)
+        }
+    }
+
+    /**
+     * Deletes the profile picture of a user from Firebase Storage.
+     *
+     * @param userId The ID of the user whose profile picture is to be deleted.
+     * @param onSuccess A callback function to be invoked if the deletion is successful.
+     * @param onFailure A callback function to be invoked if the deletion fails, with the exception as a parameter.
+     */
+    override fun deleteProfilePicture(
+        userId: String,
+        onSuccess: () -> Unit,
+        onFailure: (Exception) -> Unit
+    ) {
+        val storageRef = getProfilePictureReference(userId)
+        storageRef.delete().addOnSuccessListener {
+            onSuccess()
+        }.addOnFailureListener {
+            onFailure(it)
+        }
+    }
+}

--- a/app/src/main/java/com/github/se/icebreakrr/model/profile/ProfilesViewModel.kt
+++ b/app/src/main/java/com/github/se/icebreakrr/model/profile/ProfilesViewModel.kt
@@ -1,14 +1,18 @@
 package com.github.se.icebreakrr.model.profile
 
+import android.net.Uri
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.ViewModelProvider
 import com.google.firebase.Firebase
 import com.google.firebase.firestore.GeoPoint
 import com.google.firebase.firestore.firestore
+import com.google.firebase.storage.storage
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.update
 
-open class ProfilesViewModel(private val repository: ProfilesRepository) : ViewModel() {
+open class ProfilesViewModel(private val repository: ProfilesRepository,
+                             private val ppRepository: ProfilePicRepository) : ViewModel() {
 
   private val _profiles = MutableStateFlow<List<Profile>>(emptyList())
   open val profiles: StateFlow<List<Profile>> = _profiles
@@ -30,7 +34,7 @@ open class ProfilesViewModel(private val repository: ProfilesRepository) : ViewM
         object : ViewModelProvider.Factory {
           @Suppress("UNCHECKED_CAST")
           override fun <T : ViewModel> create(modelClass: Class<T>): T {
-            return ProfilesViewModel(ProfilesRepositoryFirestore(Firebase.firestore)) as T
+            return ProfilesViewModel(ProfilesRepositoryFirestore(Firebase.firestore), ProfilePicRepositoryStorage(Firebase.storage)) as T
           }
         }
   }
@@ -141,7 +145,45 @@ open class ProfilesViewModel(private val repository: ProfilesRepository) : ViewM
     _loading.value = true
     repository.deleteProfileByUid(
         uid, onSuccess = { _loading.value = false }, onFailure = { e -> handleError(e) })
+      ppRepository.deleteProfilePicture(userId = uid, onSuccess = {}, onFailure = { e -> handleError(e) })
   }
+
+    /**
+     * Uploads the current user's profile picture to the remote storage system.
+     *
+     * @param imageData The byte array of the image file to be uploaded.
+     * @throws IllegalStateException if the user is not logged in.
+     */
+    fun uploadCurrentUserProfilePicture(imageData: ByteArray) {
+        val userId = selectedProfile.value?.uid ?: throw IllegalStateException("User not logged in")
+        ppRepository.uploadProfilePicture(
+            userId = userId,
+            imageData = imageData,
+            onSuccess = { url ->
+                _selectedProfile.update { selected ->
+                    selected?.copy(profilePictureUrl = url)
+                }
+            },
+            onFailure = { e -> handleError(e) }
+        )
+    }
+
+    /**
+     * Deletes the current user's profile picture from the remote storage system.
+     *
+     * @throws IllegalStateException if the user is not logged in.
+     */
+    fun deleteCurrentUserProfilePicture() {
+        ppRepository.deleteProfilePicture(
+            userId = selectedProfile.value?.uid ?: throw IllegalStateException("User not logged in"),
+            onSuccess = {
+                _selectedProfile.update { currentProfile ->
+                    currentProfile?.copy(profilePictureUrl = null)
+                }
+            },
+            onFailure = { e -> handleError(e) })
+    }
+
 
   /**
    * Handles errors by updating the error and loading states.
@@ -152,4 +194,6 @@ open class ProfilesViewModel(private val repository: ProfilesRepository) : ViewM
     _error.value = exception
     _loading.value = false
   }
+
+
 }

--- a/app/src/main/java/com/github/se/icebreakrr/model/profile/ProfilesViewModel.kt
+++ b/app/src/main/java/com/github/se/icebreakrr/model/profile/ProfilesViewModel.kt
@@ -1,6 +1,5 @@
 package com.github.se.icebreakrr.model.profile
 
-import android.net.Uri
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.ViewModelProvider
 import com.google.firebase.Firebase
@@ -11,8 +10,10 @@ import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.update
 
-open class ProfilesViewModel(private val repository: ProfilesRepository,
-                             private val ppRepository: ProfilePicRepository) : ViewModel() {
+open class ProfilesViewModel(
+    private val repository: ProfilesRepository,
+    private val ppRepository: ProfilePicRepository
+) : ViewModel() {
 
   private val _profiles = MutableStateFlow<List<Profile>>(emptyList())
   open val profiles: StateFlow<List<Profile>> = _profiles
@@ -34,7 +35,10 @@ open class ProfilesViewModel(private val repository: ProfilesRepository,
         object : ViewModelProvider.Factory {
           @Suppress("UNCHECKED_CAST")
           override fun <T : ViewModel> create(modelClass: Class<T>): T {
-            return ProfilesViewModel(ProfilesRepositoryFirestore(Firebase.firestore), ProfilePicRepositoryStorage(Firebase.storage)) as T
+            return ProfilesViewModel(
+                ProfilesRepositoryFirestore(Firebase.firestore),
+                ProfilePicRepositoryStorage(Firebase.storage))
+                as T
           }
         }
   }
@@ -145,45 +149,42 @@ open class ProfilesViewModel(private val repository: ProfilesRepository,
     _loading.value = true
     repository.deleteProfileByUid(
         uid, onSuccess = { _loading.value = false }, onFailure = { e -> handleError(e) })
-      ppRepository.deleteProfilePicture(userId = uid, onSuccess = {}, onFailure = { e -> handleError(e) })
+    ppRepository.deleteProfilePicture(
+        userId = uid, onSuccess = {}, onFailure = { e -> handleError(e) })
   }
 
-    /**
-     * Uploads the current user's profile picture to the remote storage system.
-     *
-     * @param imageData The byte array of the image file to be uploaded.
-     * @throws IllegalStateException if the user is not logged in.
-     */
-    fun uploadCurrentUserProfilePicture(imageData: ByteArray) {
-        val userId = selectedProfile.value?.uid ?: throw IllegalStateException("User not logged in")
-        ppRepository.uploadProfilePicture(
-            userId = userId,
-            imageData = imageData,
-            onSuccess = { url ->
-                _selectedProfile.update { selected ->
-                    selected?.copy(profilePictureUrl = url)
-                }
-            },
-            onFailure = { e -> handleError(e) }
-        )
-    }
+  /**
+   * Uploads the current user's profile picture to the remote storage system.
+   *
+   * @param imageData The byte array of the image file to be uploaded.
+   * @throws IllegalStateException if the user is not logged in.
+   */
+  fun uploadCurrentUserProfilePicture(imageData: ByteArray) {
+    val userId = selectedProfile.value?.uid ?: throw IllegalStateException("User not logged in")
+    ppRepository.uploadProfilePicture(
+        userId = userId,
+        imageData = imageData,
+        onSuccess = { url ->
+          _selectedProfile.update { selected -> selected?.copy(profilePictureUrl = url) }
+        },
+        onFailure = { e -> handleError(e) })
+  }
 
-    /**
-     * Deletes the current user's profile picture from the remote storage system.
-     *
-     * @throws IllegalStateException if the user is not logged in.
-     */
-    fun deleteCurrentUserProfilePicture() {
-        ppRepository.deleteProfilePicture(
-            userId = selectedProfile.value?.uid ?: throw IllegalStateException("User not logged in"),
-            onSuccess = {
-                _selectedProfile.update { currentProfile ->
-                    currentProfile?.copy(profilePictureUrl = null)
-                }
-            },
-            onFailure = { e -> handleError(e) })
-    }
-
+  /**
+   * Deletes the current user's profile picture from the remote storage system.
+   *
+   * @throws IllegalStateException if the user is not logged in.
+   */
+  fun deleteCurrentUserProfilePicture() {
+    ppRepository.deleteProfilePicture(
+        userId = selectedProfile.value?.uid ?: throw IllegalStateException("User not logged in"),
+        onSuccess = {
+          _selectedProfile.update { currentProfile ->
+            currentProfile?.copy(profilePictureUrl = null)
+          }
+        },
+        onFailure = { e -> handleError(e) })
+  }
 
   /**
    * Handles errors by updating the error and loading states.
@@ -194,6 +195,4 @@ open class ProfilesViewModel(private val repository: ProfilesRepository,
     _error.value = exception
     _loading.value = false
   }
-
-
 }

--- a/app/src/test/java/com/github/se/icebreakrr/model/profile/ProfilePicRepositoryStorageTest.kt
+++ b/app/src/test/java/com/github/se/icebreakrr/model/profile/ProfilePicRepositoryStorageTest.kt
@@ -6,6 +6,7 @@ import com.google.android.gms.tasks.Tasks
 import com.google.firebase.FirebaseApp
 import com.google.firebase.storage.FirebaseStorage
 import com.google.firebase.storage.StorageReference
+import com.google.firebase.storage.UploadTask
 import junit.framework.TestCase.fail
 import org.junit.Before
 import org.junit.Test
@@ -42,22 +43,24 @@ class ProfilePicRepositoryStorageTest {
     `when`(mockStorageReference.child(anyString())).thenReturn(mockStorageReference)
   }
 
-  //      @Test
-  //      fun uploadProfilePicture_shouldUploadImage() {
-  //          `when`(mockStorageReference.putBytes(any())).thenReturn(mock(UploadTask::class.java))
-  //          `when`(mockStorageReference.downloadUrl).thenReturn(Tasks.forResult(mock()))
-  //
-  //          profilePicRepositoryStorage.uploadProfilePicture(
-  //              userId = userId,
-  //              imageData = imageData,
-  //              onSuccess = { url -> assert(url != null) },
-  //              onFailure = { fail("Failure callback should not be called") }
-  //          )
-  //
-  //          shadowOf(Looper.getMainLooper()).idle()
-  //
-  //          verify(mockStorageReference).putBytes(imageData)
-  //      }
+  @Test
+  fun uploadProfilePicture_shouldUploadImage() {
+    val mockUploadTask = mock(UploadTask::class.java)
+    `when`(mockStorageReference.putBytes(any())).thenReturn(mockUploadTask)
+    `when`(mockUploadTask.addOnSuccessListener(any())).thenReturn(mockUploadTask)
+    `when`(mockUploadTask.addOnFailureListener(any())).thenReturn(mockUploadTask)
+    `when`(mockStorageReference.downloadUrl).thenReturn(Tasks.forResult(mock()))
+
+    profilePicRepositoryStorage.uploadProfilePicture(
+        userId = userId,
+        imageData = imageData,
+        onSuccess = { url -> assert(url != null) },
+        onFailure = { fail("Failure callback should not be called") })
+
+    shadowOf(Looper.getMainLooper()).idle()
+
+    verify(mockStorageReference).putBytes(imageData)
+  }
 
   @Test
   fun uploadProfilePicture_shouldCallFailureCallback_onInvalidImage() {

--- a/app/src/test/java/com/github/se/icebreakrr/model/profile/ProfilePicRepositoryStorageTest.kt
+++ b/app/src/test/java/com/github/se/icebreakrr/model/profile/ProfilePicRepositoryStorageTest.kt
@@ -1,0 +1,115 @@
+package com.github.se.icebreakrr.model.profile
+
+import android.os.Looper
+import androidx.test.core.app.ApplicationProvider
+import com.google.android.gms.tasks.Tasks
+import com.google.firebase.FirebaseApp
+import com.google.firebase.storage.FirebaseStorage
+import com.google.firebase.storage.StorageReference
+import junit.framework.TestCase.fail
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.mockito.Mock
+import org.mockito.Mockito.*
+import org.mockito.MockitoAnnotations
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.Shadows.shadowOf
+
+@RunWith(RobolectricTestRunner::class)
+class ProfilePicRepositoryStorageTest {
+
+  @Mock private lateinit var mockFirebaseStorage: FirebaseStorage
+  @Mock private lateinit var mockStorageReference: StorageReference
+
+  private lateinit var profilePicRepositoryStorage: ProfilePicRepositoryStorage
+
+  private val userId = "testUserId"
+  private val imageData = byteArrayOf(0xFF.toByte(), 0xD8.toByte(), 0xFF.toByte(), 0xD9.toByte())
+
+  @Before
+  fun setUp() {
+    MockitoAnnotations.openMocks(this)
+
+    // Initialize Firebase if necessary
+    if (FirebaseApp.getApps(ApplicationProvider.getApplicationContext()).isEmpty()) {
+      FirebaseApp.initializeApp(ApplicationProvider.getApplicationContext())
+    }
+
+    profilePicRepositoryStorage = ProfilePicRepositoryStorage(mockFirebaseStorage)
+
+    `when`(mockFirebaseStorage.reference).thenReturn(mockStorageReference)
+    `when`(mockStorageReference.child(anyString())).thenReturn(mockStorageReference)
+  }
+
+  //      @Test
+  //      fun uploadProfilePicture_shouldUploadImage() {
+  //          `when`(mockStorageReference.putBytes(any())).thenReturn(mock(UploadTask::class.java))
+  //          `when`(mockStorageReference.downloadUrl).thenReturn(Tasks.forResult(mock()))
+  //
+  //          profilePicRepositoryStorage.uploadProfilePicture(
+  //              userId = userId,
+  //              imageData = imageData,
+  //              onSuccess = { url -> assert(url != null) },
+  //              onFailure = { fail("Failure callback should not be called") }
+  //          )
+  //
+  //          shadowOf(Looper.getMainLooper()).idle()
+  //
+  //          verify(mockStorageReference).putBytes(imageData)
+  //      }
+
+  @Test
+  fun uploadProfilePicture_shouldCallFailureCallback_onInvalidImage() {
+    val invalidImageData = byteArrayOf(0x00, 0x01, 0x02, 0x03)
+
+    profilePicRepositoryStorage.uploadProfilePicture(
+        userId = userId,
+        imageData = invalidImageData,
+        onSuccess = { fail("Success callback should not be called") },
+        onFailure = { exception -> assert(exception is IllegalArgumentException) })
+
+    shadowOf(Looper.getMainLooper()).idle()
+  }
+
+  @Test
+  fun getProfilePictureByUid_shouldReturnUrl() {
+    `when`(mockStorageReference.downloadUrl).thenReturn(Tasks.forResult(mock()))
+
+    profilePicRepositoryStorage.getProfilePictureByUid(
+        userId = userId,
+        onSuccess = { url -> assert(url != null) },
+        onFailure = { fail("Failure callback should not be called") })
+
+    shadowOf(Looper.getMainLooper()).idle()
+
+    verify(mockStorageReference).downloadUrl
+  }
+
+  @Test
+  fun deleteProfilePicture_shouldDeleteImage() {
+    `when`(mockStorageReference.delete()).thenReturn(Tasks.forResult(null))
+
+    profilePicRepositoryStorage.deleteProfilePicture(
+        userId = userId,
+        onSuccess = { /* Success */},
+        onFailure = { fail("Failure callback should not be called") })
+
+    shadowOf(Looper.getMainLooper()).idle()
+
+    verify(mockStorageReference).delete()
+  }
+
+  @Test
+  fun deleteProfilePicture_shouldCallFailureCallback_onError() {
+    `when`(mockStorageReference.delete())
+        .thenReturn(Tasks.forException(Exception("Test exception")))
+
+    profilePicRepositoryStorage.deleteProfilePicture(
+        userId = userId,
+        onSuccess = { fail("Success callback should not be called") },
+        onFailure = { exception -> assert(exception.message == "Test exception") })
+
+    shadowOf(Looper.getMainLooper()).idle()
+  }
+}

--- a/app/src/test/java/com/github/se/icebreakrr/model/profile/ProfilesViewModelTest.kt
+++ b/app/src/test/java/com/github/se/icebreakrr/model/profile/ProfilesViewModelTest.kt
@@ -1,11 +1,9 @@
 package com.github.se.icebreakrr.model.profile
 
-import androidx.lifecycle.viewmodel.compose.viewModel
 import com.google.firebase.Timestamp
 import com.google.firebase.firestore.GeoPoint
 import java.util.Calendar
 import kotlinx.coroutines.runBlocking
-import org.hamcrest.CoreMatchers.instanceOf
 import org.hamcrest.CoreMatchers.`is`
 import org.hamcrest.CoreMatchers.nullValue
 import org.hamcrest.MatcherAssert.assertThat
@@ -20,7 +18,7 @@ import org.mockito.kotlin.whenever
 
 class ProfilesViewModelTest {
   private lateinit var profilesRepository: ProfilesRepository
-    private lateinit var ppRepository: ProfilePicRepository
+  private lateinit var ppRepository: ProfilePicRepository
   private lateinit var profilesViewModel: ProfilesViewModel
 
   private val birthDate2002 =
@@ -57,7 +55,7 @@ class ProfilesViewModelTest {
   @Before
   fun setUp() {
     profilesRepository = mock(ProfilesRepository::class.java)
-      ppRepository = mock(ProfilePicRepository::class.java)
+    ppRepository = mock(ProfilePicRepository::class.java)
     profilesViewModel = ProfilesViewModel(profilesRepository, ppRepository)
   }
 
@@ -211,97 +209,100 @@ class ProfilesViewModelTest {
     assertThat(profilesViewModel.error.value, `is`(exception))
   }
 
-    @Test
-    fun uploadCurrentUserProfilePictureSucceeds() = runBlocking {
-        val imageData = ByteArray(4) { 0xFF.toByte() }
+  @Test
+  fun uploadCurrentUserProfilePictureSucceeds() = runBlocking {
+    val imageData = ByteArray(4) { 0xFF.toByte() }
 
-        whenever(profilesRepository.getProfileByUid(eq("1"), any(), any())).thenAnswer {
-            val onSuccess = it.getArgument<(Profile) -> Unit>(1)
-            onSuccess(profile1)
-        }
-
-        whenever(ppRepository.uploadProfilePicture(any(), any(), any(), any())).thenAnswer {
-            val onSuccess = it.getArgument<(String?) -> Unit>(2)
-            onSuccess("http://example.com/profile.jpg")
-        }
-
-        profilesViewModel.getProfileByUid("1")
-        profilesViewModel.uploadCurrentUserProfilePicture(imageData)
-
-        verify(ppRepository).uploadProfilePicture(eq("1"), eq(imageData), any(), any())
-        assertThat(profilesViewModel.selectedProfile.value?.profilePictureUrl, `is`("http://example.com/profile.jpg"))
+    whenever(profilesRepository.getProfileByUid(eq("1"), any(), any())).thenAnswer {
+      val onSuccess = it.getArgument<(Profile) -> Unit>(1)
+      onSuccess(profile1)
     }
 
-    @Test
-    fun uploadCurrentUserProfilePictureFails() = runBlocking {
-        val imageData = ByteArray(4) { 0xFF.toByte() }
-        val exception = Exception("Failed to upload profile picture")
-
-        whenever(profilesRepository.getProfileByUid(eq("1"), any(), any())).thenAnswer {
-            val onSuccess = it.getArgument<(Profile) -> Unit>(1)
-            onSuccess(profile1)
-        }
-
-        whenever(ppRepository.uploadProfilePicture(any(), any(), any(), any())).thenAnswer {
-            val onFailure = it.getArgument<(Exception) -> Unit>(3)
-            onFailure(exception)
-        }
-
-        profilesViewModel.getProfileByUid("1")
-        profilesViewModel.uploadCurrentUserProfilePicture(imageData)
-
-        verify(ppRepository).uploadProfilePicture(eq("1"), eq(imageData), any(), any())
-        assertThat(profilesViewModel.error.value, `is`(exception))
+    whenever(ppRepository.uploadProfilePicture(any(), any(), any(), any())).thenAnswer {
+      val onSuccess = it.getArgument<(String?) -> Unit>(2)
+      onSuccess("http://example.com/profile.jpg")
     }
 
-    @Test
-    fun uploadCurrentUserProfilePictureThrowsExceptionIfUserNotLoggedIn() {
-        val imageData = ByteArray(4) { 0xFF.toByte() }
+    profilesViewModel.getProfileByUid("1")
+    profilesViewModel.uploadCurrentUserProfilePicture(imageData)
 
-        val exception = assertThrows(IllegalStateException::class.java) {
-            profilesViewModel.uploadCurrentUserProfilePicture(imageData)
-        }
+    verify(ppRepository).uploadProfilePicture(eq("1"), eq(imageData), any(), any())
+    assertThat(
+        profilesViewModel.selectedProfile.value?.profilePictureUrl,
+        `is`("http://example.com/profile.jpg"))
+  }
 
-        assertThat(exception.message, `is`("User not logged in"))
+  @Test
+  fun uploadCurrentUserProfilePictureFails() = runBlocking {
+    val imageData = ByteArray(4) { 0xFF.toByte() }
+    val exception = Exception("Failed to upload profile picture")
+
+    whenever(profilesRepository.getProfileByUid(eq("1"), any(), any())).thenAnswer {
+      val onSuccess = it.getArgument<(Profile) -> Unit>(1)
+      onSuccess(profile1)
     }
 
-    @Test
-    fun deleteCurrentUserProfilePictureSucceeds() = runBlocking {
-        whenever(profilesRepository.getProfileByUid(eq("1"), any(), any())).thenAnswer {
-            val onSuccess = it.getArgument<(Profile) -> Unit>(1)
-            onSuccess(profile1)
-        }
-
-        whenever(ppRepository.deleteProfilePicture(any(), any(), any())).thenAnswer {
-            val onSuccess = it.getArgument<() -> Unit>(1)
-            onSuccess()
-        }
-
-        profilesViewModel.getProfileByUid("1")
-        profilesViewModel.deleteCurrentUserProfilePicture()
-
-        verify(ppRepository).deleteProfilePicture(eq("1"), any(), any())
-        assertThat(profilesViewModel.selectedProfile.value?.profilePictureUrl, `is`(nullValue()))
+    whenever(ppRepository.uploadProfilePicture(any(), any(), any(), any())).thenAnswer {
+      val onFailure = it.getArgument<(Exception) -> Unit>(3)
+      onFailure(exception)
     }
 
-    @Test
-    fun deleteCurrentUserProfilePictureFails() = runBlocking {
-        val exception = Exception("Failed to delete profile picture")
+    profilesViewModel.getProfileByUid("1")
+    profilesViewModel.uploadCurrentUserProfilePicture(imageData)
 
-        whenever(profilesRepository.getProfileByUid(eq("1"), any(), any())).thenAnswer {
-            val onSuccess = it.getArgument<(Profile) -> Unit>(1)
-            onSuccess(profile1)
+    verify(ppRepository).uploadProfilePicture(eq("1"), eq(imageData), any(), any())
+    assertThat(profilesViewModel.error.value, `is`(exception))
+  }
+
+  @Test
+  fun uploadCurrentUserProfilePictureThrowsExceptionIfUserNotLoggedIn() {
+    val imageData = ByteArray(4) { 0xFF.toByte() }
+
+    val exception =
+        assertThrows(IllegalStateException::class.java) {
+          profilesViewModel.uploadCurrentUserProfilePicture(imageData)
         }
 
-        whenever(ppRepository.deleteProfilePicture(any(), any(), any())).thenAnswer {
-            val onFailure = it.getArgument<(Exception) -> Unit>(2)
-            onFailure(exception)
-        }
+    assertThat(exception.message, `is`("User not logged in"))
+  }
 
-        profilesViewModel.getProfileByUid("1")
-        profilesViewModel.deleteCurrentUserProfilePicture()
-
-        verify(ppRepository).deleteProfilePicture(eq("1"), any(), any())
-        assertThat(profilesViewModel.error.value, `is`(exception))
+  @Test
+  fun deleteCurrentUserProfilePictureSucceeds() = runBlocking {
+    whenever(profilesRepository.getProfileByUid(eq("1"), any(), any())).thenAnswer {
+      val onSuccess = it.getArgument<(Profile) -> Unit>(1)
+      onSuccess(profile1)
     }
+
+    whenever(ppRepository.deleteProfilePicture(any(), any(), any())).thenAnswer {
+      val onSuccess = it.getArgument<() -> Unit>(1)
+      onSuccess()
+    }
+
+    profilesViewModel.getProfileByUid("1")
+    profilesViewModel.deleteCurrentUserProfilePicture()
+
+    verify(ppRepository).deleteProfilePicture(eq("1"), any(), any())
+    assertThat(profilesViewModel.selectedProfile.value?.profilePictureUrl, `is`(nullValue()))
+  }
+
+  @Test
+  fun deleteCurrentUserProfilePictureFails() = runBlocking {
+    val exception = Exception("Failed to delete profile picture")
+
+    whenever(profilesRepository.getProfileByUid(eq("1"), any(), any())).thenAnswer {
+      val onSuccess = it.getArgument<(Profile) -> Unit>(1)
+      onSuccess(profile1)
+    }
+
+    whenever(ppRepository.deleteProfilePicture(any(), any(), any())).thenAnswer {
+      val onFailure = it.getArgument<(Exception) -> Unit>(2)
+      onFailure(exception)
+    }
+
+    profilesViewModel.getProfileByUid("1")
+    profilesViewModel.deleteCurrentUserProfilePicture()
+
+    verify(ppRepository).deleteProfilePicture(eq("1"), any(), any())
+    assertThat(profilesViewModel.error.value, `is`(exception))
+  }
 }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -47,6 +47,7 @@ robolectric = "4.11.1"
 #CI
 sonar = "4.4.1.3373"
 ktfmt = "0.17.0"
+firebaseStorageKtx = "21.0.1"
 
 [libraries]
 #Google
@@ -99,6 +100,7 @@ robolectric = { module = "org.robolectric:robolectric", version.ref = "robolectr
 mockito-core = { group = "org.mockito", name = "mockito-core", version.ref = "mockitoCore" }
 mockito-kotlin = { group = "org.mockito.kotlin", name = "mockito-kotlin", version.ref = "mockitoKotlin" }
 androidx-navigation-testing = { group = "androidx.navigation", name = "navigation-testing", version.ref = "navigationTesting" }
+firebase-storage-ktx = { group = "com.google.firebase", name = "firebase-storage-ktx", version.ref = "firebaseStorageKtx" }
 
 
 [plugins]


### PR DESCRIPTION
This pull request introduces new functionalities for profile picture management in the app and the Firebase Storage (cloud). It includes the addition of a new repository for handling profile pictures, updates to the ViewModel to incorporate this repository, and corresponding updates to the tests.

### Profile Picture Management:

* Added `ProfilePicRepository` interface and its implementation `ProfilePicRepositoryStorage` to manage profile pictures using Firebase Storage. (`ProfilePicRepository.kt`, `ProfilePicRepositoryStorage.kt`) [[1]](diffhunk://#diff-dd19e2423c35a3e579757bac48d3cd1235d25696b4e0e3d54fe6d020f609be7eR1-R18) [[2]](diffhunk://#diff-871a6990a978322aa0412d5260588bdeb21b0c69632f8c8521add06283ad7172R1-R99)

### ViewModel Updates:

* Updated `ProfilesViewModel` to include methods for uploading and deleting profile pictures, and modified its constructor to accept the new `ProfilePicRepository`. (`ProfilesViewModel.kt`) [[1]](diffhunk://#diff-4a28db3315acbc7e70a871270a4ea42b4c2d61d9dd4af0fa314981600305fc03R8-R16) [[2]](diffhunk://#diff-4a28db3315acbc7e70a871270a4ea42b4c2d61d9dd4af0fa314981600305fc03L35-R43) [[3]](diffhunk://#diff-4a28db3315acbc7e70a871270a4ea42b4c2d61d9dd4af0fa314981600305fc03R134-R168)

### Dependency Management:

* Added Firebase Storage dependency to the project. (`app/build.gradle.kts`, `gradle/libs.versions.toml`) [[1]](diffhunk://#diff-8cff73265af19c059547b76aca8882cbaa3209291406f52df1dafbbc78e80c46R156) [[2]](diffhunk://#diff-697f70cdd88ba88fe77eebda60c7e143f6ad1286bca75017421e93ad84fb87dfR50) [[3]](diffhunk://#diff-697f70cdd88ba88fe77eebda60c7e143f6ad1286bca75017421e93ad84fb87dfR103)

### Testing:

* Updated `ProfilesViewModelTest` to include tests for the new profile picture management functionality. (`ProfilesViewModelTest.kt`) [[1]](diffhunk://#diff-774d252c6c8ad17ee46f69531a249202e9922706f26fe22e47158c3851f33b4bR8-R10) [[2]](diffhunk://#diff-774d252c6c8ad17ee46f69531a249202e9922706f26fe22e47158c3851f33b4bR21) [[3]](diffhunk://#diff-774d252c6c8ad17ee46f69531a249202e9922706f26fe22e47158c3851f33b4bL38-R42) [[4]](diffhunk://#diff-774d252c6c8ad17ee46f69531a249202e9922706f26fe22e47158c3851f33b4bL48-R59) [[5]](diffhunk://#diff-774d252c6c8ad17ee46f69531a249202e9922706f26fe22e47158c3851f33b4bR209-R305)