### PR TITLE
feature : block-backend

### DIFF
--- a/app/src/androidTest/java/com/github/se/icebreakrr/ui/profile/OtherProfileViewTest.kt
+++ b/app/src/androidTest/java/com/github/se/icebreakrr/ui/profile/OtherProfileViewTest.kt
@@ -171,6 +171,7 @@ class OtherProfileViewTest {
   fun testBlockUserFlowWithConfirm() {
     fakeProfilesViewModel.setLoading(false)
     fakeProfilesViewModel.setSelectedProfile(Profile.getMockedProfiles()[0])
+    fakeProfilesViewModel.setSelfProfile(Profile.getMockedProfiles()[1])
 
     composeTestRule.setContent {
       OtherProfileView(

--- a/app/src/main/java/com/github/se/icebreakrr/mock/MockProfiles.kt
+++ b/app/src/main/java/com/github/se/icebreakrr/mock/MockProfiles.kt
@@ -104,6 +104,12 @@ open class MockProfileViewModel :
   private val _loading = MutableStateFlow(false)
   override val loading: StateFlow<Boolean> = _loading.asStateFlow()
 
+  private val _selfProfile = MutableStateFlow<Profile?>(null)
+  override val selfProfile: StateFlow<Profile?> = _selfProfile.asStateFlow()
+
+  private val _loadingSelf = MutableStateFlow(false)
+  override val loadingSelf: StateFlow<Boolean> = _loadingSelf.asStateFlow()
+
   init {
     getProfiles()
   }
@@ -119,6 +125,10 @@ open class MockProfileViewModel :
   fun setSelectedProfile(profile: Profile?) {
     _selectedProfile.value = profile
   }
+
+    fun setSelfProfile(profile: Profile?) {
+        _selfProfile.value = profile
+    }
 
   /** Sets the loading state directly for testing purposes */
   fun setLoading(isLoading: Boolean) {
@@ -210,6 +220,9 @@ fun Profile.Companion.getMockedProfiles(): List<Profile> {
           listOf("entertainment", "singing", "frog"),
           listOf("adventure", "archaeology", "action"))
 
+  val hasBlockedList =
+      listOf(listOf("2", "3"), listOf(), listOf(), listOf(), listOf(), listOf(), listOf(), listOf(), listOf(), listOf(), listOf(), listOf())
+
   val profiles = mutableListOf<Profile>()
   for (i in uids.indices) {
     profiles.add(
@@ -221,7 +234,8 @@ fun Profile.Companion.getMockedProfiles(): List<Profile> {
             catchPhrase = catchPhrases[i],
             description = descriptions[i],
             tags = tagsList[i],
-            profilePictureUrl = null))
+            profilePictureUrl = null,
+            hasBlocked = hasBlockedList[i]))
   }
   return profiles
 }

--- a/app/src/main/java/com/github/se/icebreakrr/mock/MockProfiles.kt
+++ b/app/src/main/java/com/github/se/icebreakrr/mock/MockProfiles.kt
@@ -126,9 +126,9 @@ open class MockProfileViewModel :
     _selectedProfile.value = profile
   }
 
-    fun setSelfProfile(profile: Profile?) {
-        _selfProfile.value = profile
-    }
+  fun setSelfProfile(profile: Profile?) {
+    _selfProfile.value = profile
+  }
 
   /** Sets the loading state directly for testing purposes */
   fun setLoading(isLoading: Boolean) {
@@ -221,7 +221,19 @@ fun Profile.Companion.getMockedProfiles(): List<Profile> {
           listOf("adventure", "archaeology", "action"))
 
   val hasBlockedList =
-      listOf(listOf("2", "3"), listOf(), listOf(), listOf(), listOf(), listOf(), listOf(), listOf(), listOf(), listOf(), listOf(), listOf())
+      listOf(
+          listOf("2", "3"),
+          listOf(),
+          listOf(),
+          listOf(),
+          listOf(),
+          listOf(),
+          listOf(),
+          listOf(),
+          listOf(),
+          listOf(),
+          listOf(),
+          listOf())
 
   val profiles = mutableListOf<Profile>()
   for (i in uids.indices) {

--- a/app/src/main/java/com/github/se/icebreakrr/model/profile/Profile.kt
+++ b/app/src/main/java/com/github/se/icebreakrr/model/profile/Profile.kt
@@ -24,7 +24,8 @@ data class Profile(
     val description: String,
     val tags: List<String> = listOf(),
     val profilePictureUrl: String? = null,
-    val fcmToken: String? = null
+    val fcmToken: String? = null,
+    var hasBlocked: List<String> = listOf(),
 ) {
   /**
    * Calculates the user's age based on their birth date.

--- a/app/src/main/java/com/github/se/icebreakrr/model/profile/ProfilesRepositoryFirestore.kt
+++ b/app/src/main/java/com/github/se/icebreakrr/model/profile/ProfilesRepositoryFirestore.kt
@@ -281,6 +281,7 @@ class ProfilesRepositoryFirestore(private val db: FirebaseFirestore) : ProfilesR
       val tags = (document.get("tags") as? List<*>)?.filterIsInstance<String>() ?: listOf()
       val profilePictureUrl = document.getString("profilePictureUrl") // Nullable field
       val fcmToken = document.getString("fcmToken")
+        val hasBlocked = (document.get("hasBlocked") as? List<*>)?.filterIsInstance<String>() ?: listOf()
 
       // Create and return the Profile object
       Profile(
@@ -292,7 +293,8 @@ class ProfilesRepositoryFirestore(private val db: FirebaseFirestore) : ProfilesR
           description = description,
           tags = tags,
           profilePictureUrl = profilePictureUrl,
-          fcmToken = fcmToken)
+          fcmToken = fcmToken,
+          hasBlocked = hasBlocked)
     } catch (e: Exception) {
       Log.e("ProfileRepositoryFirestore", "Error converting document to Profile", e)
       null

--- a/app/src/main/java/com/github/se/icebreakrr/model/profile/ProfilesRepositoryFirestore.kt
+++ b/app/src/main/java/com/github/se/icebreakrr/model/profile/ProfilesRepositoryFirestore.kt
@@ -281,7 +281,8 @@ class ProfilesRepositoryFirestore(private val db: FirebaseFirestore) : ProfilesR
       val tags = (document.get("tags") as? List<*>)?.filterIsInstance<String>() ?: listOf()
       val profilePictureUrl = document.getString("profilePictureUrl") // Nullable field
       val fcmToken = document.getString("fcmToken")
-        val hasBlocked = (document.get("hasBlocked") as? List<*>)?.filterIsInstance<String>() ?: listOf()
+      val hasBlocked =
+          (document.get("hasBlocked") as? List<*>)?.filterIsInstance<String>() ?: listOf()
 
       // Create and return the Profile object
       Profile(

--- a/app/src/main/java/com/github/se/icebreakrr/model/profile/ProfilesViewModel.kt
+++ b/app/src/main/java/com/github/se/icebreakrr/model/profile/ProfilesViewModel.kt
@@ -1,6 +1,5 @@
 package com.github.se.icebreakrr.model.profile
 
-import android.annotation.SuppressLint
 import android.content.Context
 import android.graphics.Bitmap
 import android.graphics.BitmapFactory
@@ -19,7 +18,6 @@ import java.io.InputStream
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.update
-import java.util.concurrent.ForkJoinPool.ManagedBlocker
 
 open class ProfilesViewModel(
     private val repository: ProfilesRepository,
@@ -35,14 +33,14 @@ open class ProfilesViewModel(
   private val _selectedProfile = MutableStateFlow<Profile?>(null)
   open val selectedProfile: StateFlow<Profile?> = _selectedProfile
 
-    private val _selfProfile = MutableStateFlow<Profile?>(null)
-    open val selfProfile: StateFlow<Profile?> = _selfProfile
+  private val _selfProfile = MutableStateFlow<Profile?>(null)
+  open val selfProfile: StateFlow<Profile?> = _selfProfile
 
   private val _loading = MutableStateFlow(false)
   open val loading: StateFlow<Boolean> = _loading
 
-    private val _loadingSelf = MutableStateFlow(false)
-    open val loadingSelf: StateFlow<Boolean> = _loadingSelf
+  private val _loadingSelf = MutableStateFlow(false)
+  open val loadingSelf: StateFlow<Boolean> = _loadingSelf
 
   private val _error = MutableStateFlow<Exception?>(null)
   val error: StateFlow<Exception?> = _error
@@ -80,7 +78,7 @@ open class ProfilesViewModel(
     repository.init {
       // Fetch profiles on initialization
       getFilteredProfilesInRadius(GeoPoint(0.0, 0.0), 300.0)
-        getSelfProfile()
+      getSelfProfile()
     }
   }
 
@@ -120,7 +118,7 @@ open class ProfilesViewModel(
                         tags.isEmpty()) &&
 
                     // Filter by hasBlocked
-                    !(_selfProfile.value?.hasBlocked?.contains(profile.uid)?:false)
+                    !(_selfProfile.value?.hasBlocked?.contains(profile.uid) ?: false)
               }
           _profiles.value = profileList
           _filteredProfiles.value = filteredProfiles
@@ -268,20 +266,20 @@ open class ProfilesViewModel(
    * @param uid The unique ID of the user being blocked.
    */
   fun blockUser(uid: String) {
-      updateProfile(selfProfile.value!!.copy(hasBlocked = selfProfile.value!!.hasBlocked + uid))
-    }
+    updateProfile(selfProfile.value!!.copy(hasBlocked = selfProfile.value!!.hasBlocked + uid))
+  }
 
-  /**
-   * Fetches the current user's profile from the repository.
-   */
-  fun getSelfProfile(){
-      _loadingSelf.value = true
-          repository.getProfileByUid(
-              Firebase.auth.uid ?: "null",
-              onSuccess = { profile ->
-              _selfProfile.value = profile
-              _loadingSelf.value = false }, onFailure = { e -> handleError(e) })
-    }
+  /** Fetches the current user's profile from the repository. */
+  fun getSelfProfile() {
+    _loadingSelf.value = true
+    repository.getProfileByUid(
+        Firebase.auth.uid ?: "null",
+        onSuccess = { profile ->
+          _selfProfile.value = profile
+          _loadingSelf.value = false
+        },
+        onFailure = { e -> handleError(e) })
+  }
 
   /**
    * Converts an image URI to a processed Bitmap, cropping the image to a square at the center.

--- a/app/src/main/java/com/github/se/icebreakrr/ui/profile/OtherProfileView.kt
+++ b/app/src/main/java/com/github/se/icebreakrr/ui/profile/OtherProfileView.kt
@@ -77,7 +77,7 @@ fun OtherProfileView(
 
             // 2 sections one for the profile image with overlay and
             // one for the information section
-            ProfileHeader(profile, navigationActions, false) { sendRequest = true }
+            ProfileHeader(profile, navigationActions, false,profilesViewModel) { sendRequest = true }
             InfoSection(profile, tagsViewModel)
           }
 

--- a/app/src/main/java/com/github/se/icebreakrr/ui/profile/OtherProfileView.kt
+++ b/app/src/main/java/com/github/se/icebreakrr/ui/profile/OtherProfileView.kt
@@ -77,7 +77,9 @@ fun OtherProfileView(
 
             // 2 sections one for the profile image with overlay and
             // one for the information section
-            ProfileHeader(profile, navigationActions, false,profilesViewModel) { sendRequest = true }
+            ProfileHeader(profile, navigationActions, false, profilesViewModel) {
+              sendRequest = true
+            }
             InfoSection(profile, tagsViewModel)
           }
 

--- a/app/src/main/java/com/github/se/icebreakrr/ui/profile/ProfileView.kt
+++ b/app/src/main/java/com/github/se/icebreakrr/ui/profile/ProfileView.kt
@@ -11,6 +11,7 @@ import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
@@ -66,7 +67,7 @@ fun ProfileView(
 
                 // 2 sections one for the profile image with overlay and
                 // one for the information section
-                ProfileHeader(profile, navigationActions, true) {
+                ProfileHeader(profile, navigationActions, true,profilesViewModel) {
                   navigationActions.navigateTo(Screen.PROFILE_EDIT)
                 }
                 InfoSection(profile, tagsViewModel)

--- a/app/src/main/java/com/github/se/icebreakrr/ui/profile/ProfileView.kt
+++ b/app/src/main/java/com/github/se/icebreakrr/ui/profile/ProfileView.kt
@@ -11,7 +11,6 @@ import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
-import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
@@ -67,7 +66,7 @@ fun ProfileView(
 
                 // 2 sections one for the profile image with overlay and
                 // one for the information section
-                ProfileHeader(profile, navigationActions, true,profilesViewModel) {
+                ProfileHeader(profile, navigationActions, true, profilesViewModel) {
                   navigationActions.navigateTo(Screen.PROFILE_EDIT)
                 }
                 InfoSection(profile, tagsViewModel)

--- a/app/src/main/java/com/github/se/icebreakrr/ui/sections/AroundYou.kt
+++ b/app/src/main/java/com/github/se/icebreakrr/ui/sections/AroundYou.kt
@@ -82,8 +82,8 @@ fun AroundYouScreen(
             tagsViewModel = tagsViewModel,
             isRefreshing = isLoading.value,
             onRefresh = { center, radius, genders, ageRange, tags ->
-                profilesViewModel.getSelfProfile()
-                profilesViewModel.getFilteredProfilesInRadius(center, radius, genders, ageRange, tags)
+              profilesViewModel.getSelfProfile()
+              profilesViewModel.getFilteredProfilesInRadius(center, radius, genders, ageRange, tags)
             },
             modifier = Modifier.padding(innerPadding)) {
               LazyColumn(

--- a/app/src/main/java/com/github/se/icebreakrr/ui/sections/AroundYou.kt
+++ b/app/src/main/java/com/github/se/icebreakrr/ui/sections/AroundYou.kt
@@ -81,7 +81,10 @@ fun AroundYouScreen(
             filterViewModel = filterViewModel,
             tagsViewModel = tagsViewModel,
             isRefreshing = isLoading.value,
-            onRefresh = profilesViewModel::getFilteredProfilesInRadius,
+            onRefresh = { center, radius, genders, ageRange, tags ->
+                profilesViewModel.getSelfProfile()
+                profilesViewModel.getFilteredProfilesInRadius(center, radius, genders, ageRange, tags)
+            },
             modifier = Modifier.padding(innerPadding)) {
               LazyColumn(
                   contentPadding = PaddingValues(vertical = 16.dp),

--- a/app/src/main/java/com/github/se/icebreakrr/ui/sections/shared/DisplayProfile.kt
+++ b/app/src/main/java/com/github/se/icebreakrr/ui/sections/shared/DisplayProfile.kt
@@ -27,6 +27,8 @@ import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
@@ -51,6 +53,7 @@ import androidx.compose.ui.window.Dialog
 import coil.compose.AsyncImage
 import com.github.se.icebreakrr.R
 import com.github.se.icebreakrr.model.profile.Profile
+import com.github.se.icebreakrr.model.profile.ProfilesViewModel
 import com.github.se.icebreakrr.model.profile.reportType
 import com.github.se.icebreakrr.model.tags.TagsViewModel
 import com.github.se.icebreakrr.ui.navigation.NavigationActions
@@ -59,6 +62,8 @@ import com.github.se.icebreakrr.ui.tags.TagStyle
 import com.github.se.icebreakrr.ui.theme.IceBreakrrBlue
 import com.github.se.icebreakrr.utils.NetworkUtils.isNetworkAvailable
 import com.github.se.icebreakrr.utils.NetworkUtils.showNoInternetToast
+import com.google.firebase.Firebase
+import com.google.firebase.auth.auth
 
 private const val ASPECT_RATIO_SQUARE = 1f
 private const val MAX_DIALOG_WIDTH_FACTOR = 0.95f
@@ -147,6 +152,7 @@ fun ProfileHeader(
     profile: Profile,
     navigationActions: NavigationActions,
     myProfile: Boolean,
+    profilesViewModel: ProfilesViewModel,
     onEditClick: () -> Unit
 ) {
 
@@ -368,13 +374,18 @@ fun ProfileHeader(
                                   }
                               TextButton(
                                   onClick = {
+                                      if (isNetworkAvailable(context = context)) {
+                                        profilesViewModel.blockUser(profile.uid)
+                                        Toast.makeText(
+                                            context,
+                                            R.string.block_success_message,
+                                            Toast.LENGTH_SHORT)
+                                            .show()
+                                      } else{
+                                        showNoInternetToast(context = context)
+                                      }
                                     showBlockConfirmation = false
                                     blockReportModal = false
-                                    Toast.makeText(
-                                            context,
-                                            context.getString(R.string.block_success_message),
-                                            Toast.LENGTH_SHORT)
-                                        .show()
                                   }) {
                                     Text(stringResource(R.string.block))
                                   }

--- a/app/src/main/java/com/github/se/icebreakrr/ui/sections/shared/DisplayProfile.kt
+++ b/app/src/main/java/com/github/se/icebreakrr/ui/sections/shared/DisplayProfile.kt
@@ -27,8 +27,6 @@ import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.LaunchedEffect
-import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
@@ -62,8 +60,6 @@ import com.github.se.icebreakrr.ui.tags.TagStyle
 import com.github.se.icebreakrr.ui.theme.IceBreakrrBlue
 import com.github.se.icebreakrr.utils.NetworkUtils.isNetworkAvailable
 import com.github.se.icebreakrr.utils.NetworkUtils.showNoInternetToast
-import com.google.firebase.Firebase
-import com.google.firebase.auth.auth
 
 private const val ASPECT_RATIO_SQUARE = 1f
 private const val MAX_DIALOG_WIDTH_FACTOR = 0.95f
@@ -374,16 +370,16 @@ fun ProfileHeader(
                                   }
                               TextButton(
                                   onClick = {
-                                      if (isNetworkAvailable(context = context)) {
-                                        profilesViewModel.blockUser(profile.uid)
-                                        Toast.makeText(
-                                            context,
-                                            R.string.block_success_message,
-                                            Toast.LENGTH_SHORT)
-                                            .show()
-                                      } else{
-                                        showNoInternetToast(context = context)
-                                      }
+                                    if (isNetworkAvailable(context = context)) {
+                                      profilesViewModel.blockUser(profile.uid)
+                                      Toast.makeText(
+                                              context,
+                                              R.string.block_success_message,
+                                              Toast.LENGTH_SHORT)
+                                          .show()
+                                    } else {
+                                      showNoInternetToast(context = context)
+                                    }
                                     showBlockConfirmation = false
                                     blockReportModal = false
                                   }) {


### PR DESCRIPTION
# New Feature: Block Users

### **You can now really block a user!** 
##### (I already blocked @BotondAKovacs after his last review on my PR)
<img src="https://github.com/user-attachments/assets/0f31be3d-0fce-4a74-b725-c7adf75409e1" width="200" />
---

## **How does it work?**

The `Profile` data class has been updated to include a `hasBlocked` field, which is a `List<String>` containing the user IDs of any users you have blocked.

### **Implementation Details:**
- **ProfilesViewModel Update:** 
  - The `ProfilesViewModel` has been enhanced to simultaneously retrieve the displayed user and the current phone's user.
  - To refresh the user's own profile, call `profilesViewModel.getSelfProfile()`. This will update `profilesViewModel.selfProfile` with the `Profile` of the user on the device (retrieved from `Firebase.auth.uid`).

- **Blocking Method:**
  - The blocking functionality is implemented in `ProfilesViewModel`. It works by updating the `hasBlocked` list of the phone's user `Profile` to include the `selectedProfile`. 

### ⚠️ **Caution:**
- **One-Way Blocking Only:** Currently, blocking a user is only one-way. There's no screen yet to view or unblock users you've blocked. You have to remove them manually in Firebase.

---

## **Next Steps:**
- Adapt `ProfileView` and `ProfileEdit` to directly use `selfProfile` instead of `selectedProfile`.
- Update the tests to reflect these changes, and potentially add more tests to improve coverage. (Our current line coverage is 86%, aiming for 💯)
- Implement an unblock screen (planned for Milestone 3).
- Do the implementation of the report-user (which is slightly more complicated, but this PR prepares the field well) 
