### PR TITLE
Fix/navigation fix

### DIFF
--- a/app/src/androidTest/java/com/github/se/icebreakrr/ui/profile/profileEditTest.kt
+++ b/app/src/androidTest/java/com/github/se/icebreakrr/ui/profile/profileEditTest.kt
@@ -2,6 +2,7 @@ package com.github.se.icebreakrr.ui.profile
 
 import androidx.compose.ui.test.*
 import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.test.espresso.Espresso
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.github.se.icebreakrr.mock.MockProfileViewModel
 import com.github.se.icebreakrr.mock.getMockedProfiles
@@ -106,6 +107,26 @@ class ProfileEditingScreenTest {
   }
 
   @Test
+  fun testDisplayDialogOnUnsavedChanges() {
+    composeTestRule.setContent {
+      ProfileEditingScreen(navigationActions, tagsViewModel, fakeProfilesViewModel)
+    }
+
+    // Make changes to the profile
+    composeTestRule.onNodeWithTag("catchphrase").performTextInput("New Catchphrase")
+    composeTestRule.onNodeWithTag("description").performTextInput("New Description")
+
+    // quit keyboard
+    Espresso.pressBack()
+
+    // Simulate system back button press
+    composeTestRule.onNodeWithTag("goBackButton").performClick()
+
+    // Verify that the dialog was displayed
+    composeTestRule.onNodeWithTag("alertDialog").assertIsDisplayed()
+  }
+
+  @Test
   fun testSaveOfChanges() {
     composeTestRule.setContent {
       ProfileEditingScreen(navigationActions, tagsViewModel, fakeProfilesViewModel)
@@ -113,6 +134,39 @@ class ProfileEditingScreenTest {
 
     composeTestRule.onNodeWithTag("checkButton").performClick()
     verify(navigationActions).goBack()
+  }
+
+  @Test
+  fun testSystemNoSaveOfChangesWithoutChanges() {
+    composeTestRule.setContent {
+      ProfileEditingScreen(navigationActions, tagsViewModel, fakeProfilesViewModel)
+    }
+
+    // Simulate system back button press
+    Espresso.pressBack()
+
+    // Verify that the back navigation was handled
+    verify(navigationActions).goBack()
+  }
+
+  @Test
+  fun testSystemDisplayDialogOnUnsavedChanges() {
+    composeTestRule.setContent {
+      ProfileEditingScreen(navigationActions, tagsViewModel, fakeProfilesViewModel)
+    }
+
+    // Make changes to the profile
+    composeTestRule.onNodeWithTag("catchphrase").performTextInput("New Catchphrase")
+    composeTestRule.onNodeWithTag("description").performTextInput("New Description")
+
+    // quit keyboard
+    Espresso.pressBack()
+
+    // Simulate system back button press
+    Espresso.pressBack()
+
+    // Verify that the dialog was displayed
+    composeTestRule.onNodeWithTag("alertDialog").assertIsDisplayed()
   }
 
   @Test

--- a/app/src/androidTest/java/com/github/se/icebreakrr/ui/sections/FilterScreenTest.kt
+++ b/app/src/androidTest/java/com/github/se/icebreakrr/ui/sections/FilterScreenTest.kt
@@ -16,6 +16,7 @@ import androidx.compose.ui.test.onNodeWithText
 import androidx.compose.ui.test.performClick
 import androidx.compose.ui.test.performTextClearance
 import androidx.compose.ui.test.performTextInput
+import androidx.test.espresso.Espresso
 import com.github.se.icebreakrr.model.filter.FilterViewModel
 import com.github.se.icebreakrr.model.profile.ProfilePicRepositoryStorage
 import com.github.se.icebreakrr.model.profile.ProfilesRepository
@@ -467,6 +468,32 @@ class FilterScreenTest {
 
     // Test confirm button (Discard changes)
     composeTestRule.onNodeWithText("Discard changes").performClick()
+    composeTestRule.onNodeWithTag("alertDialog").assertDoesNotExist()
+    verify(navigationActionsMock).goBack()
+  }
+
+  @Test
+  fun testSystemBackButtonShowsDialogOnUnsavedChanges() {
+    composeTestRule.setContent { FilterScreen(navigationActionsMock) }
+
+    // Make some changes to trigger the dialog
+    composeTestRule.onNodeWithTag("GenderButtonMen").performClick()
+
+    // Simulate system back button press
+    Espresso.pressBack()
+
+    // Verify dialog is shown
+    composeTestRule.onNodeWithTag("alertDialog").assertExists().assertIsDisplayed()
+  }
+
+  @Test
+  fun testSystemBackButtonDoesNotShowDialogWithoutUnsavedChanges() {
+    composeTestRule.setContent { FilterScreen(navigationActionsMock) }
+
+    // Simulate system back button press without making any changes
+    Espresso.pressBack()
+
+    // Verify dialog is not shown and navigation action is called
     composeTestRule.onNodeWithTag("alertDialog").assertDoesNotExist()
     verify(navigationActionsMock).goBack()
   }

--- a/app/src/main/java/com/github/se/icebreakrr/ui/navigation/NavigationAction.kt
+++ b/app/src/main/java/com/github/se/icebreakrr/ui/navigation/NavigationAction.kt
@@ -1,6 +1,5 @@
 package com.github.se.icebreakrr.ui.navigation
 
-import androidx.navigation.NavGraph.Companion.findStartDestination
 import androidx.navigation.NavHostController
 
 open class NavigationActions(

--- a/app/src/main/java/com/github/se/icebreakrr/ui/navigation/NavigationAction.kt
+++ b/app/src/main/java/com/github/se/icebreakrr/ui/navigation/NavigationAction.kt
@@ -15,7 +15,7 @@ open class NavigationActions(
    */
   open fun navigateTo(destination: TopLevelDestination) {
     navController.navigate(destination.route) {
-      popUpTo(navController.graph.findStartDestination().id) {
+      popUpTo(0) {
         saveState = true
         inclusive = true
       }

--- a/app/src/main/java/com/github/se/icebreakrr/ui/profile/ProfileEdit.kt
+++ b/app/src/main/java/com/github/se/icebreakrr/ui/profile/ProfileEdit.kt
@@ -2,6 +2,7 @@ package com.github.se.icebreakrr.ui.profile
 
 import android.annotation.SuppressLint
 import android.widget.Toast
+import androidx.activity.compose.BackHandler
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
@@ -44,9 +45,10 @@ import com.github.se.icebreakrr.model.profile.ProfilesViewModel
 import com.github.se.icebreakrr.model.tags.TagsViewModel
 import com.github.se.icebreakrr.ui.navigation.NavigationActions
 import com.github.se.icebreakrr.ui.sections.shared.UnsavedChangesDialog
+import com.github.se.icebreakrr.ui.sections.shared.handleSafeBackNavigation
 import com.github.se.icebreakrr.ui.tags.TagSelector
-import com.google.firebase.Firebase
-import com.google.firebase.auth.auth
+import com.google.firebase.auth.ktx.auth
+import com.google.firebase.ktx.Firebase
 
 @SuppressLint("UnrememberedMutableState", "CoroutineCreationDuringComposition")
 @OptIn(ExperimentalMaterial3Api::class)
@@ -114,12 +116,11 @@ fun ProfileEditingScreen(
                 IconButton(
                     modifier = Modifier.testTag("goBackButton"),
                     onClick = {
-                      if (isModified) {
-                        showDialog = true
-                      } else {
-                        tagsViewModel.leaveUI()
-                        navigationActions.goBack()
-                      }
+                      handleSafeBackNavigation(
+                          isModified = isModified,
+                          setShowDialog = { showDialog = it },
+                          tagsViewModel = tagsViewModel,
+                          navigationActions = navigationActions)
                     }) {
                       Icon(Icons.Default.ArrowBack, contentDescription = "Back")
                     }
@@ -234,5 +235,14 @@ fun ProfileEditingScreen(
                     })
               }
         }
+  }
+
+  // allows the user to navigate back safely with system back button
+  BackHandler {
+    handleSafeBackNavigation(
+        isModified = isModified,
+        setShowDialog = { showDialog = it },
+        tagsViewModel = tagsViewModel,
+        navigationActions = navigationActions)
   }
 }

--- a/app/src/main/java/com/github/se/icebreakrr/ui/sections/Filter.kt
+++ b/app/src/main/java/com/github/se/icebreakrr/ui/sections/Filter.kt
@@ -1,6 +1,7 @@
 package com.github.se.icebreakrr.ui.sections
 
 import android.widget.Toast
+import androidx.activity.compose.BackHandler
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.interaction.MutableInteractionSource
 import androidx.compose.foundation.layout.Arrangement
@@ -59,6 +60,7 @@ import com.github.se.icebreakrr.model.profile.ProfilesViewModel
 import com.github.se.icebreakrr.model.tags.TagsViewModel
 import com.github.se.icebreakrr.ui.navigation.NavigationActions
 import com.github.se.icebreakrr.ui.sections.shared.UnsavedChangesDialog
+import com.github.se.icebreakrr.ui.sections.shared.handleSafeBackNavigation
 import com.github.se.icebreakrr.ui.tags.TagSelector
 import com.github.se.icebreakrr.ui.theme.Grey
 import com.github.se.icebreakrr.ui.theme.IceBreakrrBlue
@@ -245,6 +247,14 @@ fun FilterScreen(
     }
   }
 
+  BackHandler {
+    handleSafeBackNavigation(
+        isModified = isModified,
+        setShowDialog = { showDialog = it },
+        tagsViewModel = tagsViewModel,
+        navigationActions = navigationActions)
+  }
+
   Scaffold(
       topBar = {
         TopAppBar(
@@ -255,12 +265,11 @@ fun FilterScreen(
             navigationIcon = {
               IconButton(
                   onClick = {
-                    if (isModified) {
-                      showDialog = true
-                    } else {
-                      tagsViewModel.leaveUI()
-                      navigationActions.goBack()
-                    }
+                    handleSafeBackNavigation(
+                        isModified = isModified,
+                        setShowDialog = { showDialog = it },
+                        tagsViewModel = tagsViewModel,
+                        navigationActions = navigationActions)
                   },
                   modifier = Modifier.testTag("Back Button")) {
                     Icon(

--- a/app/src/main/java/com/github/se/icebreakrr/ui/sections/shared/NavigationUtils.kt
+++ b/app/src/main/java/com/github/se/icebreakrr/ui/sections/shared/NavigationUtils.kt
@@ -1,0 +1,27 @@
+package com.github.se.icebreakrr.ui.sections.shared
+
+import com.github.se.icebreakrr.model.tags.TagsViewModel
+import com.github.se.icebreakrr.ui.navigation.NavigationActions
+
+/**
+ * Handles the back navigation action. If there are unsaved changes, it shows a confirmation dialog.
+ * Otherwise, it navigates back to the previous screen.
+ *
+ * @param isModified A boolean indicating if there are unsaved changes.
+ * @param setShowDialog A lambda function to update the showDialog state.
+ * @param tagsViewModel The ViewModel for managing tags.
+ * @param navigationActions The navigation actions for navigating between screens.
+ */
+fun handleSafeBackNavigation(
+    isModified: Boolean,
+    setShowDialog: (Boolean) -> Unit,
+    tagsViewModel: TagsViewModel,
+    navigationActions: NavigationActions
+) {
+  if (isModified) {
+    setShowDialog(true)
+  } else {
+    tagsViewModel.leaveUI()
+    navigationActions.goBack()
+  }
+}


### PR DESCRIPTION
# Navigation fix
## what's new
This pull request is a simple fix to the two following bugs:
* The phone's "back button" was bypassing the confirmation popup
* navigating from a top level screen to another was possible by tapping on the phone's "back button"
I added tests for new code (and also completed the ProfileEdit test suit)

## Implementation
I created the utility function `handleSafeBackNavigation` in [section.shared.NavigationUtils.kt](https://github.com/Swent-team-6/icebreakrr/blob/2769d0391a968b82c62674b24507c455fa564e21/app/src/main/java/com/github/se/icebreakrr/ui/sections/shared/NavigationUtils.kt) file to generalize the behavior of going back when a confirmation may appear. This function is then used both in `ProfileEdit.kt` and `Filter.kt` when clicking on our app's back arrow and in a so called `BackHandler` that adds the desired behavior to the system "back button"

## To go further 
It may be a good idea to implement the "press back again to quit the app" Toast to avoid frustration, because right now going back from a top level almost feels like getting catapulted out of the app (it is the desired navigation behavior, but it could be better). 
