### PR TITLE
Feature/upload pp

### DIFF
--- a/app/src/main/java/com/github/se/icebreakrr/model/profile/ProfilesViewModel.kt
+++ b/app/src/main/java/com/github/se/icebreakrr/model/profile/ProfilesViewModel.kt
@@ -203,23 +203,32 @@ open class ProfilesViewModel(
   }
 
     fun imageUriToJpgByteArray(context: Context, imageUri: Uri, quality: Int = 100): ByteArray? {
-        return try {
-            // open an InputStream from the URI
-            val inputStream: InputStream? = context.contentResolver.openInputStream(imageUri)
+    return try {
+        // open an InputStream from the URI
+        val inputStream: InputStream? = context.contentResolver.openInputStream(imageUri)
 
-            // decode InputStream to Bitmap
-            val bitmap = BitmapFactory.decodeStream(inputStream)
-            inputStream?.close() // close the InputStream after decoding
+        // decode InputStream to Bitmap
+        val bitmap = BitmapFactory.decodeStream(inputStream)
+        inputStream?.close() // close the InputStream after decoding
 
-            //compress Bitmap to JPEG format and store in ByteArrayOutputStream
-            val byteArrayOutputStream = ByteArrayOutputStream()
-            bitmap?.compress(Bitmap.CompressFormat.JPEG, quality, byteArrayOutputStream)
+        // todo: delegate image cropping to another function
+        // calculate the dimensions for the square crop
+        val dimension = minOf(bitmap.width, bitmap.height)
+        val xOffset = (bitmap.width - dimension) / 2
+        val yOffset = (bitmap.height - dimension) / 2
 
-            // return ByteArray of compressed JPEG image (representing .jpg)
-            byteArrayOutputStream.toByteArray()
-        } catch (e: Exception) {
-            e.printStackTrace()
-            null
-        }
+        // crop the Bitmap to a square at the center
+        val croppedBitmap = Bitmap.createBitmap(bitmap, xOffset, yOffset, dimension, dimension)
+
+        // compress Bitmap to JPEG format and store in ByteArrayOutputStream
+        val byteArrayOutputStream = ByteArrayOutputStream()
+        croppedBitmap.compress(Bitmap.CompressFormat.JPEG, quality, byteArrayOutputStream)
+
+        // return ByteArray of compressed JPEG image (representing .jpg)
+        byteArrayOutputStream.toByteArray()
+    } catch (e: Exception) {
+        e.printStackTrace()
+        null
     }
+}
 }

--- a/app/src/main/java/com/github/se/icebreakrr/model/profile/ProfilesViewModel.kt
+++ b/app/src/main/java/com/github/se/icebreakrr/model/profile/ProfilesViewModel.kt
@@ -4,8 +4,8 @@ import android.content.Context
 import android.graphics.Bitmap
 import android.graphics.BitmapFactory
 import android.net.Uri
-import android.widget.Toast
 import android.util.Log
+import android.widget.Toast
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.ViewModelProvider
 import com.google.firebase.Firebase

--- a/app/src/main/java/com/github/se/icebreakrr/model/profile/ProfilesViewModel.kt
+++ b/app/src/main/java/com/github/se/icebreakrr/model/profile/ProfilesViewModel.kt
@@ -159,21 +159,22 @@ open class ProfilesViewModel(
         userId = uid, onSuccess = {}, onFailure = { e -> handleError(e) })
   }
 
-/**
- * Uploads the current user's profile picture to the remote storage system.
- *
- * @param imageData The byte array representing the image data to be uploaded.
- * @param onSuccess A callback function that is invoked with the URL of the uploaded image upon successful upload.
- * @throws IllegalStateException if the user is not logged in.
- */
-fun uploadCurrentUserProfilePicture(imageData: ByteArray, onSuccess: (url: String?) -> Unit) {
-  val userId = selectedProfile.value?.uid ?: throw IllegalStateException("User not logged in")
-  ppRepository.uploadProfilePicture(
-      userId = userId,
-      imageData = imageData,
-      onSuccess = { url -> onSuccess(url) },
-      onFailure = { e -> handleError(e) })
-}
+  /**
+   * Uploads the current user's profile picture to the remote storage system.
+   *
+   * @param imageData The byte array representing the image data to be uploaded.
+   * @param onSuccess A callback function that is invoked with the URL of the uploaded image upon
+   *   successful upload.
+   * @throws IllegalStateException if the user is not logged in.
+   */
+  fun uploadCurrentUserProfilePicture(imageData: ByteArray, onSuccess: (url: String?) -> Unit) {
+    val userId = selectedProfile.value?.uid ?: throw IllegalStateException("User not logged in")
+    ppRepository.uploadProfilePicture(
+        userId = userId,
+        imageData = imageData,
+        onSuccess = { url -> onSuccess(url) },
+        onFailure = { e -> handleError(e) })
+  }
 
   /**
    * Deletes the current user's profile picture from the remote storage system.

--- a/app/src/main/java/com/github/se/icebreakrr/model/profile/ProfilesViewModel.kt
+++ b/app/src/main/java/com/github/se/icebreakrr/model/profile/ProfilesViewModel.kt
@@ -223,8 +223,10 @@ open class ProfilesViewModel(
   private fun imageUriToJpgByteArray(
       context: Context,
       imageUri: Uri,
-      quality: Int = 100
+      quality: Int = 100,
+      maxResolution: Int = 600
   ): ByteArray? {
+
     return try {
       // Open an InputStream from the URI
       val inputStream: InputStream? = context.contentResolver.openInputStream(imageUri)
@@ -241,9 +243,21 @@ open class ProfilesViewModel(
       // Crop the Bitmap to a square at the center
       val croppedBitmap = Bitmap.createBitmap(bitmap, xOffset, yOffset, dimension, dimension)
 
+      // Resize the cropped bitmap if it exceeds the maximum resolution
+      val resizedBitmap =
+          if (dimension > maxResolution) {
+            val scale = maxResolution.toFloat() / dimension
+            Bitmap.createScaledBitmap(
+                croppedBitmap,
+                (croppedBitmap.width * scale).toInt(),
+                (croppedBitmap.height * scale).toInt(),
+                true)
+          } else {
+            croppedBitmap
+          }
       // Compress Bitmap to JPEG format and store in ByteArrayOutputStream
       val byteArrayOutputStream = ByteArrayOutputStream()
-      croppedBitmap.compress(Bitmap.CompressFormat.JPEG, quality, byteArrayOutputStream)
+      resizedBitmap.compress(Bitmap.CompressFormat.JPEG, quality, byteArrayOutputStream)
 
       // Return ByteArray of compressed JPEG image (representing .jpg)
       byteArrayOutputStream.toByteArray()

--- a/app/src/main/java/com/github/se/icebreakrr/model/profile/ProfilesViewModel.kt
+++ b/app/src/main/java/com/github/se/icebreakrr/model/profile/ProfilesViewModel.kt
@@ -180,21 +180,21 @@ open class ProfilesViewModel(
         onFailure = { e -> handleError(e) })
   }
 
-/**
- * Processes an image from a given URI into the required format (square JPEG) and uploads it as the
- * current user's profile picture.
- *
- * @param context The context used to access the content resolver and show a toast message.
- * @param imageUri The URI of the image to be processed and uploaded.
- */
-fun processAndUploadImage(context: Context, imageUri: Uri) {
+  /**
+   * Processes an image from a given URI into the required format (square JPEG) and uploads it as
+   * the current user's profile picture.
+   *
+   * @param context The context used to access the content resolver and show a toast message.
+   * @param imageUri The URI of the image to be processed and uploaded.
+   */
+  fun processAndUploadImage(context: Context, imageUri: Uri) {
     val image: ByteArray? = imageUriToJpgByteArray(context, imageUri)
     if (image != null) {
-        uploadCurrentUserProfilePicture(image)
+      uploadCurrentUserProfilePicture(image)
     } else {
-        Toast.makeText(context, "Failed to process image", Toast.LENGTH_SHORT).show()
+      Toast.makeText(context, "Failed to process image", Toast.LENGTH_SHORT).show()
     }
-}
+  }
 
   /**
    * Deletes the current user's profile picture from the remote storage system.
@@ -220,7 +220,11 @@ fun processAndUploadImage(context: Context, imageUri: Uri) {
    * @param quality The quality of the JPEG compression (0-100). Default is 100.
    * @return A byte array representing the JPEG image, or null if an error occurs.
    */
-  private fun imageUriToJpgByteArray(context: Context, imageUri: Uri, quality: Int = 100): ByteArray? {
+  private fun imageUriToJpgByteArray(
+      context: Context,
+      imageUri: Uri,
+      quality: Int = 100
+  ): ByteArray? {
     return try {
       // Open an InputStream from the URI
       val inputStream: InputStream? = context.contentResolver.openInputStream(imageUri)

--- a/app/src/main/java/com/github/se/icebreakrr/model/profile/ProfilesViewModel.kt
+++ b/app/src/main/java/com/github/se/icebreakrr/model/profile/ProfilesViewModel.kt
@@ -162,17 +162,20 @@ open class ProfilesViewModel(
   /**
    * Uploads the current user's profile picture to the remote storage system.
    *
-   * @param imageData The byte array representing the image data to be uploaded.
-   * @param onSuccess A callback function that is invoked with the URL of the uploaded image upon
-   *   successful upload.
+   * @param imageData The byte array of the image file to be uploaded.
    * @throws IllegalStateException if the user is not logged in.
    */
-  fun uploadCurrentUserProfilePicture(imageData: ByteArray, onSuccess: (url: String?) -> Unit) {
+  fun uploadCurrentUserProfilePicture(imageData: ByteArray) {
     val userId = selectedProfile.value?.uid ?: throw IllegalStateException("User not logged in")
     ppRepository.uploadProfilePicture(
         userId = userId,
         imageData = imageData,
-        onSuccess = { url -> onSuccess(url) },
+        onSuccess = { url ->
+          // _selectedProfile cannot be null here, as it must be set to current user before calling
+          // this function
+          _selectedProfile.update { selected -> selected!!.copy(profilePictureUrl = url) }
+          updateProfile(selectedProfile.value!!)
+        },
         onFailure = { e -> handleError(e) })
   }
 

--- a/app/src/main/java/com/github/se/icebreakrr/model/profile/ProfilesViewModel.kt
+++ b/app/src/main/java/com/github/se/icebreakrr/model/profile/ProfilesViewModel.kt
@@ -165,13 +165,13 @@ open class ProfilesViewModel(
    * @param imageData The byte array of the image file to be uploaded.
    * @throws IllegalStateException if the user is not logged in.
    */
-  fun uploadCurrentUserProfilePicture(imageData: ByteArray) {
+  fun uploadCurrentUserProfilePicture(imageData: ByteArray, onSuccess: (url: String?) -> Unit) {
     val userId = selectedProfile.value?.uid ?: throw IllegalStateException("User not logged in")
     ppRepository.uploadProfilePicture(
         userId = userId,
         imageData = imageData,
         onSuccess = { url ->
-          _selectedProfile.update { selected -> selected?.copy(profilePictureUrl = url) }
+          onSuccess(url)
         },
         onFailure = { e -> handleError(e) })
   }

--- a/app/src/main/java/com/github/se/icebreakrr/model/profile/ProfilesViewModel.kt
+++ b/app/src/main/java/com/github/se/icebreakrr/model/profile/ProfilesViewModel.kt
@@ -4,6 +4,7 @@ import android.content.Context
 import android.graphics.Bitmap
 import android.graphics.BitmapFactory
 import android.net.Uri
+import android.widget.Toast
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.ViewModelProvider
 import com.google.firebase.Firebase
@@ -179,6 +180,22 @@ open class ProfilesViewModel(
         onFailure = { e -> handleError(e) })
   }
 
+/**
+ * Processes an image from a given URI into the required format (square JPEG) and uploads it as the
+ * current user's profile picture.
+ *
+ * @param context The context used to access the content resolver and show a toast message.
+ * @param imageUri The URI of the image to be processed and uploaded.
+ */
+fun processAndUploadImage(context: Context, imageUri: Uri) {
+    val image: ByteArray? = imageUriToJpgByteArray(context, imageUri)
+    if (image != null) {
+        uploadCurrentUserProfilePicture(image)
+    } else {
+        Toast.makeText(context, "Failed to process image", Toast.LENGTH_SHORT).show()
+    }
+}
+
   /**
    * Deletes the current user's profile picture from the remote storage system.
    *
@@ -203,7 +220,7 @@ open class ProfilesViewModel(
    * @param quality The quality of the JPEG compression (0-100). Default is 100.
    * @return A byte array representing the JPEG image, or null if an error occurs.
    */
-  fun imageUriToJpgByteArray(context: Context, imageUri: Uri, quality: Int = 100): ByteArray? {
+  private fun imageUriToJpgByteArray(context: Context, imageUri: Uri, quality: Int = 100): ByteArray? {
     return try {
       // Open an InputStream from the URI
       val inputStream: InputStream? = context.contentResolver.openInputStream(imageUri)

--- a/app/src/main/java/com/github/se/icebreakrr/model/profile/ProfilesViewModel.kt
+++ b/app/src/main/java/com/github/se/icebreakrr/model/profile/ProfilesViewModel.kt
@@ -1,5 +1,9 @@
 package com.github.se.icebreakrr.model.profile
 
+import android.content.Context
+import android.graphics.Bitmap
+import android.graphics.BitmapFactory
+import android.net.Uri
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.ViewModelProvider
 import com.google.firebase.Firebase
@@ -9,6 +13,8 @@ import com.google.firebase.storage.storage
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.update
+import java.io.ByteArrayOutputStream
+import java.io.InputStream
 
 open class ProfilesViewModel(
     private val repository: ProfilesRepository,
@@ -195,4 +201,25 @@ open class ProfilesViewModel(
     _error.value = exception
     _loading.value = false
   }
+
+    fun imageUriToJpgByteArray(context: Context, imageUri: Uri, quality: Int = 100): ByteArray? {
+        return try {
+            // open an InputStream from the URI
+            val inputStream: InputStream? = context.contentResolver.openInputStream(imageUri)
+
+            // decode InputStream to Bitmap
+            val bitmap = BitmapFactory.decodeStream(inputStream)
+            inputStream?.close() // close the InputStream after decoding
+
+            //compress Bitmap to JPEG format and store in ByteArrayOutputStream
+            val byteArrayOutputStream = ByteArrayOutputStream()
+            bitmap?.compress(Bitmap.CompressFormat.JPEG, quality, byteArrayOutputStream)
+
+            // return ByteArray of compressed JPEG image (representing .jpg)
+            byteArrayOutputStream.toByteArray()
+        } catch (e: Exception) {
+            e.printStackTrace()
+            null
+        }
+    }
 }

--- a/app/src/main/java/com/github/se/icebreakrr/model/profile/ProfilesViewModel.kt
+++ b/app/src/main/java/com/github/se/icebreakrr/model/profile/ProfilesViewModel.kt
@@ -10,11 +10,11 @@ import com.google.firebase.Firebase
 import com.google.firebase.firestore.GeoPoint
 import com.google.firebase.firestore.firestore
 import com.google.firebase.storage.storage
+import java.io.ByteArrayOutputStream
+import java.io.InputStream
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.update
-import java.io.ByteArrayOutputStream
-import java.io.InputStream
 
 open class ProfilesViewModel(
     private val repository: ProfilesRepository,
@@ -170,9 +170,7 @@ open class ProfilesViewModel(
     ppRepository.uploadProfilePicture(
         userId = userId,
         imageData = imageData,
-        onSuccess = { url ->
-          onSuccess(url)
-        },
+        onSuccess = { url -> onSuccess(url) },
         onFailure = { e -> handleError(e) })
   }
 
@@ -202,33 +200,33 @@ open class ProfilesViewModel(
     _loading.value = false
   }
 
-    fun imageUriToJpgByteArray(context: Context, imageUri: Uri, quality: Int = 100): ByteArray? {
+  fun imageUriToJpgByteArray(context: Context, imageUri: Uri, quality: Int = 100): ByteArray? {
     return try {
-        // open an InputStream from the URI
-        val inputStream: InputStream? = context.contentResolver.openInputStream(imageUri)
+      // open an InputStream from the URI
+      val inputStream: InputStream? = context.contentResolver.openInputStream(imageUri)
 
-        // decode InputStream to Bitmap
-        val bitmap = BitmapFactory.decodeStream(inputStream)
-        inputStream?.close() // close the InputStream after decoding
+      // decode InputStream to Bitmap
+      val bitmap = BitmapFactory.decodeStream(inputStream)
+      inputStream?.close() // close the InputStream after decoding
 
-        // todo: delegate image cropping to another function
-        // calculate the dimensions for the square crop
-        val dimension = minOf(bitmap.width, bitmap.height)
-        val xOffset = (bitmap.width - dimension) / 2
-        val yOffset = (bitmap.height - dimension) / 2
+      // todo: delegate image cropping to another function
+      // calculate the dimensions for the square crop
+      val dimension = minOf(bitmap.width, bitmap.height)
+      val xOffset = (bitmap.width - dimension) / 2
+      val yOffset = (bitmap.height - dimension) / 2
 
-        // crop the Bitmap to a square at the center
-        val croppedBitmap = Bitmap.createBitmap(bitmap, xOffset, yOffset, dimension, dimension)
+      // crop the Bitmap to a square at the center
+      val croppedBitmap = Bitmap.createBitmap(bitmap, xOffset, yOffset, dimension, dimension)
 
-        // compress Bitmap to JPEG format and store in ByteArrayOutputStream
-        val byteArrayOutputStream = ByteArrayOutputStream()
-        croppedBitmap.compress(Bitmap.CompressFormat.JPEG, quality, byteArrayOutputStream)
+      // compress Bitmap to JPEG format and store in ByteArrayOutputStream
+      val byteArrayOutputStream = ByteArrayOutputStream()
+      croppedBitmap.compress(Bitmap.CompressFormat.JPEG, quality, byteArrayOutputStream)
 
-        // return ByteArray of compressed JPEG image (representing .jpg)
-        byteArrayOutputStream.toByteArray()
+      // return ByteArray of compressed JPEG image (representing .jpg)
+      byteArrayOutputStream.toByteArray()
     } catch (e: Exception) {
-        e.printStackTrace()
-        null
+      e.printStackTrace()
+      null
     }
-}
+  }
 }

--- a/app/src/main/java/com/github/se/icebreakrr/ui/profile/ProfileEdit.kt
+++ b/app/src/main/java/com/github/se/icebreakrr/ui/profile/ProfileEdit.kt
@@ -152,7 +152,9 @@ fun ProfileEditingScreen(
                 ProfilePictureSelector(
                     url = profilePictureUrl,
                     size = profilePictureSize,
-                    onSelectionSuccess = { uri -> profilesViewModel.processAndUploadImage(context, uri)},
+                    onSelectionSuccess = { uri ->
+                      profilesViewModel.processAndUploadImage(context, uri)
+                    },
                     onSelectionFailure = {
                       Toast.makeText(context, "Failed to select image", Toast.LENGTH_SHORT).show()
                     })

--- a/app/src/main/java/com/github/se/icebreakrr/ui/profile/ProfileEdit.kt
+++ b/app/src/main/java/com/github/se/icebreakrr/ui/profile/ProfileEdit.kt
@@ -162,14 +162,12 @@ fun ProfileEditingScreen(
                               isModified = true
                             })
                       } else {
-                        Toast.makeText(context, "Failed to select image", Toast.LENGTH_SHORT)
-                            .show() // todo: change later
+                        Toast.makeText(context, "Failed to select image", Toast.LENGTH_SHORT).show()
                       }
                     },
                     onSelectionFailure = {
                       Toast.makeText(context, "Failed to select image", Toast.LENGTH_SHORT).show()
-                    } // todo: change later
-                    )
+                    })
 
                 Spacer(modifier = Modifier.height(padding))
 

--- a/app/src/main/java/com/github/se/icebreakrr/ui/profile/ProfileEdit.kt
+++ b/app/src/main/java/com/github/se/icebreakrr/ui/profile/ProfileEdit.kt
@@ -224,7 +224,7 @@ fun ProfileEditingScreen(
                 Spacer(modifier = Modifier.height(padding))
 
                 UnsavedChangesDialog(
-                    showDialog = showDialog && isMofidied,
+                    showDialog = showDialog && isModified,
                     onDismiss = { showDialog = false },
                     onConfirm = {
                       showDialog = false

--- a/app/src/main/java/com/github/se/icebreakrr/ui/profile/ProfileEdit.kt
+++ b/app/src/main/java/com/github/se/icebreakrr/ui/profile/ProfileEdit.kt
@@ -76,6 +76,7 @@ fun ProfileEditingScreen(
 
   val isLoading = profilesViewModel.loading.collectAsState(initial = true).value
   val user = profilesViewModel.selectedProfile.collectAsState().value
+  val tempBitmap = profilesViewModel.tempProfilePictureBitmap.collectAsState().value
 
   LaunchedEffect(user?.tags) { user?.tags?.forEach { tag -> tagsViewModel.addFilter(tag) } }
 
@@ -129,6 +130,7 @@ fun ProfileEditingScreen(
                     modifier = Modifier.testTag("checkButton"),
                     onClick = {
                       updateProfile()
+                      profilesViewModel.validateAndUploadProfilePicture(context)
                       tagsViewModel.leaveUI()
                       navigationActions.goBack()
                     }) {
@@ -142,9 +144,11 @@ fun ProfileEditingScreen(
                 // A composable that allows the user to preview and edit a profile picture
                 ProfilePictureSelector(
                     url = user.profilePictureUrl,
+                    localBitmap = tempBitmap,
                     size = profilePictureSize,
                     onSelectionSuccess = { uri ->
-                      profilesViewModel.processAndUploadImage(context, uri)
+                      profilesViewModel.generateTempProfilePictureBitmap(context, uri)
+                      isModified = true
                     },
                     onSelectionFailure = {
                       Toast.makeText(context, "Failed to select image", Toast.LENGTH_SHORT).show()
@@ -231,7 +235,7 @@ fun ProfileEditingScreen(
                             onClick = {
                               showDialog = false
                               tagsViewModel.leaveUI()
-                              profilesViewModel.deleteCurrentUserProfilePicture()
+                              profilesViewModel.clearTempProfilePictureBitmap()
                               navigationActions.goBack()
                             }) {
                               Text("Discard changes")

--- a/app/src/main/java/com/github/se/icebreakrr/ui/profile/ProfileEdit.kt
+++ b/app/src/main/java/com/github/se/icebreakrr/ui/profile/ProfileEdit.kt
@@ -148,13 +148,12 @@ fun ProfileEditingScreen(
           Column(
               modifier = Modifier.padding(it).padding(padding).testTag("profileEditScreenContent"),
               horizontalAlignment = Alignment.CenterHorizontally) {
+                // A composable that allows the user to preview and edit a profile picture
                 ProfilePictureSelector(
                     url = profilePictureUrl,
                     size = profilePictureSize,
                     onSelectionSuccess = { uri ->
-                      val image: ByteArray? =
-                          profilesViewModel.imageUriToJpgByteArray(
-                              context, uri, quality = 100) // todo: check last one
+                      val image: ByteArray? = profilesViewModel.imageUriToJpgByteArray(context, uri)
                       if (image != null) {
                         profilesViewModel.uploadCurrentUserProfilePicture(
                             imageData = image,

--- a/app/src/main/java/com/github/se/icebreakrr/ui/profile/ProfileEdit.kt
+++ b/app/src/main/java/com/github/se/icebreakrr/ui/profile/ProfileEdit.kt
@@ -162,7 +162,6 @@ fun ProfileEditingScreen(
                               profilePictureUrl = url
                               isModified = true
                             })
-                        profilePictureUrl = uri.toString()
                       } else {
                         Toast.makeText(context, "Failed to select image", Toast.LENGTH_SHORT)
                             .show() // todo: change later

--- a/app/src/main/java/com/github/se/icebreakrr/ui/profile/ProfileEdit.kt
+++ b/app/src/main/java/com/github/se/icebreakrr/ui/profile/ProfileEdit.kt
@@ -42,7 +42,6 @@ import androidx.compose.ui.text.input.TextFieldValue
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
-import com.github.se.icebreakrr.model.profile.Profile
 import com.github.se.icebreakrr.model.profile.ProfilesViewModel
 import com.github.se.icebreakrr.model.tags.TagsViewModel
 import com.github.se.icebreakrr.ui.navigation.NavigationActions
@@ -80,7 +79,6 @@ fun ProfileEditingScreen(
 
   LaunchedEffect(user?.tags) { user?.tags?.forEach { tag -> tagsViewModel.addFilter(tag) } }
 
-  var profilePictureUrl by remember { mutableStateOf(user!!.profilePictureUrl) }
   var catchphrase by remember { mutableStateOf(TextFieldValue(user!!.catchPhrase)) }
   var description by remember { mutableStateOf(TextFieldValue(user!!.description)) }
   val expanded = remember { mutableStateOf(false) }
@@ -94,15 +92,8 @@ fun ProfileEditingScreen(
 
   fun updateProfile() {
     profilesViewModel.updateProfile(
-        Profile(
-            uid = user!!.uid,
-            name = user.name,
-            gender = user.gender,
-            birthDate = user.birthDate,
-            catchPhrase = catchphrase.text,
-            description = description.text,
-            tags = selectedTags,
-            profilePictureUrl = profilePictureUrl))
+        user!!.copy(
+            catchPhrase = catchphrase.text, description = description.text, tags = selectedTags))
   }
 
   if (isLoading) {
@@ -150,7 +141,7 @@ fun ProfileEditingScreen(
               horizontalAlignment = Alignment.CenterHorizontally) {
                 // A composable that allows the user to preview and edit a profile picture
                 ProfilePictureSelector(
-                    url = profilePictureUrl,
+                    url = user.profilePictureUrl,
                     size = profilePictureSize,
                     onSelectionSuccess = { uri ->
                       profilesViewModel.processAndUploadImage(context, uri)

--- a/app/src/main/java/com/github/se/icebreakrr/ui/profile/ProfileEdit.kt
+++ b/app/src/main/java/com/github/se/icebreakrr/ui/profile/ProfileEdit.kt
@@ -148,7 +148,7 @@ fun ProfileEditingScreen(
           Column(
               modifier = Modifier.padding(it).padding(padding).testTag("profileEditScreenContent"),
               horizontalAlignment = Alignment.CenterHorizontally) {
-                ProfilePicture(
+                ProfilePictureSelector(
                     url = profilePictureUrl,
                     size = profilePictureSize,
                     onSelectionSuccess = { uri ->

--- a/app/src/main/java/com/github/se/icebreakrr/ui/profile/ProfileEdit.kt
+++ b/app/src/main/java/com/github/se/icebreakrr/ui/profile/ProfileEdit.kt
@@ -14,7 +14,6 @@ import androidx.compose.foundation.layout.wrapContentWidth
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.ArrowBack
 import androidx.compose.material.icons.filled.Check
-import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
@@ -22,7 +21,6 @@ import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
-import androidx.compose.material3.TextButton
 import androidx.compose.material3.TopAppBar
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
@@ -231,7 +229,7 @@ fun ProfileEditingScreen(
                     onConfirm = {
                       showDialog = false
                       tagsViewModel.leaveUI()
-                        profilesViewModel.clearTempProfilePictureBitmap()
+                      profilesViewModel.clearTempProfilePictureBitmap()
                       navigationActions.goBack()
                     })
               }

--- a/app/src/main/java/com/github/se/icebreakrr/ui/profile/ProfileEdit.kt
+++ b/app/src/main/java/com/github/se/icebreakrr/ui/profile/ProfileEdit.kt
@@ -59,7 +59,7 @@ fun ProfileEditingScreen(
     profilesViewModel: ProfilesViewModel
 ) {
 
-    val context = LocalContext.current
+  val context = LocalContext.current
   val configuration = LocalConfiguration.current
   val screenWidth = configuration.screenWidthDp.dp
   val screenHeight = configuration.screenHeightDp.dp
@@ -107,10 +107,7 @@ fun ProfileEditingScreen(
 
   if (isLoading) {
     Box(
-        modifier = Modifier
-            .fillMaxSize()
-            .background(Color.LightGray)
-            .testTag("loadingBox"),
+        modifier = Modifier.fillMaxSize().background(Color.LightGray).testTag("loadingBox"),
         contentAlignment = Alignment.Center) {
           Text("Loading profile...", textAlign = TextAlign.Center)
         }
@@ -149,31 +146,32 @@ fun ProfileEditingScreen(
               })
         }) {
           Column(
-              modifier = Modifier
-                  .padding(it)
-                  .padding(padding)
-                  .testTag("profileEditScreenContent"),
+              modifier = Modifier.padding(it).padding(padding).testTag("profileEditScreenContent"),
               horizontalAlignment = Alignment.CenterHorizontally) {
-
-              ProfilePicture(
+                ProfilePicture(
                     url = profilePictureUrl,
                     size = profilePictureSize,
                     onSelectionSuccess = { uri ->
-                        val image: ByteArray? = profilesViewModel.imageUriToJpgByteArray(context, uri, quality = 100) //todo: check last one
-                        if (image != null) {
-                          profilesViewModel.uploadCurrentUserProfilePicture(
-                              imageData = image,
-                              onSuccess = { url ->
-                                  profilePictureUrl = url
-                                  isModified = true
-                              })
-                            profilePictureUrl = uri.toString()
-                        } else {
-                          Toast.makeText(context, "Failed to select image", Toast.LENGTH_SHORT).show() //todo: change later
-                        }
+                      val image: ByteArray? =
+                          profilesViewModel.imageUriToJpgByteArray(
+                              context, uri, quality = 100) // todo: check last one
+                      if (image != null) {
+                        profilesViewModel.uploadCurrentUserProfilePicture(
+                            imageData = image,
+                            onSuccess = { url ->
+                              profilePictureUrl = url
+                              isModified = true
+                            })
+                        profilePictureUrl = uri.toString()
+                      } else {
+                        Toast.makeText(context, "Failed to select image", Toast.LENGTH_SHORT)
+                            .show() // todo: change later
+                      }
                     },
-                    onSelectionFailure = {Toast.makeText(context, "Failed to select image", Toast.LENGTH_SHORT).show()} //todo: change later
-              )
+                    onSelectionFailure = {
+                      Toast.makeText(context, "Failed to select image", Toast.LENGTH_SHORT).show()
+                    } // todo: change later
+                    )
 
                 Spacer(modifier = Modifier.height(padding))
 
@@ -182,10 +180,9 @@ fun ProfileEditingScreen(
                     text = "${user.name}, ${user.calculateAge()}",
                     style = TextStyle(fontSize = textSize.value.sp),
                     modifier =
-                    Modifier
-                        .fillMaxWidth()
-                        .wrapContentWidth(Alignment.CenterHorizontally)
-                        .testTag("nameAndAge"))
+                        Modifier.fillMaxWidth()
+                            .wrapContentWidth(Alignment.CenterHorizontally)
+                            .testTag("nameAndAge"))
                 Spacer(modifier = Modifier.height(padding))
 
                 // Catchphrase Input
@@ -200,10 +197,7 @@ fun ProfileEditingScreen(
                     },
                     textStyle = TextStyle(fontSize = textSize.value.sp * 0.6),
                     modifier =
-                    Modifier
-                        .fillMaxWidth()
-                        .height(catchphraseHeight)
-                        .testTag("catchphrase"))
+                        Modifier.fillMaxWidth().height(catchphraseHeight).testTag("catchphrase"))
 
                 Spacer(modifier = Modifier.height(padding))
 
@@ -217,10 +211,7 @@ fun ProfileEditingScreen(
                     label = { Text("Description") },
                     textStyle = TextStyle(fontSize = textSize.value.sp * 0.6),
                     modifier =
-                    Modifier
-                        .fillMaxWidth()
-                        .height(descriptionHeight)
-                        .testTag("description"))
+                        Modifier.fillMaxWidth().height(descriptionHeight).testTag("description"))
                 Spacer(modifier = Modifier.height(padding))
 
                 TagSelector(
@@ -263,7 +254,7 @@ fun ProfileEditingScreen(
                             onClick = {
                               showDialog = false
                               tagsViewModel.leaveUI()
-                                profilesViewModel.deleteCurrentUserProfilePicture()
+                              profilesViewModel.deleteCurrentUserProfilePicture()
                               navigationActions.goBack()
                             }) {
                               Text("Discard changes")

--- a/app/src/main/java/com/github/se/icebreakrr/ui/profile/ProfileEdit.kt
+++ b/app/src/main/java/com/github/se/icebreakrr/ui/profile/ProfileEdit.kt
@@ -152,19 +152,7 @@ fun ProfileEditingScreen(
                 ProfilePictureSelector(
                     url = profilePictureUrl,
                     size = profilePictureSize,
-                    onSelectionSuccess = { uri ->
-                      val image: ByteArray? = profilesViewModel.imageUriToJpgByteArray(context, uri)
-                      if (image != null) {
-                        profilesViewModel.uploadCurrentUserProfilePicture(
-                            imageData = image,
-                            onSuccess = { url ->
-                              profilePictureUrl = url
-                              isModified = true
-                            })
-                      } else {
-                        Toast.makeText(context, "Failed to select image", Toast.LENGTH_SHORT).show()
-                      }
-                    },
+                    onSelectionSuccess = { uri -> profilesViewModel.processAndUploadImage(context, uri)},
                     onSelectionFailure = {
                       Toast.makeText(context, "Failed to select image", Toast.LENGTH_SHORT).show()
                     })

--- a/app/src/main/java/com/github/se/icebreakrr/ui/profile/ProfilePictureSelector.kt
+++ b/app/src/main/java/com/github/se/icebreakrr/ui/profile/ProfilePictureSelector.kt
@@ -1,5 +1,6 @@
 package com.github.se.icebreakrr.ui.profile
 
+import android.graphics.Bitmap
 import android.net.Uri
 import androidx.activity.compose.rememberLauncherForActivityResult
 import androidx.activity.result.PickVisualMediaRequest
@@ -39,6 +40,7 @@ import com.github.se.icebreakrr.ui.theme.IceBreakrrBlue
 @Composable
 fun ProfilePictureSelector(
     url: String?,
+    localBitmap: Bitmap?,
     size: Dp,
     onSelectionSuccess: (Uri) -> Unit,
     onSelectionFailure: () -> Unit
@@ -68,7 +70,7 @@ fun ProfilePictureSelector(
               .testTag("profilePicture")) {
         // Display the profile picture if the URL is not null
         AsyncImage(
-            model = url,
+            model = localBitmap ?: url, // Use the temporary bitmap if available
             contentDescription = "your profile picture",
             placeholder = painterResource(id = R.drawable.nopp),
             error = painterResource(id = R.drawable.nopp),

--- a/app/src/main/java/com/github/se/icebreakrr/ui/profile/ProfilePictureSelector.kt
+++ b/app/src/main/java/com/github/se/icebreakrr/ui/profile/ProfilePictureSelector.kt
@@ -30,16 +30,28 @@ import com.github.se.icebreakrr.ui.theme.IceBreakrrBlue
 @Preview(showBackground = true)
 @Composable
 fun ProfilePicturePreview() {
-  ProfilePicture(url = null, size = 100.dp, onSelectionSuccess = {}, onSelectionFailure = {})
+  ProfilePictureSelector(
+      url = null, size = 100.dp, onSelectionSuccess = {}, onSelectionFailure = {})
 }
 
+/**
+ * A composable function that displays a profile picture with an option to select a new image from
+ * gallery.
+ *
+ * @param url The URL of the profile picture to display. If null, a placeholder image is shown.
+ * @param size The size of the profile picture.
+ * @param onSelectionSuccess A callback function that is invoked when an image is successfully
+ *   selected.
+ * @param onSelectionFailure A callback function that is invoked when image selection fails.
+ */
 @Composable
-fun ProfilePicture(
+fun ProfilePictureSelector(
     url: String?,
     size: Dp,
     onSelectionSuccess: (Uri) -> Unit,
     onSelectionFailure: () -> Unit
 ) {
+  // Create an image picker launcher for selecting an image from the gallery
   val imagePicker =
       rememberLauncherForActivityResult(
           contract = ActivityResultContracts.PickVisualMedia(),
@@ -51,6 +63,7 @@ fun ProfilePicture(
             }
           })
 
+  // Create a Box composable to contain the profile picture and the add photo icon
   Box(
       modifier =
           Modifier.clickable(
@@ -61,13 +74,15 @@ fun ProfilePicture(
               .size(size)
               .background(MaterialTheme.colorScheme.background)
               .testTag("profilePicture")) {
+        // Display the profile picture if the URL is not null
         AsyncImage(
             model = url,
             contentDescription = "your profile picture",
-            placeholder = painterResource(id = R.drawable.nopp), // Default image during loading
-            error = painterResource(id = R.drawable.nopp), // Fallback image if URL fails
+            placeholder = painterResource(id = R.drawable.nopp),
+            error = painterResource(id = R.drawable.nopp),
             modifier = Modifier.size(size).clip(CircleShape))
 
+        // Display an edit icon to show that the user can change the profile picture
         Icon(
             Icons.Filled.Create,
             contentDescription = "Add a photo",

--- a/app/src/main/java/com/github/se/icebreakrr/ui/profile/ProfilePictureSelector.kt
+++ b/app/src/main/java/com/github/se/icebreakrr/ui/profile/ProfilePictureSelector.kt
@@ -30,11 +30,7 @@ import com.github.se.icebreakrr.ui.theme.IceBreakrrBlue
 @Preview(showBackground = true)
 @Composable
 fun ProfilePicturePreview() {
-    ProfilePicture(
-        url = null,
-        size = 100.dp,
-        onSelectionSuccess = {},
-        onSelectionFailure = {})
+  ProfilePicture(url = null, size = 100.dp, onSelectionSuccess = {}, onSelectionFailure = {})
 }
 
 @Composable
@@ -42,53 +38,46 @@ fun ProfilePicture(
     url: String?,
     size: Dp,
     onSelectionSuccess: (Uri) -> Unit,
-    onSelectionFailure: () -> Unit ) {
-    val imagePicker = rememberLauncherForActivityResult(
-        contract = ActivityResultContracts.PickVisualMedia(),
-        onResult = { uri ->
+    onSelectionFailure: () -> Unit
+) {
+  val imagePicker =
+      rememberLauncherForActivityResult(
+          contract = ActivityResultContracts.PickVisualMedia(),
+          onResult = { uri ->
             if (uri != null) {
-                onSelectionSuccess(uri)
+              onSelectionSuccess(uri)
             } else {
-                onSelectionFailure()
+              onSelectionFailure()
             }
-        }
-    )
+          })
 
-    Box(
-        modifier = Modifier
-            .clickable(onClick = {
-                imagePicker.launch(
-                    PickVisualMediaRequest(ActivityResultContracts.PickVisualMedia.ImageOnly)
-                )
-            })
-            .size(size)
-            .background(MaterialTheme.colorScheme.background)
-            .testTag("profilePicture")
-    ) {
+  Box(
+      modifier =
+          Modifier.clickable(
+                  onClick = {
+                    imagePicker.launch(
+                        PickVisualMediaRequest(ActivityResultContracts.PickVisualMedia.ImageOnly))
+                  })
+              .size(size)
+              .background(MaterialTheme.colorScheme.background)
+              .testTag("profilePicture")) {
         AsyncImage(
             model = url,
             contentDescription = "your profile picture",
             placeholder = painterResource(id = R.drawable.nopp), // Default image during loading
             error = painterResource(id = R.drawable.nopp), // Fallback image if URL fails
-            modifier = Modifier
-                .size(size)
-                .clip(CircleShape)
-        )
+            modifier = Modifier.size(size).clip(CircleShape))
 
         Icon(
             Icons.Filled.Create,
             contentDescription = "Add a photo",
             tint = MaterialTheme.colorScheme.onPrimary,
-            modifier = Modifier
-                .size(size / 3)
-                .clip(CircleShape)
-                .background(IceBreakrrBlue)
-                .padding(5.dp)
-                .align(Alignment.BottomEnd)
-                .testTag("addPhotoIcon")
-        )
-    }
+            modifier =
+                Modifier.size(size / 3)
+                    .clip(CircleShape)
+                    .background(IceBreakrrBlue)
+                    .padding(5.dp)
+                    .align(Alignment.BottomEnd)
+                    .testTag("addPhotoIcon"))
+      }
 }
-
-
-

--- a/app/src/main/java/com/github/se/icebreakrr/ui/profile/ProfilePictureSelector.kt
+++ b/app/src/main/java/com/github/se/icebreakrr/ui/profile/ProfilePictureSelector.kt
@@ -20,19 +20,11 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.res.painterResource
-import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import coil.compose.AsyncImage
 import com.github.se.icebreakrr.R
 import com.github.se.icebreakrr.ui.theme.IceBreakrrBlue
-
-@Preview(showBackground = true)
-@Composable
-fun ProfilePicturePreview() {
-  ProfilePictureSelector(
-      url = null, size = 100.dp, onSelectionSuccess = {}, onSelectionFailure = {})
-}
 
 /**
  * A composable function that displays a profile picture with an option to select a new image from

--- a/app/src/main/java/com/github/se/icebreakrr/ui/profile/ProfilePictureSelector.kt
+++ b/app/src/main/java/com/github/se/icebreakrr/ui/profile/ProfilePictureSelector.kt
@@ -1,0 +1,94 @@
+package com.github.se.icebreakrr.ui.profile
+
+import android.net.Uri
+import androidx.activity.compose.rememberLauncherForActivityResult
+import androidx.activity.result.PickVisualMediaRequest
+import androidx.activity.result.contract.ActivityResultContracts
+import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Create
+import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.dp
+import coil.compose.AsyncImage
+import com.github.se.icebreakrr.R
+import com.github.se.icebreakrr.ui.theme.IceBreakrrBlue
+
+@Preview(showBackground = true)
+@Composable
+fun ProfilePicturePreview() {
+    ProfilePicture(
+        url = null,
+        size = 100.dp,
+        onSelectionSuccess = {},
+        onSelectionFailure = {})
+}
+
+@Composable
+fun ProfilePicture(
+    url: String?,
+    size: Dp,
+    onSelectionSuccess: (Uri) -> Unit,
+    onSelectionFailure: () -> Unit ) {
+    val imagePicker = rememberLauncherForActivityResult(
+        contract = ActivityResultContracts.PickVisualMedia(),
+        onResult = { uri ->
+            if (uri != null) {
+                onSelectionSuccess(uri)
+            } else {
+                onSelectionFailure()
+            }
+        }
+    )
+
+    Box(
+        modifier = Modifier
+            .clickable(onClick = {
+                imagePicker.launch(
+                    PickVisualMediaRequest(ActivityResultContracts.PickVisualMedia.ImageOnly)
+                )
+            })
+            .size(size)
+            .background(MaterialTheme.colorScheme.background)
+            .testTag("profilePicture")
+    ) {
+        AsyncImage(
+            model = url,
+            contentDescription = "your profile picture",
+            placeholder = painterResource(id = R.drawable.nopp), // Default image during loading
+            error = painterResource(id = R.drawable.nopp), // Fallback image if URL fails
+            modifier = Modifier
+                .size(size)
+                .clip(CircleShape)
+        )
+
+        Icon(
+            Icons.Filled.Create,
+            contentDescription = "Add a photo",
+            tint = MaterialTheme.colorScheme.onPrimary,
+            modifier = Modifier
+                .size(size / 3)
+                .clip(CircleShape)
+                .background(IceBreakrrBlue)
+                .padding(5.dp)
+                .align(Alignment.BottomEnd)
+                .testTag("addPhotoIcon")
+        )
+    }
+}
+
+
+

--- a/app/src/main/java/com/github/se/icebreakrr/ui/sections/shared/ProfileCard.kt
+++ b/app/src/main/java/com/github/se/icebreakrr/ui/sections/shared/ProfileCard.kt
@@ -1,6 +1,5 @@
 package com.github.se.icebreakrr.ui.sections.shared
 
-import androidx.compose.foundation.Canvas
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
@@ -9,18 +8,23 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.heightIn
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.Card
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
+import coil.compose.AsyncImage
+import com.github.se.icebreakrr.R
 import com.github.se.icebreakrr.mock.getMockedProfiles
 import com.github.se.icebreakrr.model.profile.Profile
 
@@ -40,11 +44,13 @@ fun ProfileCard(
         horizontalArrangement = Arrangement.spacedBy(18.dp),
         verticalAlignment = Alignment.CenterVertically,
         modifier = Modifier.fillMaxWidth().padding(horizontal = 10.dp, vertical = 6.dp)) {
-
-          // todo: replace this with the actual image
-          Canvas(modifier = Modifier.size(80.dp)) {
-            drawCircle(color = Color.Gray, radius = 40.dp.toPx())
-          }
+          AsyncImage(
+              model = profile.profilePictureUrl,
+              contentDescription = "profile picture",
+              modifier = Modifier.size(80.dp).clip(CircleShape),
+              placeholder = painterResource(id = R.drawable.nopp), // Default image during loading
+              error = painterResource(id = R.drawable.nopp), // Fallback image if URL fails
+          )
 
           Column(
               verticalArrangement = Arrangement.Center,

--- a/app/src/main/java/com/github/se/icebreakrr/ui/sections/shared/ProfileCard.kt
+++ b/app/src/main/java/com/github/se/icebreakrr/ui/sections/shared/ProfileCard.kt
@@ -20,12 +20,10 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.text.font.FontWeight
-import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import coil.compose.AsyncImage
 import com.github.se.icebreakrr.R
-import com.github.se.icebreakrr.mock.getMockedProfiles
 import com.github.se.icebreakrr.model.profile.Profile
 
 @Composable
@@ -77,10 +75,4 @@ fun ProfileCard(
           }
         }
   }
-}
-
-@Preview(showBackground = true)
-@Composable
-fun ProfileCardPreview() {
-  ProfileCard(Profile.getMockedProfiles()[0], onclick = { TODO() })
 }

--- a/app/src/test/java/com/github/se/icebreakrr/model/profile/ProfilesViewModelTest.kt
+++ b/app/src/test/java/com/github/se/icebreakrr/model/profile/ProfilesViewModelTest.kt
@@ -76,7 +76,7 @@ class ProfilesViewModelTest {
     ppRepository = mock(ProfilePicRepository::class.java)
     profilesViewModel = ProfilesViewModel(profilesRepository, ppRepository)
     mockProfileViewModel = mock(ProfilesViewModel::class.java)
-    
+
     // Initialize static mocks
     bitmapFactoryMock = mockStatic(BitmapFactory::class.java)
     bitmapMock = mockStatic(Bitmap::class.java)
@@ -357,7 +357,8 @@ class ProfilesViewModelTest {
     bitmapFactoryMock.`when`<Bitmap> { BitmapFactory.decodeStream(any()) }.thenReturn(mockBitmap)
 
     // Mock Bitmap.createBitmap to return the same mock bitmap
-    bitmapMock.`when`<Bitmap> { Bitmap.createBitmap(any<Bitmap>(), any(), any(), any(), any()) }
+    bitmapMock
+        .`when`<Bitmap> { Bitmap.createBitmap(any<Bitmap>(), any(), any(), any(), any()) }
         .thenReturn(mockBitmap)
 
     profilesViewModel.generateTempProfilePictureBitmap(context, uri)
@@ -386,12 +387,14 @@ class ProfilesViewModelTest {
     bitmapFactoryMock.`when`<Bitmap> { BitmapFactory.decodeStream(any()) }.thenReturn(mockBitmap)
 
     // Mock Bitmap.createBitmap to return the same mock bitmap
-    bitmapMock.`when`<Bitmap> { Bitmap.createBitmap(any<Bitmap>(), any(), any(), any(), any()) }
+    bitmapMock
+        .`when`<Bitmap> { Bitmap.createBitmap(any<Bitmap>(), any(), any(), any(), any()) }
         .thenReturn(mockBitmap)
 
     // Mock Bitmap.createScaledBitmap to return a scaled bitmap
     val scaledBitmap = mock(Bitmap::class.java)
-    bitmapMock.`when`<Bitmap> { Bitmap.createScaledBitmap(any(), eq(600), eq(600), eq(true)) }
+    bitmapMock
+        .`when`<Bitmap> { Bitmap.createScaledBitmap(any(), eq(600), eq(600), eq(true)) }
         .thenReturn(scaledBitmap)
 
     profilesViewModel.generateTempProfilePictureBitmap(context, uri)

--- a/app/src/test/java/com/github/se/icebreakrr/model/profile/ProfilesViewModelTest.kt
+++ b/app/src/test/java/com/github/se/icebreakrr/model/profile/ProfilesViewModelTest.kt
@@ -10,7 +10,6 @@ import com.google.firebase.firestore.GeoPoint
 import java.io.ByteArrayInputStream
 import java.io.ByteArrayOutputStream
 import java.util.Calendar
-import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -24,7 +23,6 @@ import kotlinx.coroutines.test.setMain
 import org.hamcrest.CoreMatchers.`is`
 import org.hamcrest.CoreMatchers.nullValue
 import org.hamcrest.MatcherAssert.assertThat
-import org.junit.After
 import org.junit.After
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertThrows
@@ -91,10 +89,10 @@ class ProfilesViewModelTest {
     ppRepository = mock(ProfilePicRepository::class.java)
     profilesViewModel = ProfilesViewModel(profilesRepository, ppRepository)
     Dispatchers.setMain(testDispatcher) // Set main dispatcher first
-      mockProfileViewModel = mock(ProfilesViewModel::class.java)
+    mockProfileViewModel = mock(ProfilesViewModel::class.java)
 
-      bitmapFactoryMock = mockStatic(BitmapFactory::class.java)
-      bitmapMock = mockStatic(Bitmap::class.java)
+    bitmapFactoryMock = mockStatic(BitmapFactory::class.java)
+    bitmapMock = mockStatic(Bitmap::class.java)
 
     whenever(profilesRepository.isWaiting).thenReturn(MutableStateFlow(false))
     whenever(profilesRepository.waitingDone).thenReturn(MutableStateFlow(false))
@@ -104,8 +102,8 @@ class ProfilesViewModelTest {
   @After
   fun tearDown() {
     Dispatchers.resetMain()
-      bitmapFactoryMock.close()
-      bitmapMock.close()
+    bitmapFactoryMock.close()
+    bitmapMock.close()
   }
 
   @Test

--- a/app/src/test/java/com/github/se/icebreakrr/model/profile/ProfilesViewModelTest.kt
+++ b/app/src/test/java/com/github/se/icebreakrr/model/profile/ProfilesViewModelTest.kt
@@ -1,25 +1,39 @@
 package com.github.se.icebreakrr.model.profile
 
+import android.content.ContentResolver
+import android.content.Context
+import android.graphics.Bitmap
+import android.graphics.BitmapFactory
+import android.net.Uri
 import com.google.firebase.Timestamp
 import com.google.firebase.firestore.GeoPoint
+import java.io.ByteArrayInputStream
+import java.io.ByteArrayOutputStream
 import java.util.Calendar
+import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.runBlocking
 import org.hamcrest.CoreMatchers.`is`
 import org.hamcrest.CoreMatchers.nullValue
 import org.hamcrest.MatcherAssert.assertThat
+import org.junit.After
 import org.junit.Assert.assertThrows
 import org.junit.Before
 import org.junit.Test
+import org.mockito.MockedStatic
 import org.mockito.Mockito.mock
+import org.mockito.Mockito.mockStatic
+import org.mockito.Mockito.never
 import org.mockito.Mockito.verify
 import org.mockito.kotlin.any
 import org.mockito.kotlin.eq
 import org.mockito.kotlin.whenever
 
 class ProfilesViewModelTest {
+  private lateinit var context: Context
   private lateinit var profilesRepository: ProfilesRepository
   private lateinit var ppRepository: ProfilePicRepository
   private lateinit var profilesViewModel: ProfilesViewModel
+  private lateinit var mockProfileViewModel: ProfilesViewModel
 
   private val birthDate2002 =
       Timestamp(
@@ -52,11 +66,27 @@ class ProfilesViewModelTest {
           tags = listOf("adventurous", "outgoing"),
           profilePictureUrl = null)
 
+  private lateinit var bitmapFactoryMock: MockedStatic<BitmapFactory>
+  private lateinit var bitmapMock: MockedStatic<Bitmap>
+
   @Before
   fun setUp() {
+    context = mock(Context::class.java)
     profilesRepository = mock(ProfilesRepository::class.java)
     ppRepository = mock(ProfilePicRepository::class.java)
     profilesViewModel = ProfilesViewModel(profilesRepository, ppRepository)
+    mockProfileViewModel = mock(ProfilesViewModel::class.java)
+    
+    // Initialize static mocks
+    bitmapFactoryMock = mockStatic(BitmapFactory::class.java)
+    bitmapMock = mockStatic(Bitmap::class.java)
+  }
+
+  @After
+  fun tearDown() {
+    // Close static mocks
+    bitmapFactoryMock.close()
+    bitmapMock.close()
   }
 
   @Test
@@ -304,5 +334,121 @@ class ProfilesViewModelTest {
 
     verify(ppRepository).deleteProfilePicture(eq("1"), any(), any())
     assertThat(profilesViewModel.error.value, `is`(exception))
+  }
+
+  @Test
+  fun generateTempProfilePictureBitmapSucceeds() = runBlocking {
+    // Mock ContentResolver and Uri
+    val contentResolver = mock(ContentResolver::class.java)
+    val uri = mock(Uri::class.java)
+    whenever(context.contentResolver).thenReturn(contentResolver)
+
+    // Create a test image as InputStream
+    val testImageBytes = ByteArray(100) { it.toByte() }
+    val inputStream = ByteArrayInputStream(testImageBytes)
+    whenever(contentResolver.openInputStream(uri)).thenReturn(inputStream)
+
+    // Create a mock bitmap that will be "decoded" from the input stream
+    val mockBitmap = mock(Bitmap::class.java)
+    whenever(mockBitmap.width).thenReturn(100)
+    whenever(mockBitmap.height).thenReturn(100)
+
+    // Mock BitmapFactory.decodeStream to return our mock bitmap
+    bitmapFactoryMock.`when`<Bitmap> { BitmapFactory.decodeStream(any()) }.thenReturn(mockBitmap)
+
+    // Mock Bitmap.createBitmap to return the same mock bitmap
+    bitmapMock.`when`<Bitmap> { Bitmap.createBitmap(any<Bitmap>(), any(), any(), any(), any()) }
+        .thenReturn(mockBitmap)
+
+    profilesViewModel.generateTempProfilePictureBitmap(context, uri)
+
+    assertThat(profilesViewModel.tempProfilePictureBitmap.value, `is`(mockBitmap))
+  }
+
+  @Test
+  fun generateTempProfilePictureBitmapClampsToMaxResolution() = runBlocking {
+    // Mock ContentResolver and Uri
+    val contentResolver = mock(ContentResolver::class.java)
+    val uri = mock(Uri::class.java)
+    whenever(context.contentResolver).thenReturn(contentResolver)
+
+    // Create a test image as InputStream
+    val testImageBytes = ByteArray(100) { it.toByte() }
+    val inputStream = ByteArrayInputStream(testImageBytes)
+    whenever(contentResolver.openInputStream(uri)).thenReturn(inputStream)
+
+    // Create a mock bitmap that will be "decoded" from the input stream
+    val mockBitmap = mock(Bitmap::class.java)
+    whenever(mockBitmap.width).thenReturn(1200) // Width greater than max resolution
+    whenever(mockBitmap.height).thenReturn(1200) // Height greater than max resolution
+
+    // Mock BitmapFactory.decodeStream to return our mock bitmap
+    bitmapFactoryMock.`when`<Bitmap> { BitmapFactory.decodeStream(any()) }.thenReturn(mockBitmap)
+
+    // Mock Bitmap.createBitmap to return the same mock bitmap
+    bitmapMock.`when`<Bitmap> { Bitmap.createBitmap(any<Bitmap>(), any(), any(), any(), any()) }
+        .thenReturn(mockBitmap)
+
+    // Mock Bitmap.createScaledBitmap to return a scaled bitmap
+    val scaledBitmap = mock(Bitmap::class.java)
+    bitmapMock.`when`<Bitmap> { Bitmap.createScaledBitmap(any(), eq(600), eq(600), eq(true)) }
+        .thenReturn(scaledBitmap)
+
+    profilesViewModel.generateTempProfilePictureBitmap(context, uri)
+
+    // Verify that the bitmap was scaled down to the max resolution
+    assertThat(profilesViewModel.tempProfilePictureBitmap.value, `is`(scaledBitmap))
+  }
+
+  @Test
+  fun validateAndUploadProfilePictureWithNoTempBitmapDoesNothing() = runBlocking {
+    profilesViewModel.clearTempProfilePictureBitmap() // Ensure no temp bitmap exists
+    profilesViewModel.validateAndUploadProfilePicture(context)
+
+    // Verify no interactions with upload functionality
+    verify(profilesRepository, never()).updateProfile(any(), any(), any())
+  }
+
+  @Test
+  fun validateAndUploadProfilePictureSucceeds() = runBlocking {
+    // Mock successful profile setup
+    whenever(profilesRepository.getProfileByUid(eq("1"), any(), any())).thenAnswer {
+      val onSuccess = it.getArgument<(Profile) -> Unit>(1)
+      onSuccess(profile1)
+    }
+    profilesViewModel.getProfileByUid("1")
+
+    // Create and set a mock bitmap
+    val mockBitmap = mock(Bitmap::class.java)
+    whenever(mockBitmap.compress(eq(Bitmap.CompressFormat.JPEG), eq(100), any())).thenAnswer {
+      val stream = it.getArgument<ByteArrayOutputStream>(2)
+      stream.write(ByteArray(100))
+      true
+    }
+
+    // Set the temp bitmap
+    val field = ProfilesViewModel::class.java.getDeclaredField("_tempProfilePictureBitmap")
+    field.isAccessible = true
+    val tempProfilePictureBitmap = field.get(profilesViewModel) as MutableStateFlow<Bitmap?>
+    tempProfilePictureBitmap.value = mockBitmap
+
+    profilesViewModel.validateAndUploadProfilePicture(context)
+
+    // Verify upload was called and temp bitmap was cleared
+    verify(ppRepository).uploadProfilePicture(eq("1"), any(), any(), any())
+    assertThat(profilesViewModel.tempProfilePictureBitmap.value, `is`(nullValue()))
+  }
+
+  @Test
+  fun clearTempProfilePictureBitmapSucceeds() {
+    val mockBitmap = mock(Bitmap::class.java)
+    val field = ProfilesViewModel::class.java.getDeclaredField("_tempProfilePictureBitmap")
+    field.isAccessible = true
+    val tempProfilePictureBitmap = field.get(profilesViewModel) as MutableStateFlow<Bitmap?>
+    tempProfilePictureBitmap.value = mockBitmap
+
+    profilesViewModel.clearTempProfilePictureBitmap()
+
+    assertThat(profilesViewModel.tempProfilePictureBitmap.value, `is`(nullValue()))
   }
 }


### PR DESCRIPTION
# Upload profile pictures
This pull request introduces significant updates to the profile pictures display and selection. The primary changes include a profile picture selector that picks photos right from the gallery without having to use permissions. It also replaces pictures placeholders with actual profile pictures, which are stored in Firebase storage.

> [!note]  
**Revievers**: Always check at the bottom of the description as you will find a list of things that need to be checked first (doubts I had, decisions I have taken that need to be double-checked, ...)

![ezgif-3-7d3cb5cb54](https://github.com/user-attachments/assets/f25e957c-bdff-45e0-8760-c088d9b20cf4) ![image](https://github.com/user-attachments/assets/b536a8a6-547b-4408-bebf-206a7b81debb) 

## Changes
- **ProfilesViewModel.kt**
  - Added functions to process image for upload.
  - A new StateFlow that allows the UI to access a temporary processed file for display before upload.
  - Fix mistakes in last week's PR

- **ProfilePictureSelector.kt**
  - Added a new composable function `ProfilePictureSelector` to allow users to select and display profile pictures.
  - Implemented image picker functionality to choose images from the gallery.

- **ProfileEdit.kt**
  - Introduced the new `ProfilePictureSelector` composable for profile picture selection and display.

- **ProfileCard.kt**
  - Replaced empty circles with actual profile pictures

To view more details, please refer to the [pull request files](https://github.com/Swent-team-6/icebreakrr/pull/64/files).


## Review these first!
Here is a list of details I am not sure about
* I am unsure of the efficiency of my tests as it uses a lot of mocking and I don't know how much is too much.
* [SOLVED] When the picture is selected in ProfileEdit, taping the discard button to go back to the profile preview won't discard the profile picture. This difference with @louiscrc editing logic is due to the fact that doing so will lead to bad separation of layers (UI and Logic) and callback hell. This is not a big deal as it still makes sense that image and text may have different logic
* I am not sure about the error handling. Using callbacks and @arthur-mrgt `handleError` function is confusing. Maybe I am doing things wrong. The only thing I know is that the errors I could get in my function are non-terminating, so It must work anyway.
* Launcher, activities, contracts... I am completely lost with that. If someone is comfortable with that, please double-check my code (and if you have good resources to learn that, I'll take a look at them)
* [SOLVED]  I am searching for a way to use my processed square jpg as a placeholder to the profile picture selector while the actual image is being uploaded. If you have an idea how to do that dont hesitate to reach out