### PR TITLE
Feature/toggle location2

### DIFF
--- a/app/src/androidTest/java/com/github/se/endToEnd/M1_Test.kt
+++ b/app/src/androidTest/java/com/github/se/endToEnd/M1_Test.kt
@@ -2,7 +2,6 @@ package com.github.se.endToEnd
 
 import android.content.Intent
 import androidx.compose.ui.test.assertIsDisplayed
-import androidx.compose.ui.test.assertIsNotDisplayed
 import androidx.compose.ui.test.assertIsNotSelected
 import androidx.compose.ui.test.assertIsSelected
 import androidx.compose.ui.test.assertTextEquals

--- a/app/src/androidTest/java/com/github/se/endToEnd/M1_Test.kt
+++ b/app/src/androidTest/java/com/github/se/endToEnd/M1_Test.kt
@@ -2,6 +2,7 @@ package com.github.se.endToEnd
 
 import android.content.Intent
 import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.assertIsNotDisplayed
 import androidx.compose.ui.test.assertIsNotSelected
 import androidx.compose.ui.test.assertIsSelected
 import androidx.compose.ui.test.assertTextEquals

--- a/app/src/androidTest/java/com/github/se/icebreakrr/ui/navigation/NavigationTest.kt
+++ b/app/src/androidTest/java/com/github/se/icebreakrr/ui/navigation/NavigationTest.kt
@@ -30,6 +30,7 @@ import com.google.firebase.storage.FirebaseStorage
 import java.io.File
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.Job
+import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.test.TestScope
 import kotlinx.coroutines.test.UnconfinedTestDispatcher
 import kotlinx.coroutines.test.runTest
@@ -39,6 +40,7 @@ import org.junit.Test
 import org.junit.rules.TemporaryFolder
 import org.junit.runner.RunWith
 import org.mockito.Mockito.mock
+import org.mockito.Mockito.`when`
 
 @OptIn(ExperimentalCoroutinesApi::class)
 @RunWith(AndroidJUnit4::class)
@@ -98,6 +100,15 @@ class NavigationTest {
 
     locationViewModel =
         LocationViewModel(mockLocationService, mockLocationRepository, mockPermissionManager)
+
+      //mock state flow
+      `when`(mockPermissionManager.permissionStatuses).thenReturn(
+          MutableStateFlow(
+              mapOf(
+                  android.Manifest.permission.ACCESS_FINE_LOCATION to android.content.pm.PackageManager.PERMISSION_GRANTED
+              )
+          )
+      )
   }
 
   @Test
@@ -111,7 +122,9 @@ class NavigationTest {
           appDataStore,
           locationViewModel,
           Route.AUTH,
-          mock(FirebaseAuth::class.java))
+          mock(FirebaseAuth::class.java),
+          mock(IPermissionManager::class.java),
+          true)
     }
 
     // Assert that the login screen is shown on launch
@@ -129,7 +142,9 @@ class NavigationTest {
           appDataStore,
           locationViewModel,
           Route.AROUND_YOU,
-          FirebaseAuth.getInstance())
+          FirebaseAuth.getInstance(),
+          mockPermissionManager,
+          true)
     }
 
     // Check that the "Around You" screen is displayed after login

--- a/app/src/androidTest/java/com/github/se/icebreakrr/ui/navigation/NavigationTest.kt
+++ b/app/src/androidTest/java/com/github/se/icebreakrr/ui/navigation/NavigationTest.kt
@@ -101,14 +101,13 @@ class NavigationTest {
     locationViewModel =
         LocationViewModel(mockLocationService, mockLocationRepository, mockPermissionManager)
 
-      //mock state flow
-      `when`(mockPermissionManager.permissionStatuses).thenReturn(
-          MutableStateFlow(
-              mapOf(
-                  android.Manifest.permission.ACCESS_FINE_LOCATION to android.content.pm.PackageManager.PERMISSION_GRANTED
-              )
-          )
-      )
+    // mock state flow
+    `when`(mockPermissionManager.permissionStatuses)
+        .thenReturn(
+            MutableStateFlow(
+                mapOf(
+                    android.Manifest.permission.ACCESS_FINE_LOCATION to
+                        android.content.pm.PackageManager.PERMISSION_GRANTED)))
   }
 
   @Test

--- a/app/src/androidTest/java/com/github/se/icebreakrr/ui/navigation/NavigationTest.kt
+++ b/app/src/androidTest/java/com/github/se/icebreakrr/ui/navigation/NavigationTest.kt
@@ -43,100 +43,92 @@ import org.mockito.Mockito.`when`
 @OptIn(ExperimentalCoroutinesApi::class)
 @RunWith(AndroidJUnit4::class)
 class NavigationTest {
-    private val testScope = TestScope(UnconfinedTestDispatcher() + Job())
+  private val testScope = TestScope(UnconfinedTestDispatcher() + Job())
 
-    @get:Rule
-    val composeTestRule = createComposeRule()
-    @get:Rule
-    val tempFolder = TemporaryFolder()
+  @get:Rule val composeTestRule = createComposeRule()
+  @get:Rule val tempFolder = TemporaryFolder()
 
-    private lateinit var profilesViewModel: ProfilesViewModel
-    private lateinit var mockProfileViewModel: MockProfileViewModel
-    private lateinit var tagsViewModel: TagsViewModel
-    private lateinit var sortViewModel: SortViewModel
-    private lateinit var mockProfilesRepository: ProfilesRepository
-    private lateinit var mockTagsRepository: TagsRepository
-    private lateinit var mockFirebaseStorage: FirebaseStorage
-    private lateinit var mockMeetingRequestViewModel: MeetingRequestViewModel
-    private lateinit var mockFunction: FirebaseFunctions
-    private lateinit var mockFilterViewModel: FilterViewModel
-    private lateinit var testDataStore: DataStore<Preferences>
-    private lateinit var appDataStore: AppDataStore
+  private lateinit var profilesViewModel: ProfilesViewModel
+  private lateinit var mockProfileViewModel: MockProfileViewModel
+  private lateinit var tagsViewModel: TagsViewModel
+  private lateinit var sortViewModel: SortViewModel
+  private lateinit var mockProfilesRepository: ProfilesRepository
+  private lateinit var mockTagsRepository: TagsRepository
+  private lateinit var mockFirebaseStorage: FirebaseStorage
+  private lateinit var mockMeetingRequestViewModel: MeetingRequestViewModel
+  private lateinit var mockFunction: FirebaseFunctions
+  private lateinit var mockFilterViewModel: FilterViewModel
+  private lateinit var testDataStore: DataStore<Preferences>
+  private lateinit var appDataStore: AppDataStore
 
-    private lateinit var mockLocationService: ILocationService
-    private lateinit var mockLocationRepository: LocationRepository
-    private lateinit var mockPermissionManager: IPermissionManager
+  private lateinit var mockLocationService: ILocationService
+  private lateinit var mockLocationRepository: LocationRepository
+  private lateinit var mockPermissionManager: IPermissionManager
 
-    private lateinit var locationViewModel: LocationViewModel
+  private lateinit var locationViewModel: LocationViewModel
 
-    @Before
-    fun setup() {
-        // Set up real DataStore with test scope
-        testDataStore =
-            PreferenceDataStoreFactory.create(
-                scope = testScope,
-                produceFile = { File(tempFolder.newFolder(), "test_preferences.preferences_pb") })
-        appDataStore = AppDataStore(testDataStore)
+  @Before
+  fun setup() {
+    // Set up real DataStore with test scope
+    testDataStore =
+        PreferenceDataStoreFactory.create(
+            scope = testScope,
+            produceFile = { File(tempFolder.newFolder(), "test_preferences.preferences_pb") })
+    appDataStore = AppDataStore(testDataStore)
 
-        // Initialize mocks and view models
-        mockProfileViewModel = MockProfileViewModel()
-        mockProfilesRepository = mock(ProfilesRepository::class.java)
-        mockFirebaseStorage = mock(FirebaseStorage::class.java)
-        mockFunction = mock(FirebaseFunctions::class.java)
-        mockMeetingRequestViewModel = MeetingRequestViewModel(mockProfileViewModel, mockFunction)
-        mockFilterViewModel = FilterViewModel()
-        tagsViewModel =
-            TagsViewModel(
-                TagsRepository(mock(FirebaseFirestore::class.java), mock(FirebaseAuth::class.java))
-            )
-        profilesViewModel =
-            ProfilesViewModel(
-                mockProfilesRepository,
-                ProfilePicRepositoryStorage(mockFirebaseStorage),
-                mock(FirebaseAuth::class.java)
-            )
+    // Initialize mocks and view models
+    mockProfileViewModel = MockProfileViewModel()
+    mockProfilesRepository = mock(ProfilesRepository::class.java)
+    mockFirebaseStorage = mock(FirebaseStorage::class.java)
+    mockFunction = mock(FirebaseFunctions::class.java)
+    mockMeetingRequestViewModel = MeetingRequestViewModel(mockProfileViewModel, mockFunction)
+    mockFilterViewModel = FilterViewModel()
+    tagsViewModel =
+        TagsViewModel(
+            TagsRepository(mock(FirebaseFirestore::class.java), mock(FirebaseAuth::class.java)))
+    profilesViewModel =
+        ProfilesViewModel(
+            mockProfilesRepository,
+            ProfilePicRepositoryStorage(mockFirebaseStorage),
+            mock(FirebaseAuth::class.java))
 
-        sortViewModel = SortViewModel(profilesViewModel)
-        mockLocationService = mock(ILocationService::class.java)
-        mockLocationRepository = mock(LocationRepository::class.java)
-        mockPermissionManager = mock(IPermissionManager::class.java)
+    sortViewModel = SortViewModel(profilesViewModel)
+    mockLocationService = mock(ILocationService::class.java)
+    mockLocationRepository = mock(LocationRepository::class.java)
+    mockPermissionManager = mock(IPermissionManager::class.java)
 
-        locationViewModel =
-            LocationViewModel(mockLocationService, mockLocationRepository, mockPermissionManager)
+    locationViewModel =
+        LocationViewModel(mockLocationService, mockLocationRepository, mockPermissionManager)
 
-        // mock state flow
-        `when`(mockPermissionManager.permissionStatuses)
-            .thenReturn(
-                MutableStateFlow(
-                    mapOf(
-                        android.Manifest.permission.ACCESS_FINE_LOCATION to
-                                android.content.pm.PackageManager.PERMISSION_GRANTED
-                    )
-                )
-            )
+    // mock state flow
+    `when`(mockPermissionManager.permissionStatuses)
+        .thenReturn(
+            MutableStateFlow(
+                mapOf(
+                    android.Manifest.permission.ACCESS_FINE_LOCATION to
+                        android.content.pm.PackageManager.PERMISSION_GRANTED)))
+  }
+
+  @Test
+  fun testNavigationLogin() = runTest {
+    composeTestRule.setContent {
+      IcebreakrrNavHost(
+          mockProfileViewModel,
+          tagsViewModel,
+          mockFilterViewModel,
+          sortViewModel,
+          mockMeetingRequestViewModel,
+          appDataStore,
+          locationViewModel,
+          Route.AUTH,
+          mock(FirebaseAuth::class.java),
+          mock(IPermissionManager::class.java),
+          true)
     }
 
-    @Test
-    fun testNavigationLogin() = runTest {
-        composeTestRule.setContent {
-            IcebreakrrNavHost(
-                mockProfileViewModel,
-                tagsViewModel,
-                mockFilterViewModel,
-                sortViewModel,
-                mockMeetingRequestViewModel,
-                appDataStore,
-                locationViewModel,
-                Route.AUTH,
-                mock(FirebaseAuth::class.java),
-                mock(IPermissionManager::class.java),
-                true
-            )
-        }
-
-        // Assert that the login screen is shown on launch
-        composeTestRule.onNodeWithTag("loginScreen").assertExists()
-    }
+    // Assert that the login screen is shown on launch
+    composeTestRule.onNodeWithTag("loginScreen").assertExists()
+  }
 }
 
     /**

--- a/app/src/androidTest/java/com/github/se/icebreakrr/ui/navigation/NavigationTest.kt
+++ b/app/src/androidTest/java/com/github/se/icebreakrr/ui/navigation/NavigationTest.kt
@@ -43,108 +43,101 @@ import org.mockito.Mockito.`when`
 @OptIn(ExperimentalCoroutinesApi::class)
 @RunWith(AndroidJUnit4::class)
 class NavigationTest {
-  private val testScope = TestScope(UnconfinedTestDispatcher() + Job())
+    private val testScope = TestScope(UnconfinedTestDispatcher() + Job())
 
-  @get:Rule val composeTestRule = createComposeRule()
-  @get:Rule val tempFolder = TemporaryFolder()
+    @get:Rule
+    val composeTestRule = createComposeRule()
+    @get:Rule
+    val tempFolder = TemporaryFolder()
 
-  private lateinit var profilesViewModel: ProfilesViewModel
-  private lateinit var mockProfileViewModel: MockProfileViewModel
-  private lateinit var tagsViewModel: TagsViewModel
-  private lateinit var sortViewModel: SortViewModel
-  private lateinit var mockProfilesRepository: ProfilesRepository
-  private lateinit var mockTagsRepository: TagsRepository
-  private lateinit var mockFirebaseStorage: FirebaseStorage
-  private lateinit var mockMeetingRequestViewModel: MeetingRequestViewModel
-  private lateinit var mockFunction: FirebaseFunctions
-  private lateinit var mockFilterViewModel: FilterViewModel
-  private lateinit var testDataStore: DataStore<Preferences>
-  private lateinit var appDataStore: AppDataStore
+    private lateinit var profilesViewModel: ProfilesViewModel
+    private lateinit var mockProfileViewModel: MockProfileViewModel
+    private lateinit var tagsViewModel: TagsViewModel
+    private lateinit var sortViewModel: SortViewModel
+    private lateinit var mockProfilesRepository: ProfilesRepository
+    private lateinit var mockTagsRepository: TagsRepository
+    private lateinit var mockFirebaseStorage: FirebaseStorage
+    private lateinit var mockMeetingRequestViewModel: MeetingRequestViewModel
+    private lateinit var mockFunction: FirebaseFunctions
+    private lateinit var mockFilterViewModel: FilterViewModel
+    private lateinit var testDataStore: DataStore<Preferences>
+    private lateinit var appDataStore: AppDataStore
 
-  private lateinit var mockLocationService: ILocationService
-  private lateinit var mockLocationRepository: LocationRepository
-  private lateinit var mockPermissionManager: IPermissionManager
+    private lateinit var mockLocationService: ILocationService
+    private lateinit var mockLocationRepository: LocationRepository
+    private lateinit var mockPermissionManager: IPermissionManager
 
-  private lateinit var locationViewModel: LocationViewModel
+    private lateinit var locationViewModel: LocationViewModel
 
-  @Before
-  fun setup() {
-    // Set up real DataStore with test scope
-    testDataStore =
-        PreferenceDataStoreFactory.create(
-            scope = testScope,
-            produceFile = { File(tempFolder.newFolder(), "test_preferences.preferences_pb") })
-    appDataStore = AppDataStore(testDataStore)
+    @Before
+    fun setup() {
+        // Set up real DataStore with test scope
+        testDataStore =
+            PreferenceDataStoreFactory.create(
+                scope = testScope,
+                produceFile = { File(tempFolder.newFolder(), "test_preferences.preferences_pb") })
+        appDataStore = AppDataStore(testDataStore)
 
-    // Initialize mocks and view models
-    mockProfileViewModel = MockProfileViewModel()
-    mockProfilesRepository = mock(ProfilesRepository::class.java)
-    mockFirebaseStorage = mock(FirebaseStorage::class.java)
-    mockFunction = mock(FirebaseFunctions::class.java)
-    mockMeetingRequestViewModel = MeetingRequestViewModel(mockProfileViewModel, mockFunction)
-    mockFilterViewModel = FilterViewModel()
-    tagsViewModel =
-        TagsViewModel(
-            TagsRepository(mock(FirebaseFirestore::class.java), mock(FirebaseAuth::class.java)))
-    profilesViewModel =
-        ProfilesViewModel(
-            mockProfilesRepository,
-            ProfilePicRepositoryStorage(mockFirebaseStorage),
-            mock(FirebaseAuth::class.java))
+        // Initialize mocks and view models
+        mockProfileViewModel = MockProfileViewModel()
+        mockProfilesRepository = mock(ProfilesRepository::class.java)
+        mockFirebaseStorage = mock(FirebaseStorage::class.java)
+        mockFunction = mock(FirebaseFunctions::class.java)
+        mockMeetingRequestViewModel = MeetingRequestViewModel(mockProfileViewModel, mockFunction)
+        mockFilterViewModel = FilterViewModel()
+        tagsViewModel =
+            TagsViewModel(
+                TagsRepository(mock(FirebaseFirestore::class.java), mock(FirebaseAuth::class.java))
+            )
+        profilesViewModel =
+            ProfilesViewModel(
+                mockProfilesRepository,
+                ProfilePicRepositoryStorage(mockFirebaseStorage),
+                mock(FirebaseAuth::class.java)
+            )
 
-    sortViewModel = SortViewModel(profilesViewModel)
-    mockLocationService = mock(ILocationService::class.java)
-    mockLocationRepository = mock(LocationRepository::class.java)
-    mockPermissionManager = mock(IPermissionManager::class.java)
+        sortViewModel = SortViewModel(profilesViewModel)
+        mockLocationService = mock(ILocationService::class.java)
+        mockLocationRepository = mock(LocationRepository::class.java)
+        mockPermissionManager = mock(IPermissionManager::class.java)
 
-    locationViewModel =
-        LocationViewModel(mockLocationService, mockLocationRepository, mockPermissionManager)
+        locationViewModel =
+            LocationViewModel(mockLocationService, mockLocationRepository, mockPermissionManager)
 
-    // mock state flow
-    `when`(mockPermissionManager.permissionStatuses)
-        .thenReturn(
-            MutableStateFlow(
-                mapOf(
-                    android.Manifest.permission.ACCESS_FINE_LOCATION to
-                        android.content.pm.PackageManager.PERMISSION_GRANTED)))
-  }
-
-  @Test
-  fun testNavigationLogin() = runTest {
-    composeTestRule.setContent {
-      IcebreakrrNavHost(
-          mockProfileViewModel,
-          tagsViewModel,
-          mockFilterViewModel,
-          sortViewModel,
-          mockMeetingRequestViewModel,
-          appDataStore,
-          locationViewModel,
-          Route.AUTH,
-          mock(FirebaseAuth::class.java),
-          mock(IPermissionManager::class.java),
-          true)
+        // mock state flow
+        `when`(mockPermissionManager.permissionStatuses)
+            .thenReturn(
+                MutableStateFlow(
+                    mapOf(
+                        android.Manifest.permission.ACCESS_FINE_LOCATION to
+                                android.content.pm.PackageManager.PERMISSION_GRANTED
+                    )
+                )
+            )
     }
 
-    // Assert that the login screen is shown on launch
-    composeTestRule.onNodeWithTag("loginScreen").assertExists()
-  }
+    @Test
+    fun testNavigationLogin() = runTest {
+        composeTestRule.setContent {
+            IcebreakrrNavHost(
+                mockProfileViewModel,
+                tagsViewModel,
+                mockFilterViewModel,
+                sortViewModel,
+                mockMeetingRequestViewModel,
+                appDataStore,
+                locationViewModel,
+                Route.AUTH,
+                mock(FirebaseAuth::class.java),
+                mock(IPermissionManager::class.java),
+                true
+            )
+        }
 
-  @Test
-  fun testBottomNavigationBar() = runTest {
-    composeTestRule.setContent {
-      IcebreakrrNavHost(
-          mockProfileViewModel,
-          tagsViewModel,
-          mockFilterViewModel,
-          mockMeetingRequestViewModel,
-          appDataStore,
-          locationViewModel,
-          Route.AROUND_YOU,
-          FirebaseAuth.getInstance(),
-          mockPermissionManager,
-          true)
+        // Assert that the login screen is shown on launch
+        composeTestRule.onNodeWithTag("loginScreen").assertExists()
     }
+}
 
     /**
      * @Test fun testBottomNavigationBar() = runTest { composeTestRule.setContent {

--- a/app/src/androidTest/java/com/github/se/icebreakrr/ui/sections/AroundYouTest.kt
+++ b/app/src/androidTest/java/com/github/se/icebreakrr/ui/sections/AroundYouTest.kt
@@ -128,9 +128,9 @@ class AroundYouScreenTest {
           viewModel(factory = FilterViewModel.Factory),
           locationViewModel,
           sortViewModel,
-          true,
           mockPermissionManager,
           appDataStore,
+          true,
       )
     }
 

--- a/app/src/androidTest/java/com/github/se/icebreakrr/ui/sections/AroundYouTest.kt
+++ b/app/src/androidTest/java/com/github/se/icebreakrr/ui/sections/AroundYouTest.kt
@@ -7,6 +7,9 @@ import androidx.compose.ui.test.onFirst
 import androidx.compose.ui.test.onNodeWithTag
 import androidx.compose.ui.test.performClick
 import androidx.compose.ui.test.performTouchInput
+import androidx.datastore.core.DataStore
+import androidx.datastore.preferences.core.PreferenceDataStoreFactory
+import androidx.datastore.preferences.core.Preferences
 import androidx.lifecycle.viewmodel.compose.viewModel
 import androidx.test.espresso.action.ViewActions.swipeDown
 import com.github.se.icebreakrr.data.AppDataStore
@@ -28,18 +31,27 @@ import com.google.firebase.Timestamp
 import com.google.firebase.auth.FirebaseAuth
 import com.google.firebase.firestore.FirebaseFirestore
 import com.google.firebase.firestore.GeoPoint
+import java.io.File
 import java.util.Calendar
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.Job
 import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.test.TestScope
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
+import kotlinx.coroutines.test.runTest
 import org.junit.Assert.assertTrue
 import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
+import org.junit.rules.TemporaryFolder
 import org.mockito.Mockito.mock
 import org.mockito.Mockito.verify
 import org.mockito.Mockito.`when`
 import org.mockito.kotlin.any
 
+@OptIn(ExperimentalCoroutinesApi::class)
 class AroundYouScreenTest {
+  private val testScope = TestScope(UnconfinedTestDispatcher() + Job())
 
   private lateinit var navigationActions: NavigationActions
   private lateinit var mockProfilesRepository: ProfilesRepository
@@ -49,14 +61,25 @@ class AroundYouScreenTest {
   private lateinit var mockLocationService: ILocationService
   private lateinit var mockLocationRepository: LocationRepository
   private lateinit var mockPermissionManager: IPermissionManager
-  private lateinit var mockDataStore: AppDataStore
+  private lateinit var testDataStore: DataStore<Preferences>
+  private lateinit var appDataStore: AppDataStore
 
   private lateinit var locationViewModel: LocationViewModel
 
   @get:Rule val composeTestRule = createComposeRule()
+  @get:Rule val tempFolder = TemporaryFolder()
 
   @Before
-  fun setUp() {
+  fun setUp() = runTest {
+    // Set up real DataStore with test scope
+    testDataStore =
+        PreferenceDataStoreFactory.create(
+            scope = testScope,
+            produceFile = { File(tempFolder.newFolder(), "test_preferences.preferences_pb") })
+    appDataStore = AppDataStore(testDataStore)
+    appDataStore.saveDiscoverableStatus(true)
+
+    // Set up mocks
     navigationActions = mock(NavigationActions::class.java)
     mockProfilesRepository = mock(ProfilesRepository::class.java)
     mockPPRepository = mock(ProfilePicRepository::class.java)
@@ -66,7 +89,6 @@ class AroundYouScreenTest {
     mockLocationService = mock(ILocationService::class.java)
     mockLocationRepository = mock(LocationRepository::class.java)
     mockPermissionManager = mock(IPermissionManager::class.java)
-    mockDataStore = mock(AppDataStore::class.java)
 
     locationViewModel =
         LocationViewModel(mockLocationService, mockLocationRepository, mockPermissionManager)
@@ -80,7 +102,6 @@ class AroundYouScreenTest {
                 mapOf(
                     android.Manifest.permission.ACCESS_FINE_LOCATION to
                         android.content.pm.PackageManager.PERMISSION_GRANTED)))
-
     // Mock successful connection check
     `when`(mockProfilesRepository.getProfilesInRadius(any(), any(), any(), any())).thenAnswer {
         invocation ->
@@ -104,7 +125,7 @@ class AroundYouScreenTest {
           locationViewModel,
           true,
           mockPermissionManager,
-          mockDataStore,
+          appDataStore,
       )
     }
 
@@ -113,7 +134,7 @@ class AroundYouScreenTest {
   }
 
   @Test
-  fun displayTextWhenEmpty() {
+  fun displayTextWhenEmpty() = runTest {
     // Mock the repository behavior
     `when`(mockProfilesRepository.getProfilesInRadius(any(), any(), any(), any())).thenAnswer {
         invocation ->

--- a/app/src/androidTest/java/com/github/se/icebreakrr/ui/sections/AroundYouTest.kt
+++ b/app/src/androidTest/java/com/github/se/icebreakrr/ui/sections/AroundYouTest.kt
@@ -9,6 +9,7 @@ import androidx.compose.ui.test.performClick
 import androidx.compose.ui.test.performTouchInput
 import androidx.lifecycle.viewmodel.compose.viewModel
 import androidx.test.espresso.action.ViewActions.swipeDown
+import com.github.se.icebreakrr.data.AppDataStore
 import com.github.se.icebreakrr.model.filter.FilterViewModel
 import com.github.se.icebreakrr.model.location.ILocationService
 import com.github.se.icebreakrr.model.location.LocationRepository
@@ -48,6 +49,7 @@ class AroundYouScreenTest {
   private lateinit var mockLocationService: ILocationService
   private lateinit var mockLocationRepository: LocationRepository
   private lateinit var mockPermissionManager: IPermissionManager
+    private lateinit var mockDataStore: AppDataStore
 
   private lateinit var locationViewModel: LocationViewModel
 
@@ -64,13 +66,22 @@ class AroundYouScreenTest {
     mockLocationService = mock(ILocationService::class.java)
     mockLocationRepository = mock(LocationRepository::class.java)
     mockPermissionManager = mock(IPermissionManager::class.java)
+    mockDataStore = mock(AppDataStore::class.java)
 
     locationViewModel =
         LocationViewModel(mockLocationService, mockLocationRepository, mockPermissionManager)
 
-    // Mock repository state flows
+    // Mock state flows
     `when`(mockProfilesRepository.isWaiting).thenReturn(MutableStateFlow(false))
     `when`(mockProfilesRepository.waitingDone).thenReturn(MutableStateFlow(false))
+    `when`(mockPermissionManager.permissionStatuses).thenReturn(
+      MutableStateFlow(
+        mapOf(
+          android.Manifest.permission.ACCESS_FINE_LOCATION to android.content.pm.PackageManager.PERMISSION_GRANTED
+        )
+      )
+    )
+
 
     // Mock successful connection check
     `when`(mockProfilesRepository.getProfilesInRadius(any(), any(), any(), any())).thenAnswer {
@@ -93,7 +104,10 @@ class AroundYouScreenTest {
                       mock(FirebaseAuth::class.java), mock(FirebaseFirestore::class.java))),
           viewModel(factory = FilterViewModel.Factory),
           locationViewModel,
-          true)
+          true,
+            mockPermissionManager,
+            mockDataStore,
+          )
     }
 
     // Trigger initial connection check

--- a/app/src/androidTest/java/com/github/se/icebreakrr/ui/sections/AroundYouTest.kt
+++ b/app/src/androidTest/java/com/github/se/icebreakrr/ui/sections/AroundYouTest.kt
@@ -49,7 +49,7 @@ class AroundYouScreenTest {
   private lateinit var mockLocationService: ILocationService
   private lateinit var mockLocationRepository: LocationRepository
   private lateinit var mockPermissionManager: IPermissionManager
-    private lateinit var mockDataStore: AppDataStore
+  private lateinit var mockDataStore: AppDataStore
 
   private lateinit var locationViewModel: LocationViewModel
 
@@ -74,14 +74,12 @@ class AroundYouScreenTest {
     // Mock state flows
     `when`(mockProfilesRepository.isWaiting).thenReturn(MutableStateFlow(false))
     `when`(mockProfilesRepository.waitingDone).thenReturn(MutableStateFlow(false))
-    `when`(mockPermissionManager.permissionStatuses).thenReturn(
-      MutableStateFlow(
-        mapOf(
-          android.Manifest.permission.ACCESS_FINE_LOCATION to android.content.pm.PackageManager.PERMISSION_GRANTED
-        )
-      )
-    )
-
+    `when`(mockPermissionManager.permissionStatuses)
+        .thenReturn(
+            MutableStateFlow(
+                mapOf(
+                    android.Manifest.permission.ACCESS_FINE_LOCATION to
+                        android.content.pm.PackageManager.PERMISSION_GRANTED)))
 
     // Mock successful connection check
     `when`(mockProfilesRepository.getProfilesInRadius(any(), any(), any(), any())).thenAnswer {
@@ -105,9 +103,9 @@ class AroundYouScreenTest {
           viewModel(factory = FilterViewModel.Factory),
           locationViewModel,
           true,
-            mockPermissionManager,
-            mockDataStore,
-          )
+          mockPermissionManager,
+          mockDataStore,
+      )
     }
 
     // Trigger initial connection check

--- a/app/src/androidTest/java/com/github/se/icebreakrr/ui/sections/SettingsTest.kt
+++ b/app/src/androidTest/java/com/github/se/icebreakrr/ui/sections/SettingsTest.kt
@@ -38,7 +38,6 @@ import org.junit.Test
 import org.junit.rules.TemporaryFolder
 import org.mockito.Mockito
 import org.mockito.Mockito.`when`
-import org.mockito.kotlin.any
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.verify
 
@@ -53,13 +52,12 @@ class SettingsTest {
   private lateinit var navigationActionsMock: NavigationActions
   private lateinit var profilesViewModel: ProfilesViewModel
   private lateinit var mockProfilesRepository: ProfilesRepository
-    private lateinit var mockLocationService: ILocationService
-    private lateinit var mockLocationRepository: LocationRepository
-    private lateinit var mockPermissionManager: IPermissionManager
+  private lateinit var mockLocationService: ILocationService
+  private lateinit var mockLocationRepository: LocationRepository
+  private lateinit var mockPermissionManager: IPermissionManager
   private lateinit var testDataStore: DataStore<Preferences>
   private lateinit var appDataStore: AppDataStore
   private lateinit var locationViewModel: LocationViewModel
-
 
   @Before
   fun setUp() {
@@ -86,7 +84,8 @@ class SettingsTest {
     profilesViewModel =
         ProfilesViewModel(
             mockProfilesRepository, ProfilePicRepositoryStorage(mockStorage), mock<FirebaseAuth>())
-    locationViewModel = LocationViewModel(mockLocationService, mockLocationRepository, mockPermissionManager)
+    locationViewModel =
+        LocationViewModel(mockLocationService, mockLocationRepository, mockPermissionManager)
 
     // Mock necessary Flow returns
     `when`(mockProfilesRepository.isWaiting).thenReturn(MutableStateFlow(false))
@@ -94,19 +93,23 @@ class SettingsTest {
 
     `when`(navigationActionsMock.currentRoute()).thenReturn(Route.SETTINGS)
 
-    `when`(mockPermissionManager.permissionStatuses).thenReturn(
-        MutableStateFlow(
-            mapOf(
-                android.Manifest.permission.ACCESS_FINE_LOCATION to android.content.pm.PackageManager.PERMISSION_GRANTED
-            )
-        )
-    )
+    `when`(mockPermissionManager.permissionStatuses)
+        .thenReturn(
+            MutableStateFlow(
+                mapOf(
+                    android.Manifest.permission.ACCESS_FINE_LOCATION to
+                        android.content.pm.PackageManager.PERMISSION_GRANTED)))
   }
 
   @Test
   fun testProfileSettingsScreenDisplaysCorrectly() = runTest {
     composeTestRule.setContent {
-      SettingsScreen(profilesViewModel, navigationActionsMock, appDataStore, locationViewModel,  mock<FirebaseAuth>())
+      SettingsScreen(
+          profilesViewModel,
+          navigationActionsMock,
+          appDataStore,
+          locationViewModel,
+          mock<FirebaseAuth>())
     }
 
     // Assert that the top bar is displayed
@@ -129,7 +132,12 @@ class SettingsTest {
   @Test
   fun testNavigationActionsOnProfileCardClick() = runTest {
     composeTestRule.setContent {
-      SettingsScreen(profilesViewModel, navigationActionsMock, appDataStore,locationViewModel, mock<FirebaseAuth>())
+      SettingsScreen(
+          profilesViewModel,
+          navigationActionsMock,
+          appDataStore,
+          locationViewModel,
+          mock<FirebaseAuth>())
     }
 
     composeTestRule.onNodeWithTag("profileCard").performClick()
@@ -142,7 +150,12 @@ class SettingsTest {
     appDataStore.saveDiscoverableStatus(false)
 
     composeTestRule.setContent {
-      SettingsScreen(profilesViewModel, navigationActionsMock, appDataStore, locationViewModel, mock<FirebaseAuth>())
+      SettingsScreen(
+          profilesViewModel,
+          navigationActionsMock,
+          appDataStore,
+          locationViewModel,
+          mock<FirebaseAuth>())
     }
 
     // Initial state check

--- a/app/src/main/java/com/github/se/icebreakrr/MainActivity.kt
+++ b/app/src/main/java/com/github/se/icebreakrr/MainActivity.kt
@@ -264,7 +264,14 @@ fun IcebreakrrNavHost(
     ) {
       composable(Screen.AROUND_YOU) {
         AroundYouScreen(
-            navigationActions, profileViewModel, tagsViewModel, filterViewModel, locationViewModel, sortViewModel, permissionManager, appDataStore)
+            navigationActions,
+            profileViewModel,
+            tagsViewModel,
+            filterViewModel,
+            locationViewModel,
+            sortViewModel,
+            permissionManager,
+            appDataStore)
       }
       composable(Screen.OTHER_PROFILE_VIEW + "?userId={userId}") { navBackStackEntry ->
         if (meetingRequestViewModel != null) {

--- a/app/src/main/java/com/github/se/icebreakrr/MainActivity.kt
+++ b/app/src/main/java/com/github/se/icebreakrr/MainActivity.kt
@@ -43,6 +43,7 @@ import com.github.se.icebreakrr.ui.sections.FilterScreen
 import com.github.se.icebreakrr.ui.sections.NotificationScreen
 import com.github.se.icebreakrr.ui.sections.SettingsScreen
 import com.github.se.icebreakrr.ui.theme.SampleAppTheme
+import com.github.se.icebreakrr.utils.IPermissionManager
 import com.github.se.icebreakrr.utils.NetworkUtils
 import com.github.se.icebreakrr.utils.PermissionManager
 import com.google.android.gms.location.FusedLocationProviderClient
@@ -118,7 +119,7 @@ class MainActivity : ComponentActivity() {
       CompositionLocalProvider(LocalIsTesting provides isTesting) {
         SampleAppTheme {
           Surface(modifier = Modifier.fillMaxSize()) {
-            IcebreakrrApp(auth, functions, appDataStore, locationViewModel, firestore, isTesting)
+            IcebreakrrApp(auth, functions, appDataStore, locationViewModel, firestore, isTesting, permissionManager)
           }
         }
       }
@@ -175,7 +176,8 @@ fun IcebreakrrApp(
     appDataStore: AppDataStore,
     locationViewModel: LocationViewModel,
     firestore: FirebaseFirestore,
-    isTesting: Boolean
+    isTesting: Boolean,
+    permissionManager: IPermissionManager
 ) {
   val profileViewModel: ProfilesViewModel =
       viewModel(factory = ProfilesViewModel.Companion.Factory(auth, firestore))
@@ -200,7 +202,8 @@ fun IcebreakrrApp(
       appDataStore,
       locationViewModel,
       startDestination,
-      auth)
+      auth,
+      permissionManager)
 }
 
 @Composable
@@ -212,7 +215,8 @@ fun IcebreakrrNavHost(
     appDataStore: AppDataStore,
     locationViewModel: LocationViewModel,
     startDestination: String,
-    auth: FirebaseAuth
+    auth: FirebaseAuth,
+    permissionManager: IPermissionManager
 ) {
   val navController = rememberNavController()
   val navigationActions = NavigationActions(navController)
@@ -246,7 +250,13 @@ fun IcebreakrrNavHost(
     ) {
       composable(Screen.AROUND_YOU) {
         AroundYouScreen(
-            navigationActions, profileViewModel, tagsViewModel, filterViewModel, locationViewModel)
+            navigationActions = navigationActions,
+            profilesViewModel = profileViewModel,
+            tagsViewModel = tagsViewModel,
+            filterViewModel = filterViewModel,
+            locationViewModel = locationViewModel,
+            permissionManager = permissionManager,
+            appDataStore = appDataStore)
       }
       composable(Screen.OTHER_PROFILE_VIEW + "?userId={userId}") { navBackStackEntry ->
         if (meetingRequestViewModel != null) {
@@ -268,7 +278,12 @@ fun IcebreakrrNavHost(
         route = Route.SETTINGS,
     ) {
       composable(Screen.SETTINGS) {
-        SettingsScreen(profileViewModel, navigationActions, appDataStore = appDataStore, auth)
+        SettingsScreen(
+            profilesViewModel = profileViewModel,
+            navigationActions = navigationActions,
+            appDataStore = appDataStore,
+            locationViewModel = locationViewModel,
+            auth = auth)
       }
       composable(Screen.PROFILE) {
         ProfileView(profileViewModel, tagsViewModel, navigationActions, auth)

--- a/app/src/main/java/com/github/se/icebreakrr/MainActivity.kt
+++ b/app/src/main/java/com/github/se/icebreakrr/MainActivity.kt
@@ -203,7 +203,8 @@ fun IcebreakrrApp(
       locationViewModel,
       startDestination,
       auth,
-      permissionManager)
+      permissionManager,
+      isTesting)
 }
 
 @Composable
@@ -216,7 +217,8 @@ fun IcebreakrrNavHost(
     locationViewModel: LocationViewModel,
     startDestination: String,
     auth: FirebaseAuth,
-    permissionManager: IPermissionManager
+    permissionManager: IPermissionManager,
+    isTesting: Boolean
 ) {
   val navController = rememberNavController()
   val navigationActions = NavigationActions(navController)
@@ -255,6 +257,7 @@ fun IcebreakrrNavHost(
             tagsViewModel = tagsViewModel,
             filterViewModel = filterViewModel,
             locationViewModel = locationViewModel,
+            isTestMode = isTesting,
             permissionManager = permissionManager,
             appDataStore = appDataStore)
       }

--- a/app/src/main/java/com/github/se/icebreakrr/MainActivity.kt
+++ b/app/src/main/java/com/github/se/icebreakrr/MainActivity.kt
@@ -271,7 +271,8 @@ fun IcebreakrrNavHost(
             locationViewModel,
             sortViewModel,
             permissionManager,
-            appDataStore)
+            appDataStore,
+            isTesting)
       }
       composable(Screen.OTHER_PROFILE_VIEW + "?userId={userId}") { navBackStackEntry ->
         if (meetingRequestViewModel != null) {

--- a/app/src/main/java/com/github/se/icebreakrr/MainActivity.kt
+++ b/app/src/main/java/com/github/se/icebreakrr/MainActivity.kt
@@ -119,7 +119,14 @@ class MainActivity : ComponentActivity() {
       CompositionLocalProvider(LocalIsTesting provides isTesting) {
         SampleAppTheme {
           Surface(modifier = Modifier.fillMaxSize()) {
-            IcebreakrrApp(auth, functions, appDataStore, locationViewModel, firestore, isTesting, permissionManager)
+            IcebreakrrApp(
+                auth,
+                functions,
+                appDataStore,
+                locationViewModel,
+                firestore,
+                isTesting,
+                permissionManager)
           }
         }
       }

--- a/app/src/main/java/com/github/se/icebreakrr/MainActivity.kt
+++ b/app/src/main/java/com/github/se/icebreakrr/MainActivity.kt
@@ -264,7 +264,7 @@ fun IcebreakrrNavHost(
     ) {
       composable(Screen.AROUND_YOU) {
         AroundYouScreen(
-            navigationActions, profileViewModel, tagsViewModel, filterViewModel, locationViewModel)
+            navigationActions, profileViewModel, tagsViewModel, filterViewModel, locationViewModel, sortViewModel, permissionManager, appDataStore)
       }
       composable(Screen.OTHER_PROFILE_VIEW + "?userId={userId}") { navBackStackEntry ->
         if (meetingRequestViewModel != null) {

--- a/app/src/main/java/com/github/se/icebreakrr/ui/sections/AroundYou.kt
+++ b/app/src/main/java/com/github/se/icebreakrr/ui/sections/AroundYou.kt
@@ -24,10 +24,12 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
+import com.github.se.icebreakrr.R
 import com.github.se.icebreakrr.data.AppDataStore
 import com.github.se.icebreakrr.model.filter.FilterViewModel
 import com.github.se.icebreakrr.model.location.LocationViewModel
@@ -144,16 +146,15 @@ fun AroundYouScreen(
                 EmptyProfilePrompt(label = "No Internet Connection", testTag = "noConnectionPrompt")
               } else if (!isDiscoverable) {
                 EmptyProfilePrompt(
-                    label = "Activate location sharing in the app settings!",
+                    label = stringResource(R.string.ask_to_toggle_location),
                     testTag = "activateLocationPrompt")
               } else if (!isTestMode && !hasLocationPermission) {
                 EmptyProfilePrompt(
-                    label =
-                        "Precise location permission is required to show profiles. Activate it in your phone settings",
+                    label = stringResource(R.string.ask_to_give_location_permission),
                     testTag = "noLocationPermissionPrompt")
               } else if (filteredProfiles.value.isEmpty()) {
                 EmptyProfilePrompt(
-                    label = "There is no one around. Try moving!", testTag = "emptyProfilePrompt")
+                    label = stringResource(R.string.no_one_around), testTag = "emptyProfilePrompt")
               } else {
                 LazyColumn(
                     contentPadding = PaddingValues(vertical = COLUMN_VERTICAL_PADDING),

--- a/app/src/main/java/com/github/se/icebreakrr/ui/sections/AroundYou.kt
+++ b/app/src/main/java/com/github/se/icebreakrr/ui/sections/AroundYou.kt
@@ -153,7 +153,7 @@ fun AroundYouScreen(
                     EmptyProfilePrompt(
                         label = "Activate location sharing in the app settings!",
                         testTag = "activateLocationPrompt")
-                } else if (!hasLocationPermission) {
+                } else if (!isTestMode && !hasLocationPermission) {
                     EmptyProfilePrompt(
                         label =
                         "Precise location permission is required to show profiles. Activate it in your phone settings",

--- a/app/src/main/java/com/github/se/icebreakrr/ui/sections/AroundYou.kt
+++ b/app/src/main/java/com/github/se/icebreakrr/ui/sections/AroundYou.kt
@@ -83,23 +83,23 @@ fun AroundYouScreen(
     appDataStore: AppDataStore
 ) {
 
-    val permissionStatuses = permissionManager.permissionStatuses.collectAsState()
-    val hasLocationPermission =
-        permissionStatuses.value[android.Manifest.permission.ACCESS_FINE_LOCATION] ==
-                PackageManager.PERMISSION_GRANTED
+  val permissionStatuses = permissionManager.permissionStatuses.collectAsState()
+  val hasLocationPermission =
+      permissionStatuses.value[android.Manifest.permission.ACCESS_FINE_LOCATION] ==
+          PackageManager.PERMISSION_GRANTED
   val filteredProfiles = profilesViewModel.filteredProfiles.collectAsState()
   val isLoading = profilesViewModel.loading.collectAsState()
   val context = LocalContext.current
   val isConnected = profilesViewModel.isConnected.collectAsState()
   val userLocation = locationViewModel.lastKnownLocation.collectAsState()
-    // Collect the discoverability state from DataStore
-    val isDiscoverable by appDataStore.isDiscoverable.collectAsState(initial = false)
+  // Collect the discoverability state from DataStore
+  val isDiscoverable by appDataStore.isDiscoverable.collectAsState(initial = false)
 
   // Initial check and start of periodic update every 10 seconds
   LaunchedEffect(isConnected.value, userLocation.value) {
     if (!isTestMode && !isNetworkAvailable()) {
       profilesViewModel.updateIsConnected(false)
-    } else if (hasLocationPermission){
+    } else if (hasLocationPermission) {
       while (true) {
         // Use the last known position or a default position
         val centerLocation = userLocation.value ?: GeoPoint(DEFAULT_LATITUDE, DEFAULT_LONGITUDE)
@@ -147,43 +147,41 @@ fun AroundYouScreen(
             },
             modifier = Modifier.padding(innerPadding),
             content = {
-                if (!isConnected.value){
-                    EmptyProfilePrompt(label = "No Internet Connection", testTag = "noConnectionPrompt")
-                } else if (!isDiscoverable) {
-                    EmptyProfilePrompt(
-                        label = "Activate location sharing in the app settings!",
-                        testTag = "activateLocationPrompt")
-                } else if (!isTestMode && !hasLocationPermission) {
-                    EmptyProfilePrompt(
-                        label =
+              if (!isConnected.value) {
+                EmptyProfilePrompt(label = "No Internet Connection", testTag = "noConnectionPrompt")
+              } else if (!isDiscoverable) {
+                EmptyProfilePrompt(
+                    label = "Activate location sharing in the app settings!",
+                    testTag = "activateLocationPrompt")
+              } else if (!isTestMode && !hasLocationPermission) {
+                EmptyProfilePrompt(
+                    label =
                         "Precise location permission is required to show profiles. Activate it in your phone settings",
-                        testTag = "noLocationPermissionPrompt")
-                } else if (filteredProfiles.value.isEmpty()) {
-                    EmptyProfilePrompt(
-                        label = "There is no one around. Try moving!",
-                        testTag = "emptyProfilePrompt"
-                    )
-                } else {
-                    LazyColumn(
-                        contentPadding = PaddingValues(vertical = COLUMN_VERTICAL_PADDING),
-                        verticalArrangement = Arrangement.spacedBy(COLUMN_VERTICAL_PADDING),
-                        modifier =
+                    testTag = "noLocationPermissionPrompt")
+              } else if (filteredProfiles.value.isEmpty()) {
+                EmptyProfilePrompt(
+                    label = "There is no one around. Try moving!", testTag = "emptyProfilePrompt")
+              } else {
+                LazyColumn(
+                    contentPadding = PaddingValues(vertical = COLUMN_VERTICAL_PADDING),
+                    verticalArrangement = Arrangement.spacedBy(COLUMN_VERTICAL_PADDING),
+                    modifier =
                         Modifier.fillMaxSize().padding(horizontal = COLUMN_HORIZONTAL_PADDING)) {
-                        items(filteredProfiles.value.size) { index ->
-                            ProfileCard(
-                                profile = filteredProfiles.value[index],
-                                onclick = {
-                                    if (isNetworkAvailableWithContext(context)) {
-                                        navigationActions.navigateTo(
-                                            Screen.OTHER_PROFILE_VIEW +
-                                                    "?userId=${filteredProfiles.value[index].uid}")
-                                    } else {
-                                        showNoInternetToast(context)
-                                    }
-                                })
-                        }
+                      items(filteredProfiles.value.size) { index ->
+                        ProfileCard(
+                            profile = filteredProfiles.value[index],
+                            onclick = {
+                              if (isNetworkAvailableWithContext(context)) {
+                                navigationActions.navigateTo(
+                                    Screen.OTHER_PROFILE_VIEW +
+                                        "?userId=${filteredProfiles.value[index].uid}")
+                              } else {
+                                showNoInternetToast(context)
+                              }
+                            })
+                      }
                     }
-                }
+              }
             })
       },
       floatingActionButton = { FilterFloatingActionButton(navigationActions) })
@@ -225,9 +223,7 @@ fun PullToRefreshBox(
     contentAlignment: Alignment = Alignment.TopStart,
     indicator: @Composable BoxScope.() -> Unit = {
       Indicator(
-          modifier = Modifier
-              .align(Alignment.TopCenter)
-              .testTag("refreshIndicator"),
+          modifier = Modifier.align(Alignment.TopCenter).testTag("refreshIndicator"),
           isRefreshing = isRefreshing,
           state = state)
     },
@@ -250,17 +246,14 @@ fun PullToRefreshBox(
       }
 }
 
-
 @Composable
 fun EmptyProfilePrompt(label: String, testTag: String) {
-    Box(contentAlignment = Alignment.Center, modifier = Modifier
-        .fillMaxSize()
-        .testTag(testTag)) {
-        Text(
-            text = label,
-            fontSize = TEXT_SIZE_LARGE,
-            fontWeight = FontWeight.Bold,
-            color = messageTextColor,
-            textAlign = TextAlign.Center)
-    }
+  Box(contentAlignment = Alignment.Center, modifier = Modifier.fillMaxSize().testTag(testTag)) {
+    Text(
+        text = label,
+        fontSize = TEXT_SIZE_LARGE,
+        fontWeight = FontWeight.Bold,
+        color = messageTextColor,
+        textAlign = TextAlign.Center)
+  }
 }

--- a/app/src/main/java/com/github/se/icebreakrr/ui/sections/AroundYou.kt
+++ b/app/src/main/java/com/github/se/icebreakrr/ui/sections/AroundYou.kt
@@ -2,7 +2,6 @@ package com.github.se.icebreakrr.ui.sections
 
 import android.annotation.SuppressLint
 import android.content.pm.PackageManager
-import android.util.Log
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.BoxScope

--- a/app/src/main/java/com/github/se/icebreakrr/ui/sections/AroundYou.kt
+++ b/app/src/main/java/com/github/se/icebreakrr/ui/sections/AroundYou.kt
@@ -31,7 +31,6 @@ import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
-import androidx.compose.runtime.getValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
@@ -164,73 +163,63 @@ fun AroundYouScreen(
       content = { innerPadding ->
 
         // Wrapping dropdown and profile list in a Column
-        Column(modifier = Modifier
-            .padding(innerPadding)
-            .fillMaxSize()) {
-            // Sort Options Dropdown
-            SortOptionsDropdown(
-                selectedOption = sortOption.value,
-                onOptionSelected = { sortViewModel.updateSortOption(it) },
-                modifier = Modifier
-                    .fillMaxWidth()
-                    .padding(horizontal = 16.dp, vertical = 8.dp)
-            )
+        Column(modifier = Modifier.padding(innerPadding).fillMaxSize()) {
+          // Sort Options Dropdown
+          SortOptionsDropdown(
+              selectedOption = sortOption.value,
+              onOptionSelected = { sortViewModel.updateSortOption(it) },
+              modifier = Modifier.fillMaxWidth().padding(horizontal = 16.dp, vertical = 8.dp))
 
-            // Profile List
-            PullToRefreshBox(
-                locationViewModel = locationViewModel,
-                filterViewModel = filterViewModel,
-                tagsViewModel = tagsViewModel,
-                isRefreshing = isLoading.value,
-                onRefresh = { center, radiusInMeters, genders, ageRange, tags ->
-                    profilesViewModel.getFilteredProfilesInRadius(
-                        center, radiusInMeters, genders, ageRange, tags
-                    )
-                },
-                modifier = Modifier.fillMaxSize(),
-                content = {
-                    if (!isConnected.value){
-                        EmptyProfilePrompt(
-                            label = stringResource(id = R.string.no_internet),
-                            testTag = "noConnectionPrompt"
-                        )
-                    } else if (!isDiscoverable) {
-                        EmptyProfilePrompt(
-                            label = stringResource(R.string.ask_to_toggle_location),
-                            testTag = "activateLocationPrompt"
-                        )
-                    } else if (!isTestMode && !hasLocationPermission) {
-                        EmptyProfilePrompt(
-                            label = stringResource(R.string.ask_to_give_location_permission),
-                            testTag = "noLocationPermissionPrompt")
-                    } else if (sortedProfiles.isEmpty()) {
-                        EmptyProfilePrompt(
-                            label = stringResource(R.string.no_one_around), testTag = "emptyProfilePrompt")
-                    } else {
-                        LazyColumn(
-                            contentPadding = PaddingValues(vertical = COLUMN_VERTICAL_PADDING),
-                            verticalArrangement = Arrangement.spacedBy(COLUMN_VERTICAL_PADDING),
-                            modifier =
-                            Modifier.fillMaxSize().padding(horizontal = COLUMN_HORIZONTAL_PADDING)
-                        ) {
-                            items(sortedProfiles.size) { index ->
-                                ProfileCard(
-                                    profile = sortedProfiles[index],
-                                    onclick = {
-                                        if (isNetworkAvailableWithContext(context)) {
-                                            navigationActions.navigateTo(
-                                                Screen.OTHER_PROFILE_VIEW +
-                                                        "?userId=${sortedProfiles[index].uid}"
-                                            )
-                                        } else {
-                                            showNoInternetToast(context)
-                                        }
-                                    })
-                            }
-
+          // Profile List
+          PullToRefreshBox(
+              locationViewModel = locationViewModel,
+              filterViewModel = filterViewModel,
+              tagsViewModel = tagsViewModel,
+              isRefreshing = isLoading.value,
+              onRefresh = { center, radiusInMeters, genders, ageRange, tags ->
+                profilesViewModel.getFilteredProfilesInRadius(
+                    center, radiusInMeters, genders, ageRange, tags)
+              },
+              modifier = Modifier.fillMaxSize(),
+              content = {
+                if (!isConnected.value) {
+                  EmptyProfilePrompt(
+                      label = stringResource(id = R.string.no_internet),
+                      testTag = "noConnectionPrompt")
+                } else if (!isDiscoverable) {
+                  EmptyProfilePrompt(
+                      label = stringResource(R.string.ask_to_toggle_location),
+                      testTag = "activateLocationPrompt")
+                } else if (!isTestMode && !hasLocationPermission) {
+                  EmptyProfilePrompt(
+                      label = stringResource(R.string.ask_to_give_location_permission),
+                      testTag = "noLocationPermissionPrompt")
+                } else if (sortedProfiles.isEmpty()) {
+                  EmptyProfilePrompt(
+                      label = stringResource(R.string.no_one_around),
+                      testTag = "emptyProfilePrompt")
+                } else {
+                  LazyColumn(
+                      contentPadding = PaddingValues(vertical = COLUMN_VERTICAL_PADDING),
+                      verticalArrangement = Arrangement.spacedBy(COLUMN_VERTICAL_PADDING),
+                      modifier =
+                          Modifier.fillMaxSize().padding(horizontal = COLUMN_HORIZONTAL_PADDING)) {
+                        items(sortedProfiles.size) { index ->
+                          ProfileCard(
+                              profile = sortedProfiles[index],
+                              onclick = {
+                                if (isNetworkAvailableWithContext(context)) {
+                                  navigationActions.navigateTo(
+                                      Screen.OTHER_PROFILE_VIEW +
+                                          "?userId=${sortedProfiles[index].uid}")
+                                } else {
+                                  showNoInternetToast(context)
+                                }
+                              })
                         }
-                    }
-            })
+                      }
+                }
+              })
         }
       },
       floatingActionButton = { FilterFloatingActionButton(navigationActions) })
@@ -263,11 +252,10 @@ fun SortOptionsDropdown(
     // Selected option with a dropdown indicator
     Row(
         modifier =
-        Modifier
-            .fillMaxWidth()
-            .clickable { expanded = !expanded }
-            .padding(COLUMN_HORIZONTAL_PADDING)
-            .testTag("SortOptionsDropdown_Selected"),
+            Modifier.fillMaxWidth()
+                .clickable { expanded = !expanded }
+                .padding(COLUMN_HORIZONTAL_PADDING)
+                .testTag("SortOptionsDropdown_Selected"),
         verticalAlignment = Alignment.CenterVertically) {
           Text(
               text =
@@ -277,9 +265,8 @@ fun SortOptionsDropdown(
                 }",
               fontSize = TEXT_SMALL_SIZE,
               modifier =
-              Modifier
-                  .weight(1f) // Pushes the arrow to the end
-                  .testTag("SortOptionsDropdown_Text"))
+                  Modifier.weight(1f) // Pushes the arrow to the end
+                      .testTag("SortOptionsDropdown_Text"))
           Icon(
               imageVector =
                   if (expanded) Icons.Filled.KeyboardArrowUp else Icons.Filled.KeyboardArrowDown,
@@ -292,18 +279,16 @@ fun SortOptionsDropdown(
       otherOptions.forEach { option ->
         Row(
             modifier =
-            Modifier
-                .fillMaxWidth()
-                .clickable {
-                    expanded = false
-                    onOptionSelected(option)
-                }
-                .padding(
-                    start = COLUMN_VERTICAL_PADDING,
-                    top = SORT_TOP_PADDING,
-                    bottom = COLUMN_HORIZONTAL_PADDING
-                )
-                .testTag("SortOptionsDropdown_Option_${option.name}"),
+                Modifier.fillMaxWidth()
+                    .clickable {
+                      expanded = false
+                      onOptionSelected(option)
+                    }
+                    .padding(
+                        start = COLUMN_VERTICAL_PADDING,
+                        top = SORT_TOP_PADDING,
+                        bottom = COLUMN_HORIZONTAL_PADDING)
+                    .testTag("SortOptionsDropdown_Option_${option.name}"),
         ) {
           Text(
               text =
@@ -356,9 +341,7 @@ fun PullToRefreshBox(
     contentAlignment: Alignment = Alignment.TopStart,
     indicator: @Composable BoxScope.() -> Unit = {
       Indicator(
-          modifier = Modifier
-              .align(Alignment.TopCenter)
-              .testTag("refreshIndicator"),
+          modifier = Modifier.align(Alignment.TopCenter).testTag("refreshIndicator"),
           isRefreshing = isRefreshing,
           state = state)
     },
@@ -382,9 +365,7 @@ fun PullToRefreshBox(
 
 @Composable
 fun EmptyProfilePrompt(label: String, testTag: String) {
-  Box(contentAlignment = Alignment.Center, modifier = Modifier
-      .fillMaxSize()
-      .testTag(testTag)) {
+  Box(contentAlignment = Alignment.Center, modifier = Modifier.fillMaxSize().testTag(testTag)) {
     Text(
         text = label,
         fontSize = TEXT_SIZE_LARGE,

--- a/app/src/main/java/com/github/se/icebreakrr/ui/sections/Settings.kt
+++ b/app/src/main/java/com/github/se/icebreakrr/ui/sections/Settings.kt
@@ -126,10 +126,10 @@ fun SettingsScreen(
               label = "Toggle Discoverability",
               isChecked = isDiscoverable,
               onCheckedChange = { discoverable ->
-                  when (discoverable) {
-                      true -> locationViewModel.tryToStartLocationUpdates()
-                      false -> locationViewModel.stopLocationUpdates()
-                  }
+                when (discoverable) {
+                  true -> locationViewModel.tryToStartLocationUpdates()
+                  false -> locationViewModel.stopLocationUpdates()
+                }
                 coroutineScope.launch { appDataStore.saveDiscoverableStatus(discoverable) }
               })
           Spacer(modifier = Modifier.height(SPACER_HEIGHT_LARGE))

--- a/app/src/main/java/com/github/se/icebreakrr/ui/sections/Settings.kt
+++ b/app/src/main/java/com/github/se/icebreakrr/ui/sections/Settings.kt
@@ -34,6 +34,7 @@ import com.github.se.icebreakrr.authentication.logout
 import com.github.se.icebreakrr.config.LocalIsTesting
 import com.github.se.icebreakrr.data.AppDataStore
 import com.github.se.icebreakrr.mock.getMockedProfiles
+import com.github.se.icebreakrr.model.location.LocationViewModel
 import com.github.se.icebreakrr.model.profile.Profile
 import com.github.se.icebreakrr.model.profile.ProfilesViewModel
 import com.github.se.icebreakrr.ui.navigation.BottomNavigationMenu
@@ -74,6 +75,7 @@ fun SettingsScreen(
     profilesViewModel: ProfilesViewModel,
     navigationActions: NavigationActions,
     appDataStore: AppDataStore,
+    locationViewModel: LocationViewModel,
     auth: FirebaseAuth
 ) {
   val context = LocalContext.current
@@ -124,6 +126,10 @@ fun SettingsScreen(
               label = "Toggle Discoverability",
               isChecked = isDiscoverable,
               onCheckedChange = { discoverable ->
+                  when (discoverable) {
+                      true -> locationViewModel.tryToStartLocationUpdates()
+                      false -> locationViewModel.stopLocationUpdates()
+                  }
                 coroutineScope.launch { appDataStore.saveDiscoverableStatus(discoverable) }
               })
           Spacer(modifier = Modifier.height(SPACER_HEIGHT_LARGE))
@@ -168,7 +174,6 @@ fun ToggleOptionBox(
     onCheckedChange: (Boolean) -> Unit,
     modifier: Modifier = Modifier
 ) {
-  // Constants for card styling
 
   Card(
       shape = CARD_SHAPE,

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -41,6 +41,7 @@
 
     <string name="blocked_profiles">Blocked Profiles</string>
 
+    <string name="no_internet">No Internet Connection</string>
     <string name="ask_to_toggle_location">Activate location sharing in the app settings!</string>
     <string name="ask_to_give_location_permission">Precise location permission is required to show profiles. Activate it in your phone settings</string>
     <string name="no_one_around">There is no one around. Try moving!</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -35,4 +35,8 @@
 
     <string name="blocked_profiles">Blocked Profiles</string>
 
+    <string name="ask_to_toggle_location">Activate location sharing in the app settings!</string>
+    <string name="ask_to_give_location_permission">Precise location permission is required to show profiles. Activate it in your phone settings</string>
+    <string name="no_one_around">There is no one around. Try moving!</string>
+
 </resources>


### PR DESCRIPTION
# Toggle location update 2
note: code was started last week and was then discontinued. This is the same feature but started from a fresh main
## What's new
This PR links the toggle button from the settings screen to the `locationViewmodel` which allows to toggle location update. For now, disabling the location means that other user can still see your profile if they stand at your last known position (where you toggled the switch off). In later updates, the `ProfileViewmodel` will be extended to allow the toggle button to make the user truly invisible to others.
## Codebase changes:
* `Settings.kt`: linked to `LocationViewModel`
* `AroundYou.kt`: Added different empty screens when location update is disabled or permission is not aquired
* `MainActivity.kt`: update components signatures to allow use of `PermissionManager`, `AppDataStore` and `LocationViewModel`

### Special thanks to @arthur-mrgt for his very clean interface for location and permissions