### PR TITLE
Feature/filter view model and linking

### DIFF
--- a/app/src/androidTest/java/com/github/se/icebreakrr/ui/sections/AroundYouTest.kt
+++ b/app/src/androidTest/java/com/github/se/icebreakrr/ui/sections/AroundYouTest.kt
@@ -9,6 +9,7 @@ import androidx.compose.ui.test.performClick
 import androidx.compose.ui.test.performTouchInput
 import androidx.lifecycle.viewmodel.compose.viewModel
 import androidx.test.espresso.action.ViewActions.swipeDown
+import com.github.se.icebreakrr.model.filter.FilterViewModel
 import com.github.se.icebreakrr.model.profile.Gender
 import com.github.se.icebreakrr.model.profile.Profile
 import com.github.se.icebreakrr.model.profile.ProfilesRepository
@@ -47,7 +48,10 @@ class AroundYouScreenTest {
 
     composeTestRule.setContent {
       AroundYouScreen(
-          navigationActions, profilesViewModel, viewModel(factory = TagsViewModel.Factory))
+          navigationActions,
+          profilesViewModel,
+          viewModel(factory = TagsViewModel.Factory),
+          viewModel(factory = FilterViewModel.Factory))
     }
   }
 

--- a/app/src/androidTest/java/com/github/se/icebreakrr/ui/sections/FilterScreenTest.kt
+++ b/app/src/androidTest/java/com/github/se/icebreakrr/ui/sections/FilterScreenTest.kt
@@ -15,6 +15,8 @@ import androidx.compose.ui.test.onNodeWithTag
 import androidx.compose.ui.test.performClick
 import androidx.compose.ui.test.performTextClearance
 import androidx.compose.ui.test.performTextInput
+import com.github.se.icebreakrr.model.filter.FilterViewModel
+import com.github.se.icebreakrr.model.profile.Gender
 import com.github.se.icebreakrr.model.profile.ProfilesRepository
 import com.github.se.icebreakrr.model.profile.ProfilesViewModel
 import com.github.se.icebreakrr.ui.navigation.NavigationActions
@@ -30,6 +32,7 @@ class FilterScreenTest {
   private lateinit var navigationActionsMock: NavigationActions
   private lateinit var profilesRepositoryMock: ProfilesRepository
   private lateinit var profilesViewModelMock: ProfilesViewModel
+  private lateinit var filterViewModel: FilterViewModel
 
   @get:Rule val composeTestRule = createComposeRule()
 
@@ -38,6 +41,7 @@ class FilterScreenTest {
     navigationActionsMock = mock()
     profilesRepositoryMock = mock()
     profilesViewModelMock = ProfilesViewModel(profilesRepositoryMock)
+    filterViewModel = FilterViewModel()
   }
 
   @Test
@@ -278,6 +282,30 @@ class FilterScreenTest {
     composeTestRule.onNodeWithTag("FilterButton").performClick()
     // Verify that the navigation action is called
     verify(navigationActionsMock).goBack()
+  }
+
+  @Test
+  fun testFilterButtonActions() {
+    composeTestRule.setContent {
+      FilterScreen(
+          navigationActionsMock,
+          profilesViewModel = profilesViewModelMock,
+          filterViewModel = filterViewModel)
+    }
+
+    composeTestRule.onNodeWithTag("GenderButtonMen").performClick()
+    composeTestRule.onNodeWithTag("GenderButtonWomen").performClick()
+    composeTestRule.onNodeWithTag("GenderButtonOther").performClick()
+
+    composeTestRule.onNodeWithTag("FilterButton").performClick()
+
+    assert(filterViewModel.selectedGenders.value == listOf(Gender.MEN, Gender.WOMEN, Gender.OTHER))
+
+    composeTestRule.onNodeWithTag("GenderButtonWomen").performClick()
+
+    composeTestRule.onNodeWithTag("FilterButton").performClick()
+
+    assert(filterViewModel.selectedGenders.value == listOf(Gender.MEN, Gender.OTHER))
   }
 
   @Test

--- a/app/src/androidTest/java/com/github/se/icebreakrr/ui/sections/FilterScreenTest.kt
+++ b/app/src/androidTest/java/com/github/se/icebreakrr/ui/sections/FilterScreenTest.kt
@@ -15,6 +15,8 @@ import androidx.compose.ui.test.onNodeWithTag
 import androidx.compose.ui.test.performClick
 import androidx.compose.ui.test.performTextClearance
 import androidx.compose.ui.test.performTextInput
+import com.github.se.icebreakrr.model.profile.ProfilesRepository
+import com.github.se.icebreakrr.model.profile.ProfilesViewModel
 import com.github.se.icebreakrr.ui.navigation.NavigationActions
 import org.junit.Before
 import org.junit.Rule
@@ -26,12 +28,16 @@ import org.mockito.kotlin.verify
 class FilterScreenTest {
 
   private lateinit var navigationActionsMock: NavigationActions
+  private lateinit var profilesRepositoryMock: ProfilesRepository
+  private lateinit var profilesViewModelMock: ProfilesViewModel
 
   @get:Rule val composeTestRule = createComposeRule()
 
   @Before
   fun setUp() {
     navigationActionsMock = mock()
+    profilesRepositoryMock = mock()
+    profilesViewModelMock = ProfilesViewModel(profilesRepositoryMock)
   }
 
   @Test
@@ -261,16 +267,18 @@ class FilterScreenTest {
     toTextField.assert(hasText(""))
   }
 
-  // This Test now fails for no reason whatsoever, we'll have to investigate
-  // @Test
-  // fun testFilterButtonNavigation() {
-  //  composeTestRule.setContent { FilterScreen(navigationActions = navigationActionsMock) }
+  @Test
+  fun testFilterButtonNavigation() {
+    composeTestRule.setContent {
+      FilterScreen(
+          navigationActions = navigationActionsMock, profilesViewModel = profilesViewModelMock)
+    }
 
-  // Click the filter button
-  //  composeTestRule.onNodeWithTag("FilterButton").performClick()
-  // Verify that the navigation action is called
-  //  verify(navigationActionsMock).goBack()
-  // }
+    // Click the filter button
+    composeTestRule.onNodeWithTag("FilterButton").performClick()
+    // Verify that the navigation action is called
+    verify(navigationActionsMock).goBack()
+  }
 
   @Test
   fun testGenderButtonAppearance() {

--- a/app/src/androidTest/java/com/github/se/icebreakrr/ui/sections/FilterScreenTest.kt
+++ b/app/src/androidTest/java/com/github/se/icebreakrr/ui/sections/FilterScreenTest.kt
@@ -16,10 +16,11 @@ import androidx.compose.ui.test.performClick
 import androidx.compose.ui.test.performTextClearance
 import androidx.compose.ui.test.performTextInput
 import com.github.se.icebreakrr.model.filter.FilterViewModel
-import com.github.se.icebreakrr.model.profile.Gender
 import com.github.se.icebreakrr.model.profile.ProfilesRepository
 import com.github.se.icebreakrr.model.profile.ProfilesViewModel
 import com.github.se.icebreakrr.ui.navigation.NavigationActions
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
 import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
@@ -293,19 +294,55 @@ class FilterScreenTest {
           filterViewModel = filterViewModel)
     }
 
+    // Test case 1: Select genders and set valid age range
     composeTestRule.onNodeWithTag("GenderButtonMen").performClick()
     composeTestRule.onNodeWithTag("GenderButtonWomen").performClick()
-    composeTestRule.onNodeWithTag("GenderButtonOther").performClick()
+
+    // Set valid age range
+    composeTestRule.onNodeWithTag("AgeFromTextField").performTextInput("25")
+    composeTestRule.onNodeWithTag("AgeToTextField").performTextInput("30")
+
+    // Click the filter button
+    composeTestRule.onNodeWithTag("FilterButton").performClick()
+
+    // Assert that the correct age range is set
+    assertEquals(25..30, filterViewModel.ageRange.value)
+
+    // Test case 2: No age range (both fields empty)
+    composeTestRule.onNodeWithTag("AgeFromTextField").performTextClearance()
+    composeTestRule.onNodeWithTag("AgeToTextField").performTextClearance()
 
     composeTestRule.onNodeWithTag("FilterButton").performClick()
 
-    assert(filterViewModel.selectedGenders.value == listOf(Gender.MEN, Gender.WOMEN, Gender.OTHER))
+    // Assert that the age range is set to null
+    assertNull(filterViewModel.ageRange.value)
 
-    composeTestRule.onNodeWithTag("GenderButtonWomen").performClick()
+    // Test case 3: Only "From" age set
+    composeTestRule.onNodeWithTag("AgeFromTextField").performTextInput("25")
+    composeTestRule.onNodeWithTag("AgeToTextField").performTextClearance()
 
     composeTestRule.onNodeWithTag("FilterButton").performClick()
 
-    assert(filterViewModel.selectedGenders.value == listOf(Gender.MEN, Gender.OTHER))
+    // Assert that the age range is set to (25..Int.MAX_VALUE)
+    assertEquals(25..Int.MAX_VALUE, filterViewModel.ageRange.value)
+
+    // Test case 4: Only "To" age set
+    composeTestRule.onNodeWithTag("AgeFromTextField").performTextClearance()
+    composeTestRule.onNodeWithTag("AgeToTextField").performTextInput("30")
+
+    composeTestRule.onNodeWithTag("FilterButton").performClick()
+
+    // Assert that the age range is set to (0..30)
+    assertEquals(0..30, filterViewModel.ageRange.value)
+
+    // Test case 5: Invalid age range (ageFrom > ageTo)
+    composeTestRule.onNodeWithTag("AgeFromTextField").performTextInput("35")
+    composeTestRule.onNodeWithTag("AgeToTextField").performTextInput("30")
+
+    composeTestRule.onNodeWithTag("FilterButton").performClick()
+
+    // Assert that the age range is set to null due to error
+    assertNull(filterViewModel.ageRange.value)
   }
 
   @Test

--- a/app/src/androidTest/java/com/github/se/icebreakrr/ui/sections/FilterScreenTest.kt
+++ b/app/src/androidTest/java/com/github/se/icebreakrr/ui/sections/FilterScreenTest.kt
@@ -261,15 +261,16 @@ class FilterScreenTest {
     toTextField.assert(hasText(""))
   }
 
-  @Test
-  fun testFilterButtonNavigation() {
-    composeTestRule.setContent { FilterScreen(navigationActions = navigationActionsMock) }
+  // This Test now fails for no reason whatsoever, we'll have to investigate
+  // @Test
+  // fun testFilterButtonNavigation() {
+  //  composeTestRule.setContent { FilterScreen(navigationActions = navigationActionsMock) }
 
-    // Click the filter button
-    composeTestRule.onNodeWithTag("FilterButton").performClick()
-    // Verify that the navigation action is called
-    verify(navigationActionsMock).goBack()
-  }
+  // Click the filter button
+  //  composeTestRule.onNodeWithTag("FilterButton").performClick()
+  // Verify that the navigation action is called
+  //  verify(navigationActionsMock).goBack()
+  // }
 
   @Test
   fun testGenderButtonAppearance() {

--- a/app/src/main/java/com/github/se/icebreakrr/MainActivity.kt
+++ b/app/src/main/java/com/github/se/icebreakrr/MainActivity.kt
@@ -14,6 +14,7 @@ import androidx.navigation.compose.composable
 import androidx.navigation.compose.navigation
 import androidx.navigation.compose.rememberNavController
 import com.github.se.icebreakrr.config.LocalIsTesting
+import com.github.se.icebreakrr.model.filter.FilterViewModel
 import com.github.se.icebreakrr.model.profile.ProfilesViewModel
 import com.github.se.icebreakrr.model.tags.TagsViewModel
 import com.github.se.icebreakrr.ui.authentication.SignInScreen
@@ -74,6 +75,7 @@ fun IcebreakrrApp() {
   val navigationActions = NavigationActions(navController)
   val profileViewModel: ProfilesViewModel = viewModel(factory = ProfilesViewModel.Factory)
   val tagsViewModel: TagsViewModel = viewModel(factory = TagsViewModel.Factory)
+  val filterViewModel: FilterViewModel = viewModel(factory = FilterViewModel.Factory)
 
   NavHost(navController = navController, startDestination = Route.AUTH) {
     navigation(
@@ -88,7 +90,7 @@ fun IcebreakrrApp() {
         route = Route.AROUND_YOU,
     ) {
       composable(Screen.AROUND_YOU) {
-        AroundYouScreen(navigationActions, profileViewModel, tagsViewModel)
+        AroundYouScreen(navigationActions, profileViewModel, tagsViewModel, filterViewModel)
       }
     }
 
@@ -118,7 +120,7 @@ fun IcebreakrrApp() {
         startDestination = Screen.FILTER,
         route = Route.FILTER,
     ) {
-      composable(Screen.FILTER) { FilterScreen(navigationActions, tagsViewModel) }
+      composable(Screen.FILTER) { FilterScreen(navigationActions, tagsViewModel, filterViewModel) }
     }
   }
 }

--- a/app/src/main/java/com/github/se/icebreakrr/MainActivity.kt
+++ b/app/src/main/java/com/github/se/icebreakrr/MainActivity.kt
@@ -120,7 +120,9 @@ fun IcebreakrrApp() {
         startDestination = Screen.FILTER,
         route = Route.FILTER,
     ) {
-      composable(Screen.FILTER) { FilterScreen(navigationActions, tagsViewModel, filterViewModel) }
+      composable(Screen.FILTER) {
+        FilterScreen(navigationActions, tagsViewModel, filterViewModel, profileViewModel)
+      }
     }
   }
 }

--- a/app/src/main/java/com/github/se/icebreakrr/model/filter/FilterViewModel.kt
+++ b/app/src/main/java/com/github/se/icebreakrr/model/filter/FilterViewModel.kt
@@ -1,0 +1,57 @@
+package com.github.se.icebreakrr.model.filter
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.ViewModelProvider
+import com.github.se.icebreakrr.model.profile.Gender
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+
+// This file was written with the help of CursorAI
+class FilterViewModel : ViewModel() {
+
+  private val _selectedGenders = MutableStateFlow<List<Gender>>(emptyList())
+  val selectedGenders: StateFlow<List<Gender>> = _selectedGenders
+
+  private val _ageRange = MutableStateFlow<IntRange?>(null)
+  val ageRange: StateFlow<IntRange?> = _ageRange
+
+  private val _filteredTags = MutableStateFlow<List<String>>(emptyList())
+  val filteredTags: StateFlow<List<String>> = _filteredTags
+
+  /**
+   * Sets the selected genders.
+   *
+   * @param genders The list of selected genders.
+   */
+  fun setGenders(genders: List<Gender>) {
+    _selectedGenders.value = genders
+  }
+
+  /**
+   * Sets the age range.
+   *
+   * @param range The age range to set.
+   */
+  fun setAgeRange(range: IntRange?) {
+    _ageRange.value = range
+  }
+
+  /**
+   * Sets the list of filtered tags.
+   *
+   * @param tags List of tags to save.
+   */
+  fun setFilteredTags(tags: List<String>) {
+    _filteredTags.value = tags
+  }
+
+  companion object {
+    val Factory: ViewModelProvider.Factory =
+        object : ViewModelProvider.Factory {
+          @Suppress("UNCHECKED_CAST")
+          override fun <T : ViewModel> create(modelClass: Class<T>): T {
+            return FilterViewModel() as T
+          }
+        }
+  }
+}

--- a/app/src/main/java/com/github/se/icebreakrr/model/profile/ProfilesViewModel.kt
+++ b/app/src/main/java/com/github/se/icebreakrr/model/profile/ProfilesViewModel.kt
@@ -77,13 +77,15 @@ open class ProfilesViewModel(private val repository: ProfilesRepository) : ViewM
               profileList.filter { profile ->
 
                 // Filter by genders if specified
-                (genders == null || profile.gender in genders) &&
+                (genders == null || profile.gender in genders || genders.isEmpty()) &&
 
                     // Filter by age range if specified
                     (ageRange == null || profile.calculateAge() in ageRange) &&
 
                     // Filter by tags if specified
-                    (tags == null || profile.tags.containsAll(tags))
+                    (tags == null ||
+                        profile.tags.any { it.lowercase() in tags.map { it.lowercase() } } ||
+                        tags.isEmpty())
               }
           _profiles.value = profileList
           _filteredProfiles.value = filteredProfiles

--- a/app/src/main/java/com/github/se/icebreakrr/model/tags/TagsViewModel.kt
+++ b/app/src/main/java/com/github/se/icebreakrr/model/tags/TagsViewModel.kt
@@ -133,7 +133,9 @@ data class TagsViewModel(private val repository: TagsRepository) : ViewModel() {
    * @param tag : tag to add
    */
   fun addFilter(tag: String) {
-    filteringTags_.value += tag
+    if (!filteringTags.value.contains(tag)) {
+      filteringTags_.value += tag
+    }
   }
 
   /**

--- a/app/src/main/java/com/github/se/icebreakrr/ui/sections/AroundYou.kt
+++ b/app/src/main/java/com/github/se/icebreakrr/ui/sections/AroundYou.kt
@@ -24,6 +24,7 @@ import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
+import com.github.se.icebreakrr.model.filter.FilterViewModel
 import com.github.se.icebreakrr.model.profile.Gender
 import com.github.se.icebreakrr.model.profile.ProfilesViewModel
 import com.github.se.icebreakrr.model.tags.TagsViewModel
@@ -49,7 +50,8 @@ import com.google.firebase.firestore.GeoPoint
 fun AroundYouScreen(
     navigationActions: NavigationActions,
     profilesViewModel: ProfilesViewModel,
-    tagsViewModel: TagsViewModel
+    tagsViewModel: TagsViewModel,
+    filterViewModel: FilterViewModel
 ) {
 
   val filteredProfiles = profilesViewModel.filteredProfiles.collectAsState()
@@ -66,6 +68,8 @@ fun AroundYouScreen(
       topBar = { TopBar("Around You") },
       content = { innerPadding ->
         PullToRefreshBox(
+            filterViewModel = filterViewModel,
+            tagsViewModel = tagsViewModel,
             isRefreshing = isLoading.value,
             onRefresh = profilesViewModel::getFilteredProfilesInRadius,
             modifier = Modifier.padding(innerPadding)) {
@@ -119,14 +123,16 @@ fun AroundYouScreen(
 @Composable
 @ExperimentalMaterial3Api
 fun PullToRefreshBox(
+    filterViewModel: FilterViewModel,
+    tagsViewModel: TagsViewModel,
     isRefreshing: Boolean,
     onRefresh:
         (
             center: GeoPoint,
             radiusInMeters: Double,
-            genders: List<Gender>,
-            ageRange: IntRange,
-            tags: List<String>) -> Unit,
+            genders: List<Gender>?,
+            ageRange: IntRange?,
+            tags: List<String>?) -> Unit,
     modifier: Modifier = Modifier,
     state: PullToRefreshState = rememberPullToRefreshState(),
     contentAlignment: Alignment = Alignment.TopStart,
@@ -143,7 +149,11 @@ fun PullToRefreshBox(
       modifier.pullToRefresh(state = state, isRefreshing = isRefreshing) {
         // TODO Mocked values, to change with the saved filter values and current location
         onRefresh(
-            GeoPoint(0.0, 0.0), 300.0, listOf(Gender.MEN, Gender.WOMEN), 2..99, listOf("travel"))
+            GeoPoint(0.0, 0.0),
+            300.0,
+            filterViewModel.selectedGenders.value,
+            filterViewModel.ageRange.value,
+            tagsViewModel.filteredTags.value)
       },
       contentAlignment = contentAlignment) {
         content()

--- a/app/src/main/java/com/github/se/icebreakrr/ui/sections/Filter.kt
+++ b/app/src/main/java/com/github/se/icebreakrr/ui/sections/Filter.kt
@@ -50,9 +50,11 @@ import androidx.compose.ui.unit.sp
 import androidx.lifecycle.viewmodel.compose.viewModel
 import com.github.se.icebreakrr.model.filter.FilterViewModel
 import com.github.se.icebreakrr.model.profile.Gender
+import com.github.se.icebreakrr.model.profile.ProfilesViewModel
 import com.github.se.icebreakrr.model.tags.TagsViewModel
 import com.github.se.icebreakrr.ui.navigation.NavigationActions
 import com.github.se.icebreakrr.ui.tags.TagSelector
+import com.google.firebase.firestore.GeoPoint
 
 const val textSizeFactor = 0.3f
 val IcebreakrrBlue: Color = Color(0xFF1FAEF0)
@@ -71,7 +73,8 @@ const val titleFontSizeFactor = 0.03f
 fun FilterScreen(
     navigationActions: NavigationActions,
     tagsViewModel: TagsViewModel = viewModel(factory = TagsViewModel.Factory),
-    filterViewModel: FilterViewModel = viewModel(factory = FilterViewModel.Factory)
+    filterViewModel: FilterViewModel = viewModel(factory = FilterViewModel.Factory),
+    profilesViewModel: ProfilesViewModel = viewModel(factory = ProfilesViewModel.Factory)
 ) {
   val context = LocalContext.current
 
@@ -313,6 +316,13 @@ fun FilterScreen(
                       filterViewModel.setAgeRange(null)
                     }
                   }
+
+                  profilesViewModel.getFilteredProfilesInRadius(
+                      GeoPoint(0.0, 0.0),
+                      300.0,
+                      filterViewModel.selectedGenders.value,
+                      filterViewModel.ageRange.value,
+                      tagsViewModel.filteredTags.value)
 
                   navigationActions.goBack()
                 },

--- a/app/src/main/java/com/github/se/icebreakrr/ui/sections/Filter.kt
+++ b/app/src/main/java/com/github/se/icebreakrr/ui/sections/Filter.kt
@@ -88,6 +88,9 @@ fun FilterScreen(
   // Read the selected genders from the ViewModel
   val selectedGenders by filterViewModel.selectedGenders.collectAsState()
 
+  // Store the new inputs
+  val currentSelectedGenders = mutableListOf<Gender>()
+
   // Gender selection logic
   var manSelected by remember { mutableStateOf(selectedGenders.contains(Gender.MEN)) }
   var womanSelected by remember { mutableStateOf(selectedGenders.contains(Gender.WOMEN)) }
@@ -293,11 +296,10 @@ fun FilterScreen(
                   tagsViewModel.applyFilters()
                   tagsViewModel.leaveUI()
 
-                  val selectedGenders = mutableListOf<Gender>()
-                  if (manSelected) selectedGenders.add(Gender.MEN)
-                  if (womanSelected) selectedGenders.add(Gender.WOMEN)
-                  if (otherSelected) selectedGenders.add(Gender.OTHER)
-                  filterViewModel.setGenders(selectedGenders)
+                  if (manSelected) currentSelectedGenders.add(Gender.MEN)
+                  if (womanSelected) currentSelectedGenders.add(Gender.WOMEN)
+                  if (otherSelected) currentSelectedGenders.add(Gender.OTHER)
+                  filterViewModel.setGenders(currentSelectedGenders)
 
                   when {
                     ageFrom != null && ageTo != null && !ageRangeError -> {

--- a/app/src/test/java/com/github/se/icebreakrr/model/filter/FilterViewModelTest.kt
+++ b/app/src/test/java/com/github/se/icebreakrr/model/filter/FilterViewModelTest.kt
@@ -1,0 +1,85 @@
+package com.github.se.icebreakrr.model.filter
+
+import com.github.se.icebreakrr.model.profile.Gender
+import org.junit.Assert.assertEquals
+import org.junit.Before
+import org.junit.Test
+
+// This file was written with the help of CursorAI
+class FilterViewModelTest {
+  private lateinit var viewModel: FilterViewModel
+
+  @Before
+  fun setUp() {
+    viewModel = FilterViewModel()
+  }
+
+  @Test
+  fun testInitialState() {
+    // Check that all initial states are empty/null
+    assertEquals(emptyList<Gender>(), viewModel.selectedGenders.value)
+    assertEquals(null, viewModel.ageRange.value)
+    assertEquals(emptyList<String>(), viewModel.filteredTags.value)
+  }
+
+  @Test
+  fun testSetGenders() {
+    // Test setting single gender
+    val singleGender = listOf(Gender.MEN)
+    viewModel.setGenders(singleGender)
+    assertEquals(singleGender, viewModel.selectedGenders.value)
+
+    // Test setting multiple genders
+    val multipleGenders = listOf(Gender.MEN, Gender.WOMEN)
+    viewModel.setGenders(multipleGenders)
+    assertEquals(multipleGenders, viewModel.selectedGenders.value)
+
+    // Test setting empty list
+    viewModel.setGenders(emptyList())
+    assertEquals(emptyList<Gender>(), viewModel.selectedGenders.value)
+
+    // Test setting all genders
+    val allGenders = listOf(Gender.MEN, Gender.WOMEN, Gender.OTHER)
+    viewModel.setGenders(allGenders)
+    assertEquals(allGenders, viewModel.selectedGenders.value)
+  }
+
+  @Test
+  fun testSetAgeRange() {
+    // Test setting valid age range
+    val validRange = 18..30
+    viewModel.setAgeRange(validRange)
+    assertEquals(validRange, viewModel.ageRange.value)
+
+    // Test setting single age range
+    val singleAge = 25..25
+    viewModel.setAgeRange(singleAge)
+    assertEquals(singleAge, viewModel.ageRange.value)
+
+    // Test setting null age range
+    viewModel.setAgeRange(null)
+    assertEquals(null, viewModel.ageRange.value)
+
+    // Test setting wide age range
+    val wideRange = 18..99
+    viewModel.setAgeRange(wideRange)
+    assertEquals(wideRange, viewModel.ageRange.value)
+  }
+
+  @Test
+  fun testSetFilteredTags() {
+    // Test setting single tag
+    val singleTag = listOf("Sports")
+    viewModel.setFilteredTags(singleTag)
+    assertEquals(singleTag, viewModel.filteredTags.value)
+
+    // Test setting multiple tags
+    val multipleTags = listOf("Sports", "Music", "Art")
+    viewModel.setFilteredTags(multipleTags)
+    assertEquals(multipleTags, viewModel.filteredTags.value)
+
+    // Test setting empty tags list
+    viewModel.setFilteredTags(emptyList())
+    assertEquals(emptyList<String>(), viewModel.filteredTags.value)
+  }
+}


### PR DESCRIPTION
Connect Filter UI with Backend Logic

Overview
This PR implements the backend logic for the existing filter UI, by linking the backends and saving user input

Changes
- Added `FilterViewModel` to save user inputs (gender, age range, tags)
- Connected the filter UI to the view model
- The around you page profiles are correctly filtered with the filter page filters

Testing
Added unit tests covering the view model
