### PR TITLE
Feature/toggle location

### DIFF
--- a/app/src/androidTest/java/com/github/se/icebreakrr/ui/navigation/NavigationTest.kt
+++ b/app/src/androidTest/java/com/github/se/icebreakrr/ui/navigation/NavigationTest.kt
@@ -97,14 +97,15 @@ class NavigationTest {
   @Test
   fun testNavigationLogin() = runTest {
     composeTestRule.setContent {
-      IcebreakrrNavHost(
-          mockProfileViewModel,
-          tagsViewModel,
-          mockFilterViewModel,
-          mockMeetingRequestViewModel,
-          appDataStore,
-          locationViewModel,
-          Route.AUTH)
+        IcebreakrrNavHost(
+            mockProfileViewModel,
+            tagsViewModel,
+            mockFilterViewModel,
+            mockMeetingRequestViewModel,
+            appDataStore,
+            Route.AUTH,
+            locationViewModel,
+            mockPermissionManager)
     }
 
     // Assert that the login screen is shown on launch
@@ -120,8 +121,9 @@ class NavigationTest {
           mockFilterViewModel,
           mockMeetingRequestViewModel,
           appDataStore,
+            Route.AUTH,
           locationViewModel,
-          Route.AROUND_YOU)
+          mockPermissionManager)
     }
 
     // Check that the "Around You" screen is displayed after login

--- a/app/src/androidTest/java/com/github/se/icebreakrr/ui/navigation/NavigationTest.kt
+++ b/app/src/androidTest/java/com/github/se/icebreakrr/ui/navigation/NavigationTest.kt
@@ -13,12 +13,14 @@ import com.github.se.icebreakrr.R
 import com.github.se.icebreakrr.data.AppDataStore
 import com.github.se.icebreakrr.mock.MockProfileViewModel
 import com.github.se.icebreakrr.model.filter.FilterViewModel
+import com.github.se.icebreakrr.model.location.LocationViewModel
 import com.github.se.icebreakrr.model.message.MeetingRequestViewModel
 import com.github.se.icebreakrr.model.profile.ProfilePicRepositoryStorage
 import com.github.se.icebreakrr.model.profile.ProfilesRepository
 import com.github.se.icebreakrr.model.profile.ProfilesViewModel
 import com.github.se.icebreakrr.model.tags.TagsRepository
 import com.github.se.icebreakrr.model.tags.TagsViewModel
+import com.github.se.icebreakrr.utils.PermissionManager
 import com.google.firebase.functions.FirebaseFunctions
 import com.google.firebase.storage.FirebaseStorage
 import java.io.File
@@ -53,6 +55,8 @@ class NavigationTest {
   private lateinit var mockFilterViewModel: FilterViewModel
   private lateinit var testDataStore: DataStore<Preferences>
   private lateinit var appDataStore: AppDataStore
+  private lateinit var mockLocationViewModel: LocationViewModel
+  private lateinit var mockPermissionManager: PermissionManager
 
   @Before
   fun setup() {
@@ -75,6 +79,8 @@ class NavigationTest {
     tagsViewModel = TagsViewModel(mockTagsRepository)
     profilesViewModel =
         ProfilesViewModel(mockProfilesRepository, ProfilePicRepositoryStorage(mockFirebaseStorage))
+    mockLocationViewModel = mock(LocationViewModel::class.java)
+    mockPermissionManager = mock(PermissionManager::class.java)
   }
 
   @Test
@@ -86,7 +92,9 @@ class NavigationTest {
           mockFilterViewModel,
           mockMeetingRequestViewModel,
           appDataStore,
-          Route.AUTH)
+          Route.AUTH,
+          mockLocationViewModel,
+          mockPermissionManager)
     }
 
     // Assert that the login screen is shown on launch
@@ -102,7 +110,9 @@ class NavigationTest {
           mockFilterViewModel,
           mockMeetingRequestViewModel,
           appDataStore,
-          Route.AROUND_YOU)
+          Route.AROUND_YOU,
+          mockLocationViewModel,
+          mockPermissionManager)
     }
 
     // Check that the "Around You" screen is displayed after login

--- a/app/src/androidTest/java/com/github/se/icebreakrr/ui/sections/AroundYouTest.kt
+++ b/app/src/androidTest/java/com/github/se/icebreakrr/ui/sections/AroundYouTest.kt
@@ -73,8 +73,8 @@ class AroundYouScreenTest {
           profilesViewModel,
           viewModel(factory = TagsViewModel.Factory),
           viewModel(factory = FilterViewModel.Factory),
-        mockPermissionManager,
-        mockAppDataStore)
+          mockPermissionManager,
+          mockAppDataStore)
     }
 
     // Trigger initial connection check

--- a/app/src/androidTest/java/com/github/se/icebreakrr/ui/sections/AroundYouTest.kt
+++ b/app/src/androidTest/java/com/github/se/icebreakrr/ui/sections/AroundYouTest.kt
@@ -9,6 +9,7 @@ import androidx.compose.ui.test.performClick
 import androidx.compose.ui.test.performTouchInput
 import androidx.lifecycle.viewmodel.compose.viewModel
 import androidx.test.espresso.action.ViewActions.swipeDown
+import com.github.se.icebreakrr.data.AppDataStore
 import com.github.se.icebreakrr.model.filter.FilterViewModel
 import com.github.se.icebreakrr.model.profile.Gender
 import com.github.se.icebreakrr.model.profile.Profile
@@ -19,6 +20,7 @@ import com.github.se.icebreakrr.model.tags.TagsViewModel
 import com.github.se.icebreakrr.ui.navigation.NavigationActions
 import com.github.se.icebreakrr.ui.navigation.Route
 import com.github.se.icebreakrr.ui.navigation.Screen
+import com.github.se.icebreakrr.utils.PermissionManager
 import com.google.firebase.Timestamp
 import com.google.firebase.firestore.GeoPoint
 import java.util.Calendar
@@ -38,6 +40,8 @@ class AroundYouScreenTest {
   private lateinit var mockProfilesRepository: ProfilesRepository
   private lateinit var mockPPRepository: ProfilePicRepository
   private lateinit var profilesViewModel: ProfilesViewModel
+  private lateinit var mockAppDataStore: AppDataStore
+  private lateinit var mockPermissionManager: PermissionManager
 
   @get:Rule val composeTestRule = createComposeRule()
 
@@ -68,7 +72,9 @@ class AroundYouScreenTest {
           navigationActions,
           profilesViewModel,
           viewModel(factory = TagsViewModel.Factory),
-          viewModel(factory = FilterViewModel.Factory))
+          viewModel(factory = FilterViewModel.Factory),
+        mockPermissionManager,
+        mockAppDataStore)
     }
 
     // Trigger initial connection check

--- a/app/src/androidTest/java/com/github/se/icebreakrr/ui/sections/SettingsTest.kt
+++ b/app/src/androidTest/java/com/github/se/icebreakrr/ui/sections/SettingsTest.kt
@@ -10,6 +10,7 @@ import androidx.datastore.core.DataStore
 import androidx.datastore.preferences.core.PreferenceDataStoreFactory
 import androidx.datastore.preferences.core.Preferences
 import com.github.se.icebreakrr.data.AppDataStore
+import com.github.se.icebreakrr.model.location.LocationViewModel
 import com.github.se.icebreakrr.model.profile.ProfilePicRepositoryStorage
 import com.github.se.icebreakrr.model.profile.ProfilesRepository
 import com.github.se.icebreakrr.model.profile.ProfilesViewModel
@@ -49,6 +50,7 @@ class SettingsTest {
   private lateinit var mockProfilesRepository: ProfilesRepository
   private lateinit var testDataStore: DataStore<Preferences>
   private lateinit var appDataStore: AppDataStore
+  private lateinit var mockLocationViewModel: LocationViewModel
 
   @Before
   fun setUp() {
@@ -82,7 +84,7 @@ class SettingsTest {
   @Test
   fun testProfileSettingsScreenDisplaysCorrectly() = runTest {
     composeTestRule.setContent {
-      SettingsScreen(profilesViewModel, navigationActionsMock, appDataStore)
+      SettingsScreen(profilesViewModel, navigationActionsMock, mockLocationViewModel, appDataStore)
     }
 
     // Assert that the top bar is displayed
@@ -105,7 +107,7 @@ class SettingsTest {
   @Test
   fun testNavigationActionsOnProfileCardClick() = runTest {
     composeTestRule.setContent {
-      SettingsScreen(profilesViewModel, navigationActionsMock, appDataStore)
+      SettingsScreen(profilesViewModel, navigationActionsMock, mockLocationViewModel, appDataStore)
     }
 
     composeTestRule.onNodeWithTag("profileCard").performClick()
@@ -118,7 +120,7 @@ class SettingsTest {
     appDataStore.saveDiscoverableStatus(false)
 
     composeTestRule.setContent {
-      SettingsScreen(profilesViewModel, navigationActionsMock, appDataStore)
+      SettingsScreen(profilesViewModel, navigationActionsMock, mockLocationViewModel, appDataStore)
     }
 
     // Initial state check

--- a/app/src/main/java/com/github/se/icebreakrr/MainActivity.kt
+++ b/app/src/main/java/com/github/se/icebreakrr/MainActivity.kt
@@ -113,7 +113,7 @@ class MainActivity : ComponentActivity() {
       CompositionLocalProvider(LocalIsTesting provides isTesting) {
         SampleAppTheme {
           Surface(modifier = Modifier.fillMaxSize()) {
-            IcebreakrrApp(auth, functions, appDataStore)
+            IcebreakrrApp(auth, functions,appDataStore, locationViewModel, permissionManager)
           }
         }
       }
@@ -164,10 +164,11 @@ class MainActivity : ComponentActivity() {
  * @see NotificationScreen
  */
 @Composable
-fun IcebreakrrApp(auth: FirebaseAuth, functions: FirebaseFunctions, appDataStore: AppDataStore) {
+fun IcebreakrrApp(auth: FirebaseAuth, functions: FirebaseFunctions, appDataStore: AppDataStore, locationViewModel: LocationViewModel, permissionManager : PermissionManager) {
   val profileViewModel: ProfilesViewModel = viewModel(factory = ProfilesViewModel.Factory)
   val tagsViewModel: TagsViewModel = viewModel(factory = TagsViewModel.Factory)
   val filterViewModel: FilterViewModel = viewModel(factory = FilterViewModel.Factory)
+
   var userName: String? = "null"
   var userUid: String? = "null"
   MeetingRequestManager.meetingRequestViewModel =
@@ -183,7 +184,9 @@ fun IcebreakrrApp(auth: FirebaseAuth, functions: FirebaseFunctions, appDataStore
       filterViewModel,
       meetingRequestViewModel,
       appDataStore,
-      Route.AUTH)
+      Route.AUTH,
+      locationViewModel,
+      permissionManager)
 }
 
 @Composable
@@ -193,7 +196,9 @@ fun IcebreakrrNavHost(
     filterViewModel: FilterViewModel,
     meetingRequestViewModel: MeetingRequestViewModel?,
     appDataStore: AppDataStore,
-    startDestination: String
+    startDestination: String,
+    locationViewModel: LocationViewModel,
+    permissionManager: PermissionManager
 ) {
   val navController = rememberNavController()
   val navigationActions = NavigationActions(navController)
@@ -226,7 +231,8 @@ fun IcebreakrrNavHost(
         route = Route.AROUND_YOU,
     ) {
       composable(Screen.AROUND_YOU) {
-        AroundYouScreen(navigationActions, profileViewModel, tagsViewModel, filterViewModel)
+        AroundYouScreen(
+            navigationActions, profileViewModel, tagsViewModel, filterViewModel, permissionManager, appDataStore)
       }
       composable(Screen.OTHER_PROFILE_VIEW + "?userId={userId}") { navBackStackEntry ->
         if (meetingRequestViewModel != null) {
@@ -248,7 +254,7 @@ fun IcebreakrrNavHost(
         route = Route.SETTINGS,
     ) {
       composable(Screen.SETTINGS) {
-        SettingsScreen(profileViewModel, navigationActions, appDataStore = appDataStore)
+        SettingsScreen(profileViewModel, navigationActions, locationViewModel, appDataStore)
       }
       composable(Screen.PROFILE) { ProfileView(profileViewModel, tagsViewModel, navigationActions) }
     }

--- a/app/src/main/java/com/github/se/icebreakrr/MainActivity.kt
+++ b/app/src/main/java/com/github/se/icebreakrr/MainActivity.kt
@@ -113,7 +113,7 @@ class MainActivity : ComponentActivity() {
       CompositionLocalProvider(LocalIsTesting provides isTesting) {
         SampleAppTheme {
           Surface(modifier = Modifier.fillMaxSize()) {
-            IcebreakrrApp(auth, functions,appDataStore, locationViewModel, permissionManager)
+            IcebreakrrApp(auth, functions, appDataStore, locationViewModel, permissionManager)
           }
         }
       }
@@ -164,7 +164,13 @@ class MainActivity : ComponentActivity() {
  * @see NotificationScreen
  */
 @Composable
-fun IcebreakrrApp(auth: FirebaseAuth, functions: FirebaseFunctions, appDataStore: AppDataStore, locationViewModel: LocationViewModel, permissionManager : PermissionManager) {
+fun IcebreakrrApp(
+    auth: FirebaseAuth,
+    functions: FirebaseFunctions,
+    appDataStore: AppDataStore,
+    locationViewModel: LocationViewModel,
+    permissionManager: PermissionManager
+) {
   val profileViewModel: ProfilesViewModel = viewModel(factory = ProfilesViewModel.Factory)
   val tagsViewModel: TagsViewModel = viewModel(factory = TagsViewModel.Factory)
   val filterViewModel: FilterViewModel = viewModel(factory = FilterViewModel.Factory)
@@ -232,7 +238,12 @@ fun IcebreakrrNavHost(
     ) {
       composable(Screen.AROUND_YOU) {
         AroundYouScreen(
-            navigationActions, profileViewModel, tagsViewModel, filterViewModel, permissionManager, appDataStore)
+            navigationActions,
+            profileViewModel,
+            tagsViewModel,
+            filterViewModel,
+            permissionManager,
+            appDataStore)
       }
       composable(Screen.OTHER_PROFILE_VIEW + "?userId={userId}") { navBackStackEntry ->
         if (meetingRequestViewModel != null) {

--- a/app/src/main/java/com/github/se/icebreakrr/MainActivity.kt
+++ b/app/src/main/java/com/github/se/icebreakrr/MainActivity.kt
@@ -42,6 +42,7 @@ import com.github.se.icebreakrr.ui.sections.FilterScreen
 import com.github.se.icebreakrr.ui.sections.NotificationScreen
 import com.github.se.icebreakrr.ui.sections.SettingsScreen
 import com.github.se.icebreakrr.ui.theme.SampleAppTheme
+import com.github.se.icebreakrr.utils.IPermissionManager
 import com.github.se.icebreakrr.utils.NetworkUtils
 import com.github.se.icebreakrr.utils.PermissionManager
 import com.google.android.gms.location.FusedLocationProviderClient
@@ -204,7 +205,7 @@ fun IcebreakrrNavHost(
     appDataStore: AppDataStore,
     startDestination: String,
     locationViewModel: LocationViewModel,
-    permissionManager: PermissionManager
+    permissionManager: IPermissionManager
 ) {
   val navController = rememberNavController()
   val navigationActions = NavigationActions(navController)

--- a/app/src/main/java/com/github/se/icebreakrr/ui/sections/AroundYou.kt
+++ b/app/src/main/java/com/github/se/icebreakrr/ui/sections/AroundYou.kt
@@ -44,10 +44,10 @@ import com.github.se.icebreakrr.ui.sections.shared.FilterFloatingActionButton
 import com.github.se.icebreakrr.ui.sections.shared.ProfileCard
 import com.github.se.icebreakrr.ui.sections.shared.TopBar
 import com.github.se.icebreakrr.ui.theme.messageTextColor
+import com.github.se.icebreakrr.utils.IPermissionManager
 import com.github.se.icebreakrr.utils.NetworkUtils.isNetworkAvailable
 import com.github.se.icebreakrr.utils.NetworkUtils.isNetworkAvailableWithContext
 import com.github.se.icebreakrr.utils.NetworkUtils.showNoInternetToast
-import com.github.se.icebreakrr.utils.PermissionManager
 import com.google.firebase.firestore.GeoPoint
 import kotlinx.coroutines.delay
 
@@ -77,7 +77,7 @@ fun AroundYouScreen(
     profilesViewModel: ProfilesViewModel,
     tagsViewModel: TagsViewModel,
     filterViewModel: FilterViewModel,
-    permissionManager: PermissionManager,
+    permissionManager: IPermissionManager,
     appDataStore: AppDataStore,
     locationViewModel: LocationViewModel,
     isTestMode: Boolean = false

--- a/app/src/main/java/com/github/se/icebreakrr/ui/sections/AroundYou.kt
+++ b/app/src/main/java/com/github/se/icebreakrr/ui/sections/AroundYou.kt
@@ -28,10 +28,8 @@ import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
-import androidx.datastore.dataStore
 import com.github.se.icebreakrr.data.AppDataStore
 import com.github.se.icebreakrr.model.filter.FilterViewModel
-import com.github.se.icebreakrr.model.location.LocationViewModel
 import com.github.se.icebreakrr.model.profile.Gender
 import com.github.se.icebreakrr.model.profile.ProfilesViewModel
 import com.github.se.icebreakrr.model.tags.TagsViewModel
@@ -80,14 +78,16 @@ fun AroundYouScreen(
     appDataStore: AppDataStore
 ) {
 
-    val permissionStatuses = permissionManager.permissionStatuses.collectAsState()
-    val hasLocationPermission = permissionStatuses.value[android.Manifest.permission.ACCESS_FINE_LOCATION] == PackageManager.PERMISSION_GRANTED
-    val filteredProfiles = profilesViewModel.filteredProfiles.collectAsState()
+  val permissionStatuses = permissionManager.permissionStatuses.collectAsState()
+  val hasLocationPermission =
+      permissionStatuses.value[android.Manifest.permission.ACCESS_FINE_LOCATION] ==
+          PackageManager.PERMISSION_GRANTED
+  val filteredProfiles = profilesViewModel.filteredProfiles.collectAsState()
   val isLoading = profilesViewModel.loading.collectAsState()
   val context = LocalContext.current
   val isConnected = profilesViewModel.isConnected.collectAsState()
-    // Collect the discoverability state from DataStore
-    val isDiscoverable by appDataStore.isDiscoverable.collectAsState(initial = false)
+  // Collect the discoverability state from DataStore
+  val isDiscoverable by appDataStore.isDiscoverable.collectAsState(initial = false)
 
   // Check network state when screen loads
   LaunchedEffect(Unit) {
@@ -131,20 +131,22 @@ fun AroundYouScreen(
                 EmptyProfilePrompt(label = "No Internet Connection", testTag = "noConnectionPrompt")
               } else if (!isDiscoverable) {
                 EmptyProfilePrompt(
-                    label = "Activate location sharing in the app settings!", testTag = "activateLocationPrompt")
+                    label = "Activate location sharing in the app settings!",
+                    testTag = "activateLocationPrompt")
               } else if (!hasLocationPermission) {
                 EmptyProfilePrompt(
-                    label = "Precise location permission is required to show profiles. Activate it in your phone settings",
+                    label =
+                        "Precise location permission is required to show profiles. Activate it in your phone settings",
                     testTag = "noLocationPermissionPrompt")
               } else if (filteredProfiles.value.isEmpty()) {
                 EmptyProfilePrompt(
-                    label = "There is no one around. Try moving!",
-                    testTag = "emptyProfilePrompt")
+                    label = "There is no one around. Try moving!", testTag = "emptyProfilePrompt")
               } else {
                 LazyColumn(
-                    contentPadding = PaddingValues( vertical = COLUMN_VERTICAL_PADDING),
+                    contentPadding = PaddingValues(vertical = COLUMN_VERTICAL_PADDING),
                     verticalArrangement = Arrangement.spacedBy(COLUMN_VERTICAL_PADDING),
-                    modifier = Modifier.fillMaxSize().padding(horizontal = COLUMN_HORIZONTAL_PADDING)) {
+                    modifier =
+                        Modifier.fillMaxSize().padding(horizontal = COLUMN_HORIZONTAL_PADDING)) {
                       items(filteredProfiles.value.size) { index ->
                         ProfileCard(
                             profile = filteredProfiles.value[index],

--- a/app/src/main/java/com/github/se/icebreakrr/ui/sections/Settings.kt
+++ b/app/src/main/java/com/github/se/icebreakrr/ui/sections/Settings.kt
@@ -34,6 +34,7 @@ import com.github.se.icebreakrr.authentication.logout
 import com.github.se.icebreakrr.config.LocalIsTesting
 import com.github.se.icebreakrr.data.AppDataStore
 import com.github.se.icebreakrr.mock.getMockedProfiles
+import com.github.se.icebreakrr.model.location.LocationViewModel
 import com.github.se.icebreakrr.model.profile.Profile
 import com.github.se.icebreakrr.model.profile.ProfilesViewModel
 import com.github.se.icebreakrr.ui.navigation.BottomNavigationMenu
@@ -73,6 +74,7 @@ private val CARD_PADDING = 16.dp
 fun SettingsScreen(
     profilesViewModel: ProfilesViewModel,
     navigationActions: NavigationActions,
+    locationViewModel: LocationViewModel,
     appDataStore: AppDataStore
 ) {
   val context = LocalContext.current
@@ -80,7 +82,7 @@ fun SettingsScreen(
   val coroutineScope = rememberCoroutineScope()
 
   // Collect the discoverability state from DataStore
-  val isDiscoverable by appDataStore.isDiscoverable.collectAsState(initial = true)
+  val isDiscoverable by appDataStore.isDiscoverable.collectAsState(initial = false)
 
   lateinit var auth: FirebaseAuth
 
@@ -124,9 +126,13 @@ fun SettingsScreen(
 
           // Display Toggle Options
           ToggleOptionBox(
-              label = "Toggle Discoverability",
+              label = "Toggle location update",
               isChecked = isDiscoverable,
               onCheckedChange = { discoverable ->
+                  when (discoverable) {
+                      true -> locationViewModel.tryToStartLocationUpdates()
+                      false -> locationViewModel.stopLocationUpdates()
+                  }
                 coroutineScope.launch { appDataStore.saveDiscoverableStatus(discoverable) }
               })
           Spacer(modifier = Modifier.height(SPACER_HEIGHT_LARGE))
@@ -172,8 +178,6 @@ fun ToggleOptionBox(
     onCheckedChange: (Boolean) -> Unit,
     modifier: Modifier = Modifier
 ) {
-  // Constants for card styling
-
   Card(
       shape = CARD_SHAPE,
       modifier =

--- a/app/src/main/java/com/github/se/icebreakrr/ui/sections/Settings.kt
+++ b/app/src/main/java/com/github/se/icebreakrr/ui/sections/Settings.kt
@@ -129,10 +129,10 @@ fun SettingsScreen(
               label = "Toggle location update",
               isChecked = isDiscoverable,
               onCheckedChange = { discoverable ->
-                  when (discoverable) {
-                      true -> locationViewModel.tryToStartLocationUpdates()
-                      false -> locationViewModel.stopLocationUpdates()
-                  }
+                when (discoverable) {
+                  true -> locationViewModel.tryToStartLocationUpdates()
+                  false -> locationViewModel.stopLocationUpdates()
+                }
                 coroutineScope.launch { appDataStore.saveDiscoverableStatus(discoverable) }
               })
           Spacer(modifier = Modifier.height(SPACER_HEIGHT_LARGE))


### PR DESCRIPTION
# Toggle location update
## What's new
This PR links the toggle button from the settings screen to the `locationViewmodel` which allows to toggle location update. For now, disabling the location means that other user can still see your profile if they stand at your last known position (where you toggled the switch off). In later updates, the `ProfileViewmodel` will be extended to allow the toggle button to make the user truly invisible to others.
## Codebase changes:
* `Settings.kt`: linked to `LocationViewModel`
* `AroundYou.kt`: Added different empty screens when location update is disabled or permission is not aquired
* `MainActivity.kt`: update components signatures to allow use of `PermissionManager`, `AppDataStore` and `LocationViewModel`

### Special thanks to @arthur-mrgt for his very clean interface for location and permissions