### PR TITLE
Feature/datastore

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -225,6 +225,10 @@ dependencies {
     androidTestImplementation(libs.mockito.kotlin)
 
     implementation(platform(libs.firebase.bom))
+
+    // Add these under the dependencies block
+    implementation(libs.androidx.datastore.preferences)
+    implementation(libs.androidx.datastore.preferences.core)
 }
 
 tasks.withType<Test> {

--- a/app/src/main/java/com/github/se/icebreakrr/MainActivity.kt
+++ b/app/src/main/java/com/github/se/icebreakrr/MainActivity.kt
@@ -19,6 +19,7 @@ import androidx.navigation.compose.composable
 import androidx.navigation.compose.navigation
 import androidx.navigation.compose.rememberNavController
 import com.github.se.icebreakrr.config.LocalIsTesting
+import com.github.se.icebreakrr.data.AppDataStore
 import com.github.se.icebreakrr.model.filter.FilterViewModel
 import com.github.se.icebreakrr.model.message.MeetingRequestManager
 import com.github.se.icebreakrr.model.message.MeetingRequestViewModel
@@ -36,6 +37,7 @@ import com.github.se.icebreakrr.ui.sections.FilterScreen
 import com.github.se.icebreakrr.ui.sections.NotificationScreen
 import com.github.se.icebreakrr.ui.sections.SettingsScreen
 import com.github.se.icebreakrr.ui.theme.SampleAppTheme
+import com.github.se.icebreakrr.utils.NetworkUtils
 import com.google.firebase.FirebaseApp
 import com.google.firebase.auth.FirebaseAuth
 import com.google.firebase.functions.FirebaseFunctions
@@ -43,22 +45,30 @@ import com.google.firebase.functions.FirebaseFunctions
 class MainActivity : ComponentActivity() {
   private lateinit var auth: FirebaseAuth
   private lateinit var functions: FirebaseFunctions
+  private lateinit var appDataStore: AppDataStore
 
   override fun onCreate(savedInstanceState: Bundle?) {
     super.onCreate(savedInstanceState)
     // Retrieve the testing flag from the Intent
     val isTesting = intent?.getBooleanExtra("IS_TESTING", false) ?: false
 
+    NetworkUtils.init(this)
+
     requestNotificationPermission()
     FirebaseApp.initializeApp(this)
     auth = FirebaseAuth.getInstance()
     functions = FirebaseFunctions.getInstance()
 
+    // Initialize DataStore
+    appDataStore = AppDataStore(this)
+
     setContent {
       // Provide the `isTesting` flag to the entire composable tree
       CompositionLocalProvider(LocalIsTesting provides isTesting) {
         SampleAppTheme {
-          Surface(modifier = Modifier.fillMaxSize()) { IcebreakrrApp(auth, functions) }
+          Surface(modifier = Modifier.fillMaxSize()) {
+            IcebreakrrApp(auth, functions, appDataStore)
+          }
         }
       }
     }
@@ -88,7 +98,7 @@ class MainActivity : ComponentActivity() {
  * @see NotificationScreen
  */
 @Composable
-fun IcebreakrrApp(auth: FirebaseAuth, functions: FirebaseFunctions) {
+fun IcebreakrrApp(auth: FirebaseAuth, functions: FirebaseFunctions, appDataStore: AppDataStore) {
   val profileViewModel: ProfilesViewModel = viewModel(factory = ProfilesViewModel.Factory)
   val tagsViewModel: TagsViewModel = viewModel(factory = TagsViewModel.Factory)
   val filterViewModel: FilterViewModel = viewModel(factory = FilterViewModel.Factory)
@@ -103,7 +113,12 @@ fun IcebreakrrApp(auth: FirebaseAuth, functions: FirebaseFunctions) {
   val meetingRequestViewModel = MeetingRequestManager.meetingRequestViewModel
 
   IcebreakrrNavHost(
-      profileViewModel, tagsViewModel, filterViewModel, meetingRequestViewModel, Route.AUTH)
+      profileViewModel,
+      tagsViewModel,
+      filterViewModel,
+      meetingRequestViewModel,
+      appDataStore,
+      Route.AUTH)
 }
 
 @Composable
@@ -112,6 +127,7 @@ fun IcebreakrrNavHost(
     tagsViewModel: TagsViewModel,
     filterViewModel: FilterViewModel,
     meetingRequestViewModel: MeetingRequestViewModel?,
+    appDataStore: AppDataStore,
     startDestination: String
 ) {
   val navController = rememberNavController()
@@ -128,7 +144,8 @@ fun IcebreakrrNavHost(
               meetingRequestViewModel,
               navigationActions,
               filterViewModel = filterViewModel,
-              tagsViewModel = tagsViewModel)
+              tagsViewModel = tagsViewModel,
+              appDataStore = appDataStore)
         } else {
           throw IllegalStateException(
               "The Meeting Request View Model shouldn't be null : Bad initialization")
@@ -162,7 +179,9 @@ fun IcebreakrrNavHost(
         startDestination = Screen.SETTINGS,
         route = Route.SETTINGS,
     ) {
-      composable(Screen.SETTINGS) { SettingsScreen(profileViewModel, navigationActions) }
+      composable(Screen.SETTINGS) {
+        SettingsScreen(profileViewModel, navigationActions, appDataStore = appDataStore)
+      }
       composable(Screen.PROFILE) { ProfileView(profileViewModel, tagsViewModel, navigationActions) }
     }
 

--- a/app/src/main/java/com/github/se/icebreakrr/authentication/User.kt
+++ b/app/src/main/java/com/github/se/icebreakrr/authentication/User.kt
@@ -3,6 +3,7 @@ package com.github.se.icebreakrr.authentication
 import android.content.Context
 import android.util.Log
 import com.github.se.icebreakrr.R
+import com.github.se.icebreakrr.data.AppDataStore
 import com.github.se.icebreakrr.ui.navigation.NavigationActions
 import com.github.se.icebreakrr.ui.navigation.Screen
 import com.google.android.gms.auth.api.signin.GoogleSignIn
@@ -22,7 +23,7 @@ import com.google.firebase.auth.FirebaseAuth
  * @param context Used to initialize GoogleSignInClient.
  * @param navigationActions Handles navigation to the authentication screen.
  */
-fun logout(context: Context, navigationActions: NavigationActions) {
+fun logout(context: Context, navigationActions: NavigationActions, appDataStore: AppDataStore) {
 
   // Initialize FirebaseAuth
   val auth = FirebaseAuth.getInstance()
@@ -36,6 +37,9 @@ fun logout(context: Context, navigationActions: NavigationActions) {
           .build()
 
   val googleSignInClient: GoogleSignInClient = GoogleSignIn.getClient(context, gso)
+
+  // Clear stored auth token
+  kotlinx.coroutines.runBlocking { appDataStore.clearAuthToken() }
 
   // Sign out from Firebase
   auth.signOut()

--- a/app/src/main/java/com/github/se/icebreakrr/data/AppDataStore.kt
+++ b/app/src/main/java/com/github/se/icebreakrr/data/AppDataStore.kt
@@ -1,0 +1,92 @@
+package com.github.se.icebreakrr.data
+
+import android.content.Context
+import androidx.datastore.core.DataStore
+import androidx.datastore.preferences.core.Preferences
+import androidx.datastore.preferences.core.booleanPreferencesKey
+import androidx.datastore.preferences.core.edit
+import androidx.datastore.preferences.core.stringPreferencesKey
+import androidx.datastore.preferences.preferencesDataStore
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.map
+
+/**
+ * Manages persistent app preferences using DataStore. This class handles storage and retrieval of
+ * user preferences such as:
+ * - Authentication token
+ * - Discoverability status
+ *
+ * All operations are suspending functions or return Flows to ensure safe background execution.
+ */
+class AppDataStore(private val dataStore: DataStore<Preferences>) {
+  /**
+   * Secondary constructor that creates a DataStore instance from a Context.
+   *
+   * @param context The application context used to create the DataStore
+   */
+  constructor(context: Context) : this(context.dataStore)
+
+  companion object {
+    /**
+     * DataStore instance created using the preferencesDataStore delegate. Ensures only one instance
+     * of DataStore is created for the application.
+     */
+    private val Context.dataStore: DataStore<Preferences> by
+        preferencesDataStore(name = "app_preferences")
+
+    // Preference Keys
+    /** Key for storing the authentication token Type: String */
+    private val AUTH_TOKEN_KEY = stringPreferencesKey("auth_token")
+
+    /** Key for storing the user's discoverability preference Type: Boolean */
+    private val DISCOVERABLE_KEY = booleanPreferencesKey("is_discoverable")
+  }
+
+  /**
+   * Provides access to the stored authentication token as a Flow.
+   *
+   * @return Flow<String?> that emits the current auth token or null if not set
+   */
+  val authToken: Flow<String?> = dataStore.data.map { preferences -> preferences[AUTH_TOKEN_KEY] }
+
+  /**
+   * Saves an authentication token to persistent storage.
+   *
+   * @param token The authentication token to store
+   */
+  suspend fun saveAuthToken(token: String) {
+    dataStore.edit { preferences -> preferences[AUTH_TOKEN_KEY] = token }
+  }
+
+  /**
+   * Removes the stored authentication token. Used during logout or when the token needs to be
+   * invalidated.
+   */
+  suspend fun clearAuthToken() {
+    dataStore.edit { preferences -> preferences.remove(AUTH_TOKEN_KEY) }
+  }
+
+  /**
+   * Clears all stored preferences. Use with caution as this will reset all preferences to their
+   * default values.
+   */
+  suspend fun clearAll() {
+    dataStore.edit { preferences -> preferences.clear() }
+  }
+
+  /**
+   * Check if we have a valid auth token stored
+   *
+   * @return Flow<Boolean> indicating if we have a token
+   */
+  val hasAuthToken: Flow<Boolean> = authToken.map { token -> !token.isNullOrEmpty() }
+
+  /** Save discoverability preference */
+  suspend fun saveDiscoverableStatus(isDiscoverable: Boolean) {
+    dataStore.edit { preferences -> preferences[DISCOVERABLE_KEY] = isDiscoverable }
+  }
+
+  /** Get discoverability status as a Flow Default value is true to maintain existing behavior */
+  val isDiscoverable: Flow<Boolean> =
+      dataStore.data.map { preferences -> preferences[DISCOVERABLE_KEY] ?: true }
+}

--- a/app/src/main/java/com/github/se/icebreakrr/model/profile/ProfilesRepositoryFirestore.kt
+++ b/app/src/main/java/com/github/se/icebreakrr/model/profile/ProfilesRepositoryFirestore.kt
@@ -3,12 +3,14 @@ package com.github.se.icebreakrr.model.profile
 import android.os.Handler
 import android.os.Looper
 import android.util.Log
+import com.github.se.icebreakrr.utils.NetworkUtils
 import com.google.android.gms.tasks.Task
 import com.google.firebase.Firebase
 import com.google.firebase.auth.auth
 import com.google.firebase.firestore.DocumentSnapshot
 import com.google.firebase.firestore.FirebaseFirestore
 import com.google.firebase.firestore.GeoPoint
+import com.google.firebase.firestore.Source
 import kotlinx.coroutines.flow.MutableStateFlow
 
 class ProfilesRepositoryFirestore(private val db: FirebaseFirestore) : ProfilesRepository {
@@ -202,8 +204,14 @@ class ProfilesRepositoryFirestore(private val db: FirebaseFirestore) : ProfilesR
       onSuccess: (Profile?) -> Unit,
       onFailure: (Exception) -> Unit
   ) {
+    val source =
+        if (NetworkUtils.isNetworkAvailable()) {
+          Source.SERVER
+        } else {
+          Source.CACHE
+        }
     Log.d("ProfilesRepositoryFirestore", "getProfileByUid")
-    db.collection("profiles").document(uid).get().addOnCompleteListener { task ->
+    db.collection("profiles").document(uid).get(source).addOnCompleteListener { task ->
       if (task.isSuccessful) {
         val profile = task.result?.let { document -> documentToProfile(document) }
         onSuccess(profile)

--- a/app/src/main/java/com/github/se/icebreakrr/model/profile/ProfilesViewModel.kt
+++ b/app/src/main/java/com/github/se/icebreakrr/model/profile/ProfilesViewModel.kt
@@ -41,7 +41,7 @@ open class ProfilesViewModel(
   private val _tempProfilePictureBitmap = MutableStateFlow<Bitmap?>(null)
   val tempProfilePictureBitmap: StateFlow<Bitmap?> = _tempProfilePictureBitmap
 
-  private var _isConnected = MutableStateFlow(true)
+  var _isConnected = MutableStateFlow(true)
   var isConnected: StateFlow<Boolean> = _isConnected
 
   companion object {

--- a/app/src/main/java/com/github/se/icebreakrr/ui/sections/AroundYou.kt
+++ b/app/src/main/java/com/github/se/icebreakrr/ui/sections/AroundYou.kt
@@ -16,6 +16,7 @@ import androidx.compose.material3.pulltorefresh.PullToRefreshState
 import androidx.compose.material3.pulltorefresh.pullToRefresh
 import androidx.compose.material3.pulltorefresh.rememberPullToRefreshState
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -63,6 +64,28 @@ fun AroundYouScreen(
   val context = LocalContext.current
   val isConnected = profilesViewModel.isConnected.collectAsState()
 
+  // Define constants for magic numbers
+  val defaultGeoPoint = GeoPoint(0.0, 0.0)
+  val searchRadius = 300.0
+  val verticalPadding = 16.dp
+  val horizontalPadding = 8.dp
+  val messageTextSize = 20.sp
+  val messageTextColor = Color(0xFF575757)
+
+  // Check network state when screen loads
+  LaunchedEffect(Unit) {
+    if (!isNetworkAvailable()) {
+      profilesViewModel._isConnected.value = false
+    } else {
+      profilesViewModel.getFilteredProfilesInRadius(
+          defaultGeoPoint,
+          searchRadius,
+          filterViewModel.selectedGenders.value,
+          filterViewModel.ageRange.value,
+          tagsViewModel.filteredTags.value)
+    }
+  }
+
   Scaffold(
       modifier = Modifier.testTag("aroundYouScreen"),
       bottomBar = {
@@ -84,9 +107,9 @@ fun AroundYouScreen(
             onRefresh = profilesViewModel::getFilteredProfilesInRadius,
             modifier = Modifier.padding(innerPadding)) {
               LazyColumn(
-                  contentPadding = PaddingValues(vertical = 16.dp),
-                  verticalArrangement = Arrangement.spacedBy(16.dp),
-                  modifier = Modifier.fillMaxSize().padding(horizontal = 8.dp)) {
+                  contentPadding = PaddingValues(vertical = verticalPadding),
+                  verticalArrangement = Arrangement.spacedBy(verticalPadding),
+                  modifier = Modifier.fillMaxSize().padding(horizontal = horizontalPadding)) {
                     if (!isConnected.value) {
                       item {
                         Box(
@@ -94,9 +117,9 @@ fun AroundYouScreen(
                             modifier = Modifier.fillMaxSize().testTag("noConnectionPrompt")) {
                               Text(
                                   text = "No Internet Connection",
-                                  fontSize = 20.sp,
+                                  fontSize = messageTextSize,
                                   fontWeight = FontWeight.Bold,
-                                  color = Color(0xFF575757))
+                                  color = messageTextColor)
                             }
                       }
                     } else if (filteredProfiles.value.isNotEmpty()) {
@@ -104,7 +127,7 @@ fun AroundYouScreen(
                         ProfileCard(
                             profile = filteredProfiles.value[index],
                             onclick = {
-                              if (isNetworkAvailable(context = context)) {
+                              if (isNetworkAvailable()) {
                                 navigationActions.navigateTo(
                                     Screen.OTHER_PROFILE_VIEW +
                                         "?userId=${filteredProfiles.value[index].uid}")
@@ -120,9 +143,9 @@ fun AroundYouScreen(
                             modifier = Modifier.fillMaxSize().testTag("emptyProfilePrompt")) {
                               Text(
                                   text = "There is no one around. Try moving!",
-                                  fontSize = 20.sp,
+                                  fontSize = messageTextSize,
                                   fontWeight = FontWeight.Bold,
-                                  color = Color(0xFF575757))
+                                  color = messageTextColor)
                             }
                       }
                     }
@@ -175,12 +198,14 @@ fun PullToRefreshBox(
     content: @Composable BoxScope.() -> Unit
 ) {
 
+  val defaultGeoPoint = GeoPoint(0.0, 0.0)
+  val searchRadius = 300.0
+
   Box(
       modifier.pullToRefresh(state = state, isRefreshing = isRefreshing) {
-        // TODO Mocked values, to change with  current location
         onRefresh(
-            GeoPoint(0.0, 0.0),
-            300.0,
+            defaultGeoPoint,
+            searchRadius,
             filterViewModel.selectedGenders.value,
             filterViewModel.ageRange.value,
             tagsViewModel.filteredTags.value)

--- a/app/src/main/java/com/github/se/icebreakrr/ui/sections/Settings.kt
+++ b/app/src/main/java/com/github/se/icebreakrr/ui/sections/Settings.kt
@@ -21,8 +21,8 @@ import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
-import androidx.compose.runtime.mutableStateOf
-import androidx.compose.runtime.remember
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
@@ -31,6 +31,7 @@ import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.unit.dp
 import com.github.se.icebreakrr.authentication.logout
 import com.github.se.icebreakrr.config.LocalIsTesting
+import com.github.se.icebreakrr.data.AppDataStore
 import com.github.se.icebreakrr.mock.getMockedProfiles
 import com.github.se.icebreakrr.model.profile.Profile
 import com.github.se.icebreakrr.model.profile.ProfilesViewModel
@@ -44,13 +45,28 @@ import com.github.se.icebreakrr.ui.sections.shared.TopBar
 import com.google.firebase.Firebase
 import com.google.firebase.auth.FirebaseAuth
 import com.google.firebase.auth.auth
+import kotlinx.coroutines.launch
 
 // This File was written with the help of Cursor
 @Composable
-fun SettingsScreen(profilesViewModel: ProfilesViewModel, navigationActions: NavigationActions) {
+fun SettingsScreen(
+    profilesViewModel: ProfilesViewModel,
+    navigationActions: NavigationActions,
+    appDataStore: AppDataStore
+) {
   val context = LocalContext.current
   val scrollState = rememberScrollState()
+  val coroutineScope = rememberCoroutineScope()
+
+  // Collect the discoverability state from DataStore
+  val isDiscoverable by appDataStore.isDiscoverable.collectAsState(initial = true)
+
   lateinit var auth: FirebaseAuth
+
+  // Constants for padding and spacing
+  val screenPadding = 16.dp
+  val verticalSpacing = 8.dp
+  val buttonVerticalSpacing = 16.dp
 
   LaunchedEffect(Unit) {
     Firebase.auth.currentUser?.let { profilesViewModel.getProfileByUid(it.uid) }
@@ -76,7 +92,10 @@ fun SettingsScreen(profilesViewModel: ProfilesViewModel, navigationActions: Navi
   ) { innerPadding ->
     Column(
         modifier =
-            Modifier.fillMaxSize().padding(innerPadding).padding(16.dp).verticalScroll(scrollState),
+            Modifier.fillMaxSize()
+                .padding(innerPadding)
+                .padding(screenPadding)
+                .verticalScroll(scrollState),
         verticalArrangement = Arrangement.Top,
         horizontalAlignment = Alignment.Start) {
           if (profile != null) {
@@ -89,12 +108,16 @@ fun SettingsScreen(profilesViewModel: ProfilesViewModel, navigationActions: Navi
             }
           }
 
-          Spacer(modifier = Modifier.padding(vertical = 8.dp))
+          Spacer(modifier = Modifier.padding(vertical = verticalSpacing))
 
-          ToggleOptionBox(label = "Toggle Location")
-          ToggleOptionBox(label = "Option 1")
+          ToggleOptionBox(
+              label = "Toggle discoverability",
+              isChecked = isDiscoverable,
+              onCheckedChange = { discoverable ->
+                coroutineScope.launch { appDataStore.saveDiscoverableStatus(discoverable) }
+              })
 
-          Spacer(modifier = Modifier.padding(vertical = 16.dp))
+          Spacer(modifier = Modifier.padding(vertical = buttonVerticalSpacing))
 
           Button(
               onClick = {
@@ -102,7 +125,10 @@ fun SettingsScreen(profilesViewModel: ProfilesViewModel, navigationActions: Navi
                   navigationActions.navigateTo(Screen.AUTH)
                 } else {
                   auth = FirebaseAuth.getInstance()
-                  auth.currentUser?.let { logout(context, navigationActions) }
+                  auth.currentUser?.let {
+                    logout(context, navigationActions, appDataStore = appDataStore)
+                  }
+                  logout(context, navigationActions, appDataStore)
                 }
               },
               colors = ButtonDefaults.buttonColors(containerColor = Color.Red),
@@ -114,22 +140,31 @@ fun SettingsScreen(profilesViewModel: ProfilesViewModel, navigationActions: Navi
 }
 
 @Composable
-fun ToggleOptionBox(label: String) {
-  val toggleState = remember { mutableStateOf(false) }
+fun ToggleOptionBox(
+    label: String,
+    isChecked: Boolean,
+    onCheckedChange: (Boolean) -> Unit,
+    modifier: Modifier = Modifier
+) {
+  // Constants for card styling
+  val cardShape = RoundedCornerShape(16.dp)
+  val cardElevation = 4.dp
+  val cardHeight = 55.dp
+  val cardPadding = 16.dp
 
   Card(
-      shape = RoundedCornerShape(16.dp),
-      modifier = Modifier.fillMaxWidth().padding(vertical = 8.dp).height(55.dp).testTag(label),
-      elevation = CardDefaults.cardElevation(defaultElevation = 4.dp)) {
+      shape = cardShape,
+      modifier = modifier.fillMaxWidth().padding(vertical = 8.dp).height(cardHeight).testTag(label),
+      elevation = CardDefaults.cardElevation(defaultElevation = cardElevation)) {
         Row(
-            modifier = Modifier.fillMaxWidth().padding(16.dp),
+            modifier = Modifier.fillMaxWidth().padding(cardPadding),
             verticalAlignment = Alignment.CenterVertically) {
               Text(label)
               Spacer(modifier = Modifier.weight(1f))
               Switch(
-                  checked = toggleState.value,
+                  checked = isChecked,
                   modifier = Modifier.testTag("switch$label"),
-                  onCheckedChange = { toggleState.value = it })
+                  onCheckedChange = onCheckedChange)
             }
       }
 }

--- a/app/src/main/java/com/github/se/icebreakrr/ui/sections/shared/DisplayProfile.kt
+++ b/app/src/main/java/com/github/se/icebreakrr/ui/sections/shared/DisplayProfile.kt
@@ -228,7 +228,6 @@ fun ProfileHeader(
                   color = Color.White,
                   modifier = Modifier.testTag("username"))
 
-              val context = LocalContext.current
               // Edit Button or message button
               if (myProfile) {
                 Box(
@@ -239,7 +238,7 @@ fun ProfileHeader(
                     contentAlignment = Alignment.Center) {
                       IconButton(
                           onClick = {
-                            if (isNetworkAvailable(context = context)) {
+                            if (isNetworkAvailable()) {
                               onEditClick()
                             } else {
                               showNoInternetToast(context = context)
@@ -262,7 +261,7 @@ fun ProfileHeader(
                     contentAlignment = Alignment.Center) {
                       IconButton(
                           onClick = {
-                            if (isNetworkAvailable(context = context)) {
+                            if (isNetworkAvailable()) {
                               onEditClick()
                             } else {
                               showNoInternetToast(context = context)

--- a/app/src/main/java/com/github/se/icebreakrr/utils/NetworkUtils.kt
+++ b/app/src/main/java/com/github/se/icebreakrr/utils/NetworkUtils.kt
@@ -4,37 +4,61 @@ import android.content.Context
 import android.net.ConnectivityManager
 import android.net.NetworkCapabilities
 import android.widget.Toast
-import com.github.se.icebreakrr.R
 
-// Written with the help of CursorAI and Claude
+// This File was written with the help of Cursor AI
 
 /**
- * A utility object for network-related functions.
- *
- * This object provides methods to check network availability and to show a toast message when there
- * is no internet connection.
+ * Utility object for handling network-related operations and checks.
+ * Provides functionality to:
+ * - Check network connectivity
+ * - Display network status messages
+ * - Initialize network monitoring
  */
 object NetworkUtils {
+  /**
+   * ConnectivityManager instance used to monitor network state.
+   * Initialized via [init] or [setConnectivityManagerForTesting].
+   */
+  private var connectivityManager: ConnectivityManager? = null
 
   /**
-   * Checks if the network is available.
+   * Initializes the NetworkUtils with the application context.
+   * Must be called before using other methods in this class.
    *
-   * @param context The context used to access system services.
-   * @return True if the network is available, false otherwise.
+   * @param context The application context used to get the ConnectivityManager service
    */
-  fun isNetworkAvailable(context: Context): Boolean {
-    val connectivityManager = context.getSystemService(ConnectivityManager::class.java)
+  fun init(context: Context) {
+    connectivityManager = context.getSystemService(ConnectivityManager::class.java)
+  }
+
+  /**
+   * Sets a custom ConnectivityManager instance for testing purposes.
+   * This allows mocking of network states in unit tests.
+   *
+   * @param manager The mock ConnectivityManager instance to use for testing
+   */
+  fun setConnectivityManagerForTesting(manager: ConnectivityManager) {
+    connectivityManager = manager
+  }
+
+  /**
+   * Checks if the device currently has a valid internet connection.
+   * Uses NET_CAPABILITY_VALIDATED to ensure the network can reach the internet.
+   *
+   * @return true if internet is available, false otherwise
+   */
+  fun isNetworkAvailable(): Boolean {
     val currentNetwork = connectivityManager?.activeNetwork
     val caps = connectivityManager?.getNetworkCapabilities(currentNetwork)
     return caps?.hasCapability(NetworkCapabilities.NET_CAPABILITY_VALIDATED) ?: false
   }
 
   /**
-   * Shows a toast message indicating that there is no internet connection.
+   * Displays a toast message indicating no internet connection is available.
    *
-   * @param context The context used to display the toast message.
+   * @param context The context used to show the toast message
    */
   fun showNoInternetToast(context: Context) {
-    Toast.makeText(context, context.getString(R.string.No_Internet_Toast), Toast.LENGTH_LONG).show()
+    Toast.makeText(context, "No internet connection", Toast.LENGTH_SHORT).show()
   }
 }

--- a/app/src/test/java/com/github/se/icebreakrr/data/AppDataStoreTest.kt
+++ b/app/src/test/java/com/github/se/icebreakrr/data/AppDataStoreTest.kt
@@ -1,0 +1,89 @@
+package com.github.se.icebreakrr.data
+
+import androidx.datastore.core.DataStore
+import androidx.datastore.preferences.core.PreferenceDataStoreFactory
+import androidx.datastore.preferences.core.Preferences
+import java.io.File
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.test.TestScope
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertEquals
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+import org.junit.rules.TemporaryFolder
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class AppDataStoreTest {
+  private val testScope = TestScope(UnconfinedTestDispatcher() + Job())
+
+  @get:Rule val tempFolder: TemporaryFolder = TemporaryFolder()
+
+  private lateinit var testDataStore: DataStore<Preferences>
+  private lateinit var appDataStore: AppDataStore
+
+  @Before
+  fun setUp() {
+    testDataStore =
+        PreferenceDataStoreFactory.create(
+            scope = testScope,
+            produceFile = { File(tempFolder.newFolder(), "test_preferences.preferences_pb") })
+    appDataStore = AppDataStore(testDataStore)
+  }
+
+  @Test
+  fun testSaveAndRetrieveAuthToken() = runTest {
+    val token = "test_token"
+    appDataStore.saveAuthToken(token)
+
+    val retrievedToken = appDataStore.authToken.first()
+    assertEquals(token, retrievedToken)
+  }
+
+  @Test
+  fun testClearAuthToken() = runTest {
+    appDataStore.saveAuthToken("test_token")
+    appDataStore.clearAuthToken()
+
+    val retrievedToken = appDataStore.authToken.first()
+    assertEquals(null, retrievedToken)
+  }
+
+  @Test
+  fun testHasAuthToken() = runTest {
+    appDataStore.saveAuthToken("test_token")
+    val hasToken = appDataStore.hasAuthToken.first()
+    assertEquals(true, hasToken)
+
+    appDataStore.clearAuthToken()
+    val hasNoToken = appDataStore.hasAuthToken.first()
+    assertEquals(false, hasNoToken)
+  }
+
+  @Test
+  fun testSaveAndRetrieveDiscoverableStatus() = runTest {
+    appDataStore.saveDiscoverableStatus(false)
+    val isDiscoverable = appDataStore.isDiscoverable.first()
+    assertEquals(false, isDiscoverable)
+
+    appDataStore.saveDiscoverableStatus(true)
+    val isDiscoverableAgain = appDataStore.isDiscoverable.first()
+    assertEquals(true, isDiscoverableAgain)
+  }
+
+  @Test
+  fun testClearAll() = runTest {
+    appDataStore.saveAuthToken("test_token")
+    appDataStore.saveDiscoverableStatus(false)
+    appDataStore.clearAll()
+
+    val retrievedToken = appDataStore.authToken.first()
+    val isDiscoverable = appDataStore.isDiscoverable.first()
+
+    assertEquals(null, retrievedToken)
+    assertEquals(true, isDiscoverable) // Default value is true
+  }
+}

--- a/app/src/test/java/com/github/se/icebreakrr/utils/NetworkUtilsTest.kt
+++ b/app/src/test/java/com/github/se/icebreakrr/utils/NetworkUtilsTest.kt
@@ -1,6 +1,5 @@
 package com.github.se.icebreakrr.utils
 
-import android.content.Context
 import android.net.ConnectivityManager
 import android.net.Network
 import android.net.NetworkCapabilities
@@ -8,27 +7,24 @@ import org.junit.Assert.assertFalse
 import org.junit.Assert.assertTrue
 import org.junit.Before
 import org.junit.Test
-import org.mockito.Mockito.* //
+import org.mockito.Mockito.*
 
-// Tests written with the help of CursorAI, I know the tests may be weird since everything is mocked
-// but I don't know how else to test
 class NetworkUtilsTest {
 
-  private lateinit var context: Context
   private lateinit var connectivityManager: ConnectivityManager
   private lateinit var network: Network
   private lateinit var networkCapabilities: NetworkCapabilities
 
   @Before
   fun setUp() {
-    context = mock(Context::class.java)
     connectivityManager = mock(ConnectivityManager::class.java)
     network = mock(Network::class.java)
     networkCapabilities = mock(NetworkCapabilities::class.java)
 
-    `when`(context.getSystemService(ConnectivityManager::class.java))
-        .thenReturn(connectivityManager)
     `when`(connectivityManager.activeNetwork).thenReturn(network)
+
+    // Set the mocked ConnectivityManager for testing
+    NetworkUtils.setConnectivityManagerForTesting(connectivityManager)
   }
 
   @Test
@@ -37,13 +33,13 @@ class NetworkUtilsTest {
     `when`(networkCapabilities.hasCapability(NetworkCapabilities.NET_CAPABILITY_VALIDATED))
         .thenReturn(true)
 
-    assertTrue(NetworkUtils.isNetworkAvailable(context))
+    assertTrue(NetworkUtils.isNetworkAvailable())
   }
 
   @Test
   fun testIsNetworkAvailable_withNoNetwork() {
     `when`(connectivityManager.getNetworkCapabilities(network)).thenReturn(null)
 
-    assertFalse(NetworkUtils.isNetworkAvailable(context))
+    assertFalse(NetworkUtils.isNetworkAvailable())
   }
 }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -2,6 +2,7 @@
 #Google
 converterMoshi = "2.9.0"
 coreTesting = "2.2.0"
+datastorePreferences = "1.1.1"
 googleServices = "4.4.2"
 mockitoInline = "4.0.0"
 mockitoInlineVersion = "5.2.0"
@@ -58,6 +59,8 @@ firebaseStorageKtx = "21.0.1"
 [libraries]
 #Google
 androidx-core-testing = { module = "androidx.arch.core:core-testing", version.ref = "coreTesting" }
+androidx-datastore-preferences = { module = "androidx.datastore:datastore-preferences", version.ref = "datastorePreferences" }
+androidx-datastore-preferences-core = { module = "androidx.datastore:datastore-preferences-core", version.ref = "datastorePreferences" }
 converter-moshi = { module = "com.squareup.retrofit2:converter-moshi", version.ref = "converterMoshi" }
 firebase-messaging-ktx = { module = "com.google.firebase:firebase-messaging-ktx" }
 mockito-inline = { module = "org.mockito:mockito-inline", version.ref = "mockitoInline" }


### PR DESCRIPTION
# DataStore Implementation

## Overview
This PR implements persistent data storage using DataStore to enhance offline functionality.

## Key Changes
1. **DataStore Implementation**
   - Created DataStore class for handling auth token and discoverability preferences
   - Added methods for saving, retrieving, and clearing user data
   - Implemented unit tests for DataStore operations
  

3. **Network Utilities**
   -  Modified it so that isNetworkAvailable doesn't require context anymore

4. **Integration**
   - Added DataStore initialization in app startup

5. **New Features**
  - Added a launch effect to the AroundYou page so that when the user logs in offline it immediately displays "no internet" instead of having to wait for the timeout
   - Force firebase to retrieve from cache if the user is offline so that the user can immediately see its profile
   - If the user has already signed in once, the auth token is stored and the user can next time login offline

## Technical Details
- Uses Preferences DataStore for persistent storage

## Testing
- Unit tests for DataStore operations
- Network utility tests with mock ConnectivityManager
- Integration tests for offline functionality

## Dependencies
- Added DataStore dependencies to Gradle
