### PR TITLE
Feature/already met backend

### DIFF
--- a/app/src/androidTest/java/com/github/se/icebreakrr/ui/sections/AlreadyMetTest.kt
+++ b/app/src/androidTest/java/com/github/se/icebreakrr/ui/sections/AlreadyMetTest.kt
@@ -2,90 +2,216 @@ package com.github.se.icebreakrr.ui.sections
 
 import androidx.compose.ui.test.*
 import androidx.compose.ui.test.junit4.createComposeRule
-import com.github.se.icebreakrr.model.profile.Gender
+import androidx.test.platform.app.InstrumentationRegistry
+import com.github.se.icebreakrr.R
+import com.github.se.icebreakrr.mock.MockProfileViewModel
+import com.github.se.icebreakrr.mock.getMockedProfiles
 import com.github.se.icebreakrr.model.profile.Profile
+import com.github.se.icebreakrr.model.profile.ProfilePicRepositoryStorage
+import com.github.se.icebreakrr.model.profile.ProfilesRepository
 import com.github.se.icebreakrr.model.profile.ProfilesViewModel
 import com.github.se.icebreakrr.ui.navigation.NavigationActions
-import com.github.se.icebreakrr.ui.navigation.Screen
-import com.google.firebase.Timestamp
-import java.util.*
 import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.test.runTest
 import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
-import org.mockito.Mockito.*
+import org.mockito.Mockito
+import org.mockito.kotlin.any
+import org.mockito.kotlin.mock
 
-class AlreadyMetTest {
+// The file was written with the help of CursorAI
+class AlreadyMetScreenTest {
   @get:Rule val composeTestRule = createComposeRule()
 
+  private val context = InstrumentationRegistry.getInstrumentation().targetContext
   private lateinit var navigationActions: NavigationActions
   private lateinit var profilesViewModel: ProfilesViewModel
-  private val profiles = MutableStateFlow<List<Profile>>(emptyList())
+  private lateinit var fakeProfilesViewModel: MockProfileViewModel
+  private lateinit var mockProfilesRepository: ProfilesRepository
+  private lateinit var alreadyMetProfiles: List<Profile>
+  private lateinit var myProfile: Profile
 
   @Before
-  fun setup() {
-    navigationActions = mock(NavigationActions::class.java)
-    profilesViewModel = mock(ProfilesViewModel::class.java)
-    `when`(profilesViewModel.profiles).thenReturn(profiles)
+  fun setUp() {
+    navigationActions = mock()
+    mockProfilesRepository = Mockito.mock(ProfilesRepository::class.java)
+    profilesViewModel =
+        ProfilesViewModel(mockProfilesRepository, ProfilePicRepositoryStorage(mock()), mock())
+    fakeProfilesViewModel = MockProfileViewModel()
+
+    // Get Alice's profile (first mock profile)
+    myProfile = Profile.getMockedProfiles()[0]
+
+    // Get profiles that Alice has already met
+    alreadyMetProfiles = Profile.getMockedProfiles().filter { it.uid in myProfile.hasAlreadyMet }
+
+    // Set up fake view model with the already met profiles
+    fakeProfilesViewModel.setSelfProfile(myProfile)
+    fakeProfilesViewModel.setLoading(false)
+
+    // Mock repository state flows
+    Mockito.`when`(mockProfilesRepository.isWaiting).thenReturn(MutableStateFlow(false))
+    Mockito.`when`(mockProfilesRepository.waitingDone).thenReturn(MutableStateFlow(false))
   }
 
   @Test
-  fun hasRequiredComponents() {
-    composeTestRule.setContent { AlreadyMetScreen(navigationActions, profilesViewModel) }
+  fun testAlreadyMetScreenBasicLayout() = runTest {
+    composeTestRule.setContent {
+      AlreadyMetScreen(
+          navigationActions = navigationActions,
+          profilesViewModel = profilesViewModel,
+          isTestMode = true)
+    }
 
-    composeTestRule.onNodeWithTag("alreadyMetScreen").assertIsDisplayed()
+    // Verify basic layout components
+    composeTestRule.onNodeWithTag("profileListScreen").assertIsDisplayed()
+    composeTestRule.onNodeWithTag("bottomNavigationMenu").assertIsDisplayed()
     composeTestRule.onNodeWithTag("topBar").assertIsDisplayed()
-    composeTestRule.onNodeWithTag("goBackButton").assertIsDisplayed()
   }
 
   @Test
-  fun testGoBackButtonFunctionality() {
-    composeTestRule.setContent { AlreadyMetScreen(navigationActions, profilesViewModel) }
+  fun testAlreadyMetScreenWithProfiles() = runTest {
+    // Set up the fake view model with the already met profiles
+    fakeProfilesViewModel.setLoading(false)
 
-    composeTestRule.onNodeWithTag("goBackButton").performClick()
-    verify(navigationActions).goBack()
+    composeTestRule.setContent {
+      AlreadyMetScreen(
+          navigationActions = navigationActions,
+          profilesViewModel = fakeProfilesViewModel,
+          isTestMode = true)
+    }
+
+    // Wait for UI to update
+    composeTestRule.waitForIdle()
+
+    // Verify profiles are displayed
+    alreadyMetProfiles.forEach { profile ->
+      composeTestRule.onNodeWithText(profile.name).assertExists()
+      composeTestRule.onNodeWithText(profile.name).assertIsDisplayed()
+    }
   }
 
   @Test
-  fun displayProfileCardsWhenNotEmpty() {
-    // Create mock profiles
-    val mockProfiles = listOf(mockProfile(), mockProfile().copy(uid = "2"))
-    profiles.value = mockProfiles
+  fun testAlreadyMetScreenEmptyState() = runTest {
+    // Mock repository to return empty list
+    Mockito.`when`(mockProfilesRepository.getMultipleProfiles(any(), any(), any())).thenAnswer {
+        invocation ->
+      val onSuccessCallback = invocation.getArgument<(List<Profile>) -> Unit>(1)
+      onSuccessCallback(emptyList())
+      null
+    }
 
-    composeTestRule.setContent { AlreadyMetScreen(navigationActions, profilesViewModel) }
+    composeTestRule.setContent {
+      AlreadyMetScreen(
+          navigationActions = navigationActions,
+          profilesViewModel = profilesViewModel,
+          isTestMode = true)
+    }
 
-    // Verify profile cards are displayed
-    composeTestRule.onAllNodesWithTag("profileCard").assertCountEquals(2)
+    profilesViewModel.getAlreadyMetUsers()
+    composeTestRule.waitForIdle()
+
+    // Verify empty state message
+    composeTestRule
+        .onNodeWithText(context.getString(R.string.no_already_met_users))
+        .assertIsDisplayed()
   }
 
   @Test
-  fun testProfileCardNavigation() {
-    val mockProfile = mockProfile()
-    profiles.value = listOf(mockProfile)
+  fun testUnmeetUserFlow() = runTest {
+    fakeProfilesViewModel.setLoading(false)
 
-    composeTestRule.setContent { AlreadyMetScreen(navigationActions, profilesViewModel) }
+    composeTestRule.setContent {
+      AlreadyMetScreen(
+          navigationActions = navigationActions,
+          profilesViewModel = fakeProfilesViewModel,
+          isTestMode = true)
+    }
 
-    composeTestRule.onNodeWithTag("profileCard").performClick()
-    verify(navigationActions).navigateTo(Screen.OTHER_PROFILE_VIEW + "?userId=${mockProfile.uid}")
+    composeTestRule.waitForIdle()
+
+    alreadyMetProfiles.first().let { profile ->
+      composeTestRule.onNodeWithText(profile.name).performClick()
+    }
+
+    // Verify confirmation dialog
+    composeTestRule.onNodeWithTag("confirmDialog").assertIsDisplayed()
+    composeTestRule.onNodeWithText(context.getString(R.string.unmeet_confirm)).assertIsDisplayed()
+    composeTestRule
+        .onNodeWithText(context.getString(R.string.unmeet_confirm_message))
+        .assertIsDisplayed()
+    composeTestRule.onNodeWithText(context.getString(R.string.unmeet_yes)).assertIsDisplayed()
+    composeTestRule.onNodeWithText(context.getString(R.string.unmeet_no)).assertIsDisplayed()
   }
 
-  // Helper function to create a mock profile
-  private val birthDate2002 =
-      Timestamp(
-          Calendar.getInstance()
-              .apply {
-                set(2002, Calendar.JANUARY, 1, 0, 0, 0)
-                set(Calendar.MILLISECOND, 0)
-              }
-              .time)
+  @Test
+  fun testUnmeetUserConfirmation() = runTest {
+    composeTestRule.setContent {
+      AlreadyMetScreen(
+          navigationActions = navigationActions,
+          profilesViewModel = fakeProfilesViewModel,
+          isTestMode = true)
+    }
 
-  private fun mockProfile() =
-      Profile(
-          uid = "1",
-          name = "John Doe",
-          gender = Gender.MEN,
-          birthDate = birthDate2002,
-          catchPhrase = "Just a friendly guy",
-          description = "I love meeting new people.",
-          tags = listOf("friendly", "outgoing"))
+    composeTestRule.waitForIdle()
+
+    // Click on first already met profile
+    val firstProfile = alreadyMetProfiles.first()
+    composeTestRule.onNodeWithText(firstProfile.name).performClick()
+
+    // Click Yes on confirmation dialog
+    composeTestRule.onNodeWithText(context.getString(R.string.unmeet_yes)).performClick()
+
+    // Wait for the UI to update after unmeet action
+    composeTestRule.waitForIdle()
+
+    // Dialog should be dismissed
+    composeTestRule.onNodeWithTag("confirmDialog").assertDoesNotExist()
+  }
+
+  @Test
+  fun testUnmeetUserCancellation() = runTest {
+    fakeProfilesViewModel.setLoading(false)
+
+    composeTestRule.setContent {
+      AlreadyMetScreen(
+          navigationActions = navigationActions,
+          profilesViewModel = fakeProfilesViewModel,
+          isTestMode = true)
+    }
+
+    composeTestRule.waitForIdle()
+
+    // Click on first already met profile
+    val firstProfile = alreadyMetProfiles.first()
+    composeTestRule.onNodeWithText(firstProfile.name).performClick()
+
+    // Click No on confirmation dialog
+    composeTestRule.onNodeWithText(context.getString(R.string.unmeet_no)).performClick()
+
+    // Wait for the UI to update
+    composeTestRule.waitForIdle()
+
+    // Dialog should be dismissed
+    composeTestRule.onNodeWithTag("confirmDialog").assertDoesNotExist()
+
+    // Profile should still be visible
+    composeTestRule.onNodeWithText(firstProfile.name).assertIsDisplayed()
+  }
+
+  @Test
+  fun testPullToRefresh() = runTest {
+    fakeProfilesViewModel.updateIsConnected(true)
+
+    composeTestRule.setContent {
+      AlreadyMetScreen(
+          navigationActions = navigationActions,
+          profilesViewModel = fakeProfilesViewModel,
+          isTestMode = true)
+    }
+
+    // Verify refresh indicator exists
+    composeTestRule.onNodeWithTag("refreshIndicator").assertExists()
+  }
 }

--- a/app/src/androidTest/java/com/github/se/icebreakrr/ui/sections/UnblockProfileTest.kt
+++ b/app/src/androidTest/java/com/github/se/icebreakrr/ui/sections/UnblockProfileTest.kt
@@ -66,7 +66,7 @@ class UnblockProfileTest {
           profilesViewModel = profilesViewModel,
           isTestMode = true)
     }
-    composeTestRule.onNodeWithTag("unblockScreen").assertIsDisplayed()
+    composeTestRule.onNodeWithTag("profileListScreen").assertIsDisplayed()
     composeTestRule.onNodeWithTag("bottomNavigationMenu").assertIsDisplayed()
     composeTestRule.onNodeWithTag("topBar").assertIsDisplayed()
   }
@@ -120,7 +120,7 @@ class UnblockProfileTest {
     composeTestRule.waitForIdle()
 
     composeTestRule.onNodeWithText(blockedProfiles[0].name).performClick()
-    composeTestRule.onNodeWithTag("unblockDialog").assertIsDisplayed()
+    composeTestRule.onNodeWithTag("confirmDialog").assertIsDisplayed()
     composeTestRule.onNodeWithText("Yes").assertIsDisplayed()
     composeTestRule.onNodeWithText("No").assertIsDisplayed()
     composeTestRule.onNodeWithText("Unblock ?").assertIsDisplayed()
@@ -141,8 +141,9 @@ class UnblockProfileTest {
     composeTestRule.waitForIdle()
 
     composeTestRule.onNodeWithText(blockedProfiles[0].name).performClick()
+    composeTestRule.onNodeWithText("No").assertIsDisplayed()
     composeTestRule.onNodeWithText("No").performClick()
-    composeTestRule.onNodeWithTag("unblockDialog").assertIsNotDisplayed()
+    composeTestRule.onNodeWithTag("confirmDialog").assertIsNotDisplayed()
     composeTestRule.onNodeWithText(blockedProfiles[0].name).assertIsDisplayed()
   }
 

--- a/app/src/main/java/com/github/se/icebreakrr/mock/MockProfiles.kt
+++ b/app/src/main/java/com/github/se/icebreakrr/mock/MockProfiles.kt
@@ -255,6 +255,21 @@ fun Profile.Companion.getMockedProfiles(): List<Profile> {
           listOf(),
           listOf())
 
+  val hasAlreadyMetList =
+      listOf(
+          listOf("4", "5"),
+          listOf(),
+          listOf(),
+          listOf(),
+          listOf(),
+          listOf(),
+          listOf(),
+          listOf(),
+          listOf(),
+          listOf(),
+          listOf(),
+          listOf())
+
   val profiles = mutableListOf<Profile>()
   for (i in uids.indices) {
     profiles.add(
@@ -267,7 +282,8 @@ fun Profile.Companion.getMockedProfiles(): List<Profile> {
             description = descriptions[i],
             tags = tagsList[i],
             profilePictureUrl = null,
-            hasBlocked = hasBlockedList[i]))
+            hasBlocked = hasBlockedList[i],
+            hasAlreadyMet = hasAlreadyMetList[i]))
   }
   return profiles
 }

--- a/app/src/main/java/com/github/se/icebreakrr/mock/MockProfiles.kt
+++ b/app/src/main/java/com/github/se/icebreakrr/mock/MockProfiles.kt
@@ -64,14 +64,6 @@ open class MockProfileRepository : ProfilesRepository {
     onSuccess(Profile.getMockedProfiles().filter { it.uid in uidList })
   }
 
-  override fun getAlreadyMetProfiles(
-      alreadyMetProfiles: List<String>,
-      onSuccess: (List<Profile>) -> Unit,
-      onFailure: (Exception) -> Unit
-  ) {
-    onSuccess(Profile.getMockedProfiles().filter { it.uid in alreadyMetProfiles })
-  }
-
   // Simulates successful profile addition by calling onSuccess
   override fun addNewProfile(
       profile: Profile,

--- a/app/src/main/java/com/github/se/icebreakrr/mock/MockProfiles.kt
+++ b/app/src/main/java/com/github/se/icebreakrr/mock/MockProfiles.kt
@@ -249,7 +249,7 @@ fun Profile.Companion.getMockedProfiles(): List<Profile> {
 
   val hasAlreadyMetList =
       listOf(
-          listOf("4", "5"),
+          listOf("4"),
           listOf(),
           listOf(),
           listOf(),

--- a/app/src/main/java/com/github/se/icebreakrr/mock/MockProfiles.kt
+++ b/app/src/main/java/com/github/se/icebreakrr/mock/MockProfiles.kt
@@ -64,6 +64,14 @@ open class MockProfileRepository : ProfilesRepository {
     onSuccess(Profile.getMockedProfiles().filter { it.uid in blockedProfiles })
   }
 
+  override fun getAlreadyMetProfiles(
+      alreadyMetProfiles: List<String>,
+      onSuccess: (List<Profile>) -> Unit,
+      onFailure: (Exception) -> Unit
+  ) {
+    onSuccess(Profile.getMockedProfiles().filter { it.uid in alreadyMetProfiles })
+  }
+
   // Simulates successful profile addition by calling onSuccess
   override fun addNewProfile(
       profile: Profile,

--- a/app/src/main/java/com/github/se/icebreakrr/model/profile/Profile.kt
+++ b/app/src/main/java/com/github/se/icebreakrr/model/profile/Profile.kt
@@ -29,6 +29,7 @@ data class Profile(
     val location: GeoPoint? = null,
     val geohash: String? = null,
     var hasBlocked: List<String> = listOf(),
+    var hasAlreadyMet: List<String> = listOf(),
     val meetingRequestSent: List<String> = listOf(),
     val meetingRequestInbox: Map<String, String> = mapOf()
 ) {

--- a/app/src/main/java/com/github/se/icebreakrr/model/profile/ProfilesRepository.kt
+++ b/app/src/main/java/com/github/se/icebreakrr/model/profile/ProfilesRepository.kt
@@ -31,6 +31,12 @@ interface ProfilesRepository {
       onFailure: (Exception) -> Unit
   )
 
+  fun getAlreadyMetProfiles(
+      alreadyMetProfiles: List<String>,
+      onSuccess: (List<Profile>) -> Unit,
+      onFailure: (Exception) -> Unit
+  )
+
   fun addNewProfile(profile: Profile, onSuccess: () -> Unit, onFailure: (Exception) -> Unit)
 
   fun updateProfile(profile: Profile, onSuccess: () -> Unit, onFailure: (Exception) -> Unit)

--- a/app/src/main/java/com/github/se/icebreakrr/model/profile/ProfilesRepository.kt
+++ b/app/src/main/java/com/github/se/icebreakrr/model/profile/ProfilesRepository.kt
@@ -31,12 +31,6 @@ interface ProfilesRepository {
       onFailure: (Exception) -> Unit
   )
 
-  fun getAlreadyMetProfiles(
-      alreadyMetProfiles: List<String>,
-      onSuccess: (List<Profile>) -> Unit,
-      onFailure: (Exception) -> Unit
-  )
-
   fun addNewProfile(profile: Profile, onSuccess: () -> Unit, onFailure: (Exception) -> Unit)
 
   fun updateProfile(profile: Profile, onSuccess: () -> Unit, onFailure: (Exception) -> Unit)

--- a/app/src/main/java/com/github/se/icebreakrr/model/profile/ProfilesRepositoryFirestore.kt
+++ b/app/src/main/java/com/github/se/icebreakrr/model/profile/ProfilesRepositoryFirestore.kt
@@ -214,36 +214,6 @@ class ProfilesRepositoryFirestore(
         }
   }
 
-  override fun getAlreadyMetProfiles(
-      alreadyMetProfiles: List<String>,
-      onSuccess: (List<Profile>) -> Unit,
-      onFailure: (Exception) -> Unit
-  ) {
-    if (alreadyMetProfiles.isEmpty()) {
-      onSuccess(emptyList())
-      return
-    }
-    db.collection(collectionPath)
-        .whereIn("uid", alreadyMetProfiles)
-        .get()
-        .addOnSuccessListener { result ->
-          waitingDone.value = false
-          isWaiting.value = false
-          val profiles = result.documents.mapNotNull { documentToProfile(it) }
-          onSuccess(profiles)
-        }
-        .addOnFailureListener { e ->
-          Log.e("ProfilesRepositoryFirestore", "Error getting profiles", e)
-          if (e is com.google.firebase.firestore.FirebaseFirestoreException) {
-            if (!_isWaiting.value && !_waitingDone.value) {
-              _isWaiting.value = true
-              handleConnectionFailure(onFailure)
-            }
-            onFailure(e)
-          }
-        }
-  }
-
   /**
    * Adds a new profile to Firestore.
    *

--- a/app/src/main/java/com/github/se/icebreakrr/model/profile/ProfilesViewModel.kt
+++ b/app/src/main/java/com/github/se/icebreakrr/model/profile/ProfilesViewModel.kt
@@ -146,7 +146,10 @@ open class ProfilesViewModel(
                     !(_selfProfile.value?.hasBlocked?.contains(profile.uid) ?: false) &&
 
                     // Filter by isBlocked
-                    !(profile.hasBlocked.contains(_selfProfile.value?.uid ?: ""))
+                    !(profile.hasBlocked.contains(_selfProfile.value?.uid ?: "")) &&
+
+                    // Filter by hasAlreadyMet
+                    !(_selfProfile.value?.hasAlreadyMet?.contains(profile.uid) ?: false)
               }
           _profiles.value = profileList
           _filteredProfiles.value = filteredProfiles
@@ -343,6 +346,43 @@ open class ProfilesViewModel(
     _loading.value = true
     repository.getBlockedProfiles(
         selfProfile.value?.hasBlocked ?: emptyList(),
+        onSuccess = { profileList ->
+          _profiles.value = profileList
+          _loading.value = false
+          _isConnected.value = true
+        },
+        onFailure = { e -> handleError(e) })
+  }
+
+  /**
+   * Adds user to current user's already met list in the repository.
+   *
+   * @param uid The unique ID of the user being added.
+   */
+  fun addAlreadyMet(uid: String) {
+    _selfProfile.update { currentProfile ->
+      currentProfile?.copy(hasAlreadyMet = currentProfile.hasAlreadyMet + uid)
+    }
+    updateProfile(selfProfile.value!!)
+  }
+
+  /**
+   * Removes user to current user's already met list in the repository.
+   *
+   * @param uid The unique ID of the user being removed.
+   */
+  fun removeAlreadyMet(uid: String) {
+    _selfProfile.update { currentProfile ->
+      currentProfile?.copy(hasAlreadyMet = currentProfile.hasAlreadyMet.filter { it != uid })
+    }
+    updateProfile(selfProfile.value!!)
+    getBlockedUsers()
+  }
+
+  fun getAlreadyMetUsers() {
+    _loading.value = true
+    repository.getAlreadyMetProfiles(
+        selfProfile.value?.hasAlreadyMet ?: emptyList(),
         onSuccess = { profileList ->
           _profiles.value = profileList
           _loading.value = false

--- a/app/src/main/java/com/github/se/icebreakrr/model/profile/ProfilesViewModel.kt
+++ b/app/src/main/java/com/github/se/icebreakrr/model/profile/ProfilesViewModel.kt
@@ -154,12 +154,11 @@ open class ProfilesViewModel(
 
                     // Filter by isBlocked
                     !(profile.hasBlocked.contains(currentUserId)) &&
-
                     !(profile.hasBlocked.contains(_selfProfile.value?.uid ?: "")) &&
 
                     // Filter by hasAlreadyMet
                     !(_selfProfile.value?.hasAlreadyMet?.contains(profile.uid) ?: false) &&
-                
+
                     // Filter by how you have reported
                     profile.reports[currentUserId] == null
               }

--- a/app/src/main/java/com/github/se/icebreakrr/model/profile/ProfilesViewModel.kt
+++ b/app/src/main/java/com/github/se/icebreakrr/model/profile/ProfilesViewModel.kt
@@ -409,7 +409,7 @@ open class ProfilesViewModel(
 
   fun getAlreadyMetUsers() {
     _loading.value = true
-    repository.getAlreadyMetProfiles(
+    repository.getMultipleProfiles(
         selfProfile.value?.hasAlreadyMet ?: emptyList(),
         onSuccess = { profileList ->
           _profiles.value = profileList

--- a/app/src/main/java/com/github/se/icebreakrr/ui/profile/OtherProfileView.kt
+++ b/app/src/main/java/com/github/se/icebreakrr/ui/profile/OtherProfileView.kt
@@ -39,6 +39,8 @@ import com.github.se.icebreakrr.ui.message.SendRequestScreen
 import com.github.se.icebreakrr.ui.navigation.NavigationActions
 import com.github.se.icebreakrr.ui.sections.shared.InfoSection
 import com.github.se.icebreakrr.ui.sections.shared.ProfileHeader
+import com.github.se.icebreakrr.utils.NetworkUtils.isNetworkAvailableWithContext
+import com.github.se.icebreakrr.utils.NetworkUtils.showNoInternetToast
 
 /**
  * In Around You, when you click on a profile, this is the composable used to display it
@@ -103,7 +105,15 @@ fun OtherProfileView(
             // Already met button
             Button(
                 onClick = {
-                  Toast.makeText(context, R.string.Not_Implemented_Toast, Toast.LENGTH_SHORT).show()
+                  if (isNetworkAvailableWithContext(context)) {
+                    profilesViewModel.addAlreadyMet(profile.uid)
+                    Toast.makeText(context, R.string.Already_Met_Button_Success, Toast.LENGTH_SHORT)
+                        .show()
+                    profilesViewModel.getSelfProfile()
+                    navigationActions.goBack()
+                  } else {
+                    showNoInternetToast(context = context)
+                  }
                 },
                 colors =
                     ButtonDefaults.buttonColors(containerColor = MaterialTheme.colorScheme.primary),

--- a/app/src/main/java/com/github/se/icebreakrr/ui/sections/AlreadyMet.kt
+++ b/app/src/main/java/com/github/se/icebreakrr/ui/sections/AlreadyMet.kt
@@ -44,13 +44,14 @@ fun AlreadyMetScreen(
       profilesViewModel = profilesViewModel,
       title = stringResource(R.string.already_met),
       emptyMessage = stringResource(R.string.no_already_met_users),
-      onProfileClick = { profile ->
+      onProfileClickConfirm = { profile ->
         if (isNetworkAvailableWithContext(context)) {
           profileToUnmeet = profile
         } else {
           showNoInternetToast(context)
         }
       },
+      onProfileClickDismiss = { profileToUnmeet = null },
       profiles = alreadyMetProfiles,
       isLoading = isLoading,
       isConnected = isConnected,

--- a/app/src/main/java/com/github/se/icebreakrr/ui/sections/Settings.kt
+++ b/app/src/main/java/com/github/se/icebreakrr/ui/sections/Settings.kt
@@ -149,7 +149,13 @@ fun SettingsScreen(
           Spacer(modifier = Modifier.padding(vertical = BUTTON_PADDING))
 
           Button(
-              onClick = { navigationActions.navigateTo(Screen.ALREADY_MET) },
+              onClick = {
+                if (isNetworkAvailableWithContext(context) || isTesting) {
+                  navigationActions.navigateTo(Screen.ALREADY_MET)
+                } else {
+                  Toast.makeText(context, R.string.No_Internet_Toast, Toast.LENGTH_SHORT).show()
+                }
+              },
               colors =
                   ButtonDefaults.buttonColors(containerColor = MaterialTheme.colorScheme.secondary),
               modifier = Modifier.fillMaxWidth().testTag("alreadyMetButton")) {

--- a/app/src/main/java/com/github/se/icebreakrr/ui/sections/UnblockProfile.kt
+++ b/app/src/main/java/com/github/se/icebreakrr/ui/sections/UnblockProfile.kt
@@ -1,203 +1,73 @@
 package com.github.se.icebreakrr.ui.sections
 
-import android.annotation.SuppressLint
-import androidx.compose.foundation.layout.Arrangement
-import androidx.compose.foundation.layout.Box
-import androidx.compose.foundation.layout.BoxScope
-import androidx.compose.foundation.layout.PaddingValues
-import androidx.compose.foundation.layout.fillMaxSize
-import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.lazy.LazyColumn
-import androidx.compose.material3.*
-import androidx.compose.material3.ExperimentalMaterial3Api
-import androidx.compose.material3.Scaffold
-import androidx.compose.material3.Text
-import androidx.compose.material3.pulltorefresh.PullToRefreshDefaults.Indicator
-import androidx.compose.material3.pulltorefresh.PullToRefreshState
-import androidx.compose.material3.pulltorefresh.pullToRefresh
-import androidx.compose.material3.pulltorefresh.rememberPullToRefreshState
-import androidx.compose.runtime.*
+import ProfileListScreen
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
-import androidx.compose.ui.Alignment
-import androidx.compose.ui.Modifier
-import androidx.compose.ui.platform.testTag
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
-import androidx.compose.ui.text.font.FontWeight
-import androidx.compose.ui.unit.dp
-import androidx.compose.ui.unit.sp
 import com.github.se.icebreakrr.R
 import com.github.se.icebreakrr.model.profile.Profile
 import com.github.se.icebreakrr.model.profile.ProfilesViewModel
-import com.github.se.icebreakrr.ui.navigation.BottomNavigationMenu
-import com.github.se.icebreakrr.ui.navigation.LIST_TOP_LEVEL_DESTINATIONS
 import com.github.se.icebreakrr.ui.navigation.NavigationActions
-import com.github.se.icebreakrr.ui.navigation.Route
-import com.github.se.icebreakrr.ui.sections.shared.ProfileCard
-import com.github.se.icebreakrr.ui.sections.shared.TopBar
-import com.github.se.icebreakrr.ui.theme.messageTextColor
-import com.github.se.icebreakrr.utils.NetworkUtils.isNetworkAvailable
-import kotlinx.coroutines.delay
-
-// Constants for layout dimensions
-private val COLUMN_VERTICAL_PADDING = 16.dp
-private val COLUMN_HORIZONTAL_PADDING = 8.dp
-private val TEXT_SIZE_LARGE = 20.sp
-private val NO_CONNECTION_TEXT_COLOR = messageTextColor
-private val EMPTY_PROFILE_TEXT_COLOR = messageTextColor
-private const val REFRESH_INTERVAL = 10_000L
-
-@OptIn(ExperimentalMaterial3Api::class)
-@SuppressLint("UnusedMaterial3ScaffoldPaddingParameter")
-@Composable
+import com.github.se.icebreakrr.utils.NetworkUtils.isNetworkAvailableWithContext
+import com.github.se.icebreakrr.utils.NetworkUtils.showNoInternetToast
 
 /**
- * Composable function for displaying the "Around You" screen.
+ * Composable function for displaying the "Blocked" screen.
  *
  * It includes a bottom navigation bar and displays the main content of the screen.
  *
  * @param navigationActions The actions used for navigating between screens.
  * @param profilesViewModel The view model of the profiles
  */
+@Composable
 fun UnblockProfileScreen(
     navigationActions: NavigationActions,
     profilesViewModel: ProfilesViewModel,
     isTestMode: Boolean = false
 ) {
-
   val blockedProfiles = profilesViewModel.profiles.collectAsState()
   val isLoading = profilesViewModel.loading.collectAsState()
   val isConnected = profilesViewModel.isConnected.collectAsState()
+  val context = LocalContext.current
 
   var profileToUnblock by remember { mutableStateOf<Profile?>(null) }
 
-  if (profileToUnblock != null) {
-    AlertDialog(
-        modifier = Modifier.testTag("unblockDialog"),
-        onDismissRequest = { profileToUnblock = null },
-        title = { Text(stringResource(R.string.unblock_confirm)) },
-        text = { Text(stringResource(R.string.unblock_confirm_message, profileToUnblock!!.name)) },
-        confirmButton = {
-          TextButton(
-              onClick = {
-                profilesViewModel.unblockUser(profileToUnblock!!.uid)
-                profilesViewModel.getBlockedUsers()
-                profileToUnblock = null
-              }) {
-                Text(stringResource(R.string.block_yes))
-              }
-        },
-        dismissButton = {
-          TextButton(onClick = { profileToUnblock = null }) {
-            Text(stringResource(R.string.block_no))
-          }
-        })
-  }
-
-  // Initial check and start of periodic update every 10 seconds
-  LaunchedEffect(isConnected.value) {
-    if (!isTestMode && !isNetworkAvailable()) {
-      profilesViewModel.updateIsConnected(false)
-    } else {
-      while (true) {
-        // Call the profile fetch function
-        profilesViewModel.getBlockedUsers()
-
-        // Wait 10 seconds before the next update
-        delay(REFRESH_INTERVAL)
-      }
-    }
-  }
-
-  Scaffold(
-      modifier = Modifier.testTag("unblockScreen"),
-      bottomBar = {
-        BottomNavigationMenu(
-            onTabSelect = { route ->
-              if (navigationActions.currentRoute() != Route.SETTINGS &&
-                  route.route == Route.SETTINGS) {
-                navigationActions.navigateTo(Route.SETTINGS)
-              } else {
-                navigationActions.navigateTo(route.route)
-              }
-            },
-            tabList = LIST_TOP_LEVEL_DESTINATIONS,
-            selectedItem = Route.UNBLOCK_PROFILE)
+  ProfileListScreen(
+      navigationActions = navigationActions,
+      profilesViewModel = profilesViewModel,
+      title = stringResource(R.string.blocked_profiles),
+      emptyMessage = stringResource(R.string.no_blocked_users),
+      onProfileClick = { profile ->
+        if (isNetworkAvailableWithContext(context)) {
+          profileToUnblock = profile
+        } else {
+          showNoInternetToast(context)
+        }
       },
-      topBar = {
-        TopBar(stringResource(R.string.blocked_profiles), true) { navigationActions.goBack() }
+      profiles = blockedProfiles,
+      isLoading = isLoading,
+      isConnected = isConnected,
+      onRefresh = { profilesViewModel.getBlockedUsers() },
+      additionalRefreshAction = { profilesViewModel.getSelfProfile() },
+      showConfirmDialog = profileToUnblock != null,
+      confirmDialogTitle = stringResource(R.string.unblock_confirm),
+      confirmDialogMessage =
+          profileToUnblock?.let { stringResource(R.string.unblock_confirm_message, it.name) },
+      confirmButtonText = stringResource(R.string.block_yes),
+      dismissButtonText = stringResource(R.string.block_no),
+      onConfirmAction = {
+        profileToUnblock?.let { profile ->
+          profilesViewModel.unblockUser(profile.uid)
+          profilesViewModel.getBlockedUsers()
+          profileToUnblock = null
+        }
       },
-      content = { innerPadding ->
-        PullToRefreshBox(
-            isRefreshing = isLoading.value,
-            onRefresh = {
-              profilesViewModel.getSelfProfile()
-              profilesViewModel.getBlockedUsers()
-            },
-            modifier = Modifier.padding(innerPadding)) {
-              LazyColumn(
-                  contentPadding = PaddingValues(vertical = COLUMN_VERTICAL_PADDING),
-                  verticalArrangement = Arrangement.spacedBy(COLUMN_VERTICAL_PADDING),
-                  modifier =
-                      Modifier.fillMaxSize().padding(horizontal = COLUMN_HORIZONTAL_PADDING)) {
-                    if (blockedProfiles.value.isNotEmpty()) {
-                      items(blockedProfiles.value.size) { index ->
-                        ProfileCard(
-                            profile = blockedProfiles.value[index],
-                            onclick = { profileToUnblock = blockedProfiles.value[index] })
-                      }
-                    } else {
-                      item {
-                        Box(
-                            contentAlignment = Alignment.Center,
-                            modifier = Modifier.fillMaxSize().testTag("emptyProfilePrompt")) {
-                              Text(
-                                  text = stringResource(id = R.string.no_blocked_users),
-                                  fontSize = TEXT_SIZE_LARGE,
-                                  fontWeight = FontWeight.Bold,
-                                  color = EMPTY_PROFILE_TEXT_COLOR)
-                            }
-                      }
-                    }
-                  }
-            }
-      })
-}
-
-/**
- * A composable container with pull-to-refresh functionality, displaying a refresh indicator while
- * refreshing.
- *
- * @param isRefreshing Whether the refresh operation is ongoing; the indicator shows while true.
- * @param onRefresh Called on pull-to-refresh with parameters for filtering:
- * @param modifier [Modifier] for styling the container.
- * @param state State for managing pull-to-refresh gesture.
- * @param contentAlignment Alignment for the content within the box.
- * @param indicator Refresh indicator composable, centered by default.
- * @param content The main content to display inside the container.
- */
-@Composable
-@ExperimentalMaterial3Api
-fun PullToRefreshBox(
-    isRefreshing: Boolean,
-    onRefresh: () -> Unit,
-    modifier: Modifier = Modifier,
-    state: PullToRefreshState = rememberPullToRefreshState(),
-    contentAlignment: Alignment = Alignment.TopStart,
-    indicator: @Composable (BoxScope.() -> Unit) = {
-      Indicator(
-          modifier = Modifier.align(Alignment.TopCenter).testTag("refreshIndicator"),
-          isRefreshing = isRefreshing,
-          state = state)
-    },
-    content: @Composable (BoxScope.() -> Unit)
-) {
-
-  Box(
-      modifier.pullToRefresh(state = state, isRefreshing = isRefreshing) { onRefresh() },
-      contentAlignment = contentAlignment) {
-        content()
-        indicator()
-      }
+      selectedProfile = profileToUnblock,
+      periodicRefreshAction = { profilesViewModel.getBlockedUsers() },
+      isTestMode = isTestMode)
 }

--- a/app/src/main/java/com/github/se/icebreakrr/ui/sections/UnblockProfile.kt
+++ b/app/src/main/java/com/github/se/icebreakrr/ui/sections/UnblockProfile.kt
@@ -42,13 +42,14 @@ fun UnblockProfileScreen(
       profilesViewModel = profilesViewModel,
       title = stringResource(R.string.blocked_profiles),
       emptyMessage = stringResource(R.string.no_blocked_users),
-      onProfileClick = { profile ->
+      onProfileClickConfirm = { profile ->
         if (isNetworkAvailableWithContext(context)) {
           profileToUnblock = profile
         } else {
           showNoInternetToast(context)
         }
       },
+      onProfileClickDismiss = { profileToUnblock = null },
       profiles = blockedProfiles,
       isLoading = isLoading,
       isConnected = isConnected,

--- a/app/src/main/java/com/github/se/icebreakrr/ui/sections/shared/ProfileListScreen.kt
+++ b/app/src/main/java/com/github/se/icebreakrr/ui/sections/shared/ProfileListScreen.kt
@@ -36,6 +36,8 @@ import com.github.se.icebreakrr.ui.theme.messageTextColor
 import com.github.se.icebreakrr.utils.NetworkUtils.isNetworkAvailable
 import kotlinx.coroutines.delay
 
+// This file was written with the help of CursorAI
+
 private val COLUMN_VERTICAL_PADDING = 16.dp
 private val COLUMN_HORIZONTAL_PADDING = 8.dp
 private val TEXT_SIZE_LARGE = 20.sp
@@ -43,6 +45,30 @@ private val NO_CONNECTION_TEXT_COLOR = messageTextColor
 private val EMPTY_PROFILE_TEXT_COLOR = messageTextColor
 private const val REFRESH_INTERVAL = 10_000L
 
+/**
+ * A composable function that displays a list of profiles with various interactive features.
+ *
+ * @param navigationActions Handler for navigation actions within the app
+ * @param profilesViewModel ViewModel managing profile-related data
+ * @param title Screen title displayed in the top bar
+ * @param emptyMessage Message to display when no profiles are available
+ * @param onProfileClickConfirm Callback when a profile is clicked and confirmed
+ * @param onProfileClickDismiss Callback when a profile selection is dismissed
+ * @param profiles State containing the list of profiles to display
+ * @param isLoading State indicating if data is being loaded
+ * @param isConnected State indicating network connectivity
+ * @param onRefresh Callback for refresh action
+ * @param additionalRefreshAction Optional additional action to perform on refresh
+ * @param showConfirmDialog Whether to show confirmation dialog
+ * @param confirmDialogTitle Title for confirmation dialog
+ * @param confirmDialogMessage Message for confirmation dialog
+ * @param confirmButtonText Text for confirm button
+ * @param dismissButtonText Text for dismiss button
+ * @param onConfirmAction Callback for confirmation action
+ * @param selectedProfile Currently selected profile
+ * @param periodicRefreshAction Optional action for periodic refresh
+ * @param isTestMode Flag to indicate if running in test mode
+ */
 @OptIn(ExperimentalMaterial3Api::class)
 @SuppressLint("UnusedMaterial3ScaffoldPaddingParameter")
 @Composable

--- a/app/src/main/java/com/github/se/icebreakrr/ui/sections/shared/ProfileListScreen.kt
+++ b/app/src/main/java/com/github/se/icebreakrr/ui/sections/shared/ProfileListScreen.kt
@@ -51,7 +51,8 @@ fun ProfileListScreen(
     profilesViewModel: ProfilesViewModel,
     title: String,
     emptyMessage: String,
-    onProfileClick: (Profile) -> Unit,
+    onProfileClickConfirm: (Profile) -> Unit,
+    onProfileClickDismiss: (Profile) -> Unit,
     profiles: State<List<Profile>>,
     isLoading: State<Boolean>,
     isConnected: State<Boolean>,
@@ -82,7 +83,7 @@ fun ProfileListScreen(
   if (showConfirmDialog && selectedProfile != null) {
     AlertDialog(
         modifier = Modifier.testTag("confirmDialog"),
-        onDismissRequest = { onProfileClick(selectedProfile) }, // Dismiss dialog
+        onDismissRequest = { onProfileClickDismiss(selectedProfile) }, // Dismiss dialog
         title = { Text(confirmDialogTitle ?: "") },
         text = { Text(confirmDialogMessage ?: "") },
         confirmButton = {
@@ -90,7 +91,7 @@ fun ProfileListScreen(
         },
         dismissButton = {
           TextButton(
-              onClick = { onProfileClick(selectedProfile) } // Dismiss dialog
+              onClick = { onProfileClickDismiss(selectedProfile) } // Dismiss dialog
               ) {
                 Text(dismissButtonText ?: "")
               }
@@ -131,7 +132,7 @@ fun ProfileListScreen(
                         items(profiles.value.size) { index: Int ->
                           ProfileCard(
                               profile = profiles.value[index],
-                              onclick = { onProfileClick(profiles.value[index]) })
+                              onclick = { onProfileClickConfirm(profiles.value[index]) })
                         }
                       } else {
                         item {

--- a/app/src/main/java/com/github/se/icebreakrr/ui/sections/shared/ProfileListScreen.kt
+++ b/app/src/main/java/com/github/se/icebreakrr/ui/sections/shared/ProfileListScreen.kt
@@ -1,0 +1,190 @@
+import android.annotation.SuppressLint
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.BoxScope
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.material3.AlertDialog
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.material3.pulltorefresh.PullToRefreshDefaults.Indicator
+import androidx.compose.material3.pulltorefresh.PullToRefreshState
+import androidx.compose.material3.pulltorefresh.pullToRefresh
+import androidx.compose.material3.pulltorefresh.rememberPullToRefreshState
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.State
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import com.github.se.icebreakrr.model.profile.Profile
+import com.github.se.icebreakrr.model.profile.ProfilesViewModel
+import com.github.se.icebreakrr.ui.navigation.BottomNavigationMenu
+import com.github.se.icebreakrr.ui.navigation.LIST_TOP_LEVEL_DESTINATIONS
+import com.github.se.icebreakrr.ui.navigation.NavigationActions
+import com.github.se.icebreakrr.ui.navigation.Route
+import com.github.se.icebreakrr.ui.sections.shared.ProfileCard
+import com.github.se.icebreakrr.ui.sections.shared.TopBar
+import com.github.se.icebreakrr.ui.theme.messageTextColor
+import com.github.se.icebreakrr.utils.NetworkUtils.isNetworkAvailable
+import kotlinx.coroutines.delay
+
+private val COLUMN_VERTICAL_PADDING = 16.dp
+private val COLUMN_HORIZONTAL_PADDING = 8.dp
+private val TEXT_SIZE_LARGE = 20.sp
+private val NO_CONNECTION_TEXT_COLOR = messageTextColor
+private val EMPTY_PROFILE_TEXT_COLOR = messageTextColor
+private const val REFRESH_INTERVAL = 10_000L
+
+@OptIn(ExperimentalMaterial3Api::class)
+@SuppressLint("UnusedMaterial3ScaffoldPaddingParameter")
+@Composable
+fun ProfileListScreen(
+    navigationActions: NavigationActions,
+    profilesViewModel: ProfilesViewModel,
+    title: String,
+    emptyMessage: String,
+    onProfileClick: (Profile) -> Unit,
+    profiles: State<List<Profile>>,
+    isLoading: State<Boolean>,
+    isConnected: State<Boolean>,
+    onRefresh: () -> Unit,
+    additionalRefreshAction: (() -> Unit)? = null,
+    showConfirmDialog: Boolean = false,
+    confirmDialogTitle: String? = null,
+    confirmDialogMessage: String? = null,
+    confirmButtonText: String? = null,
+    dismissButtonText: String? = null,
+    onConfirmAction: (() -> Unit)? = null,
+    selectedProfile: Profile? = null,
+    periodicRefreshAction: (() -> Unit)? = null,
+    isTestMode: Boolean = false
+) {
+  LaunchedEffect(isConnected.value) {
+    if (!isTestMode && !isNetworkAvailable()) {
+      profilesViewModel.updateIsConnected(false)
+    } else {
+      while (true) {
+        periodicRefreshAction?.invoke()
+        delay(REFRESH_INTERVAL)
+      }
+    }
+  }
+
+  // Add dialog if confirmation is needed
+  if (showConfirmDialog && selectedProfile != null) {
+    AlertDialog(
+        modifier = Modifier.testTag("confirmDialog"),
+        onDismissRequest = { onProfileClick(selectedProfile) }, // Dismiss dialog
+        title = { Text(confirmDialogTitle ?: "") },
+        text = { Text(confirmDialogMessage ?: "") },
+        confirmButton = {
+          TextButton(onClick = { onConfirmAction?.invoke() }) { Text(confirmButtonText ?: "") }
+        },
+        dismissButton = {
+          TextButton(
+              onClick = { onProfileClick(selectedProfile) } // Dismiss dialog
+              ) {
+                Text(dismissButtonText ?: "")
+              }
+        })
+  }
+
+  Scaffold(
+      modifier = Modifier.testTag("profileListScreen"),
+      bottomBar = {
+        BottomNavigationMenu(
+            onTabSelect = { route ->
+              if (navigationActions.currentRoute() != Route.SETTINGS &&
+                  route.route == Route.SETTINGS) {
+                navigationActions.navigateTo(Route.SETTINGS)
+              } else {
+                navigationActions.navigateTo(route.route)
+              }
+            },
+            tabList = LIST_TOP_LEVEL_DESTINATIONS,
+            selectedItem = Route.UNBLOCK_PROFILE)
+      },
+      topBar = { TopBar(title, true) { navigationActions.goBack() } },
+      content = { innerPadding ->
+        PullToRefreshBox(
+            isRefreshing = isLoading.value,
+            onRefresh = {
+              onRefresh()
+              additionalRefreshAction?.invoke()
+            },
+            modifier = Modifier.padding(innerPadding)) {
+              Box(modifier = Modifier.fillMaxSize()) {
+                LazyColumn(
+                    contentPadding = PaddingValues(vertical = COLUMN_VERTICAL_PADDING),
+                    verticalArrangement = Arrangement.spacedBy(COLUMN_VERTICAL_PADDING),
+                    modifier =
+                        Modifier.fillMaxSize().padding(horizontal = COLUMN_HORIZONTAL_PADDING)) {
+                      if (profiles.value.isNotEmpty()) {
+                        items(profiles.value.size) { index: Int ->
+                          ProfileCard(
+                              profile = profiles.value[index],
+                              onclick = { onProfileClick(profiles.value[index]) })
+                        }
+                      } else {
+                        item {
+                          Box(
+                              contentAlignment = Alignment.Center,
+                              modifier = Modifier.fillMaxSize().testTag("emptyProfilePrompt")) {
+                                Text(
+                                    text = emptyMessage,
+                                    fontSize = TEXT_SIZE_LARGE,
+                                    fontWeight = FontWeight.Bold,
+                                    color = EMPTY_PROFILE_TEXT_COLOR)
+                              }
+                        }
+                      }
+                    }
+              }
+            }
+      })
+}
+
+/**
+ * A composable container with pull-to-refresh functionality, displaying a refresh indicator while
+ * refreshing.
+ *
+ * @param isRefreshing Whether the refresh operation is ongoing; the indicator shows while true.
+ * @param onRefresh Called on pull-to-refresh with parameters for filtering:
+ * @param modifier [Modifier] for styling the container.
+ * @param state State for managing pull-to-refresh gesture.
+ * @param contentAlignment Alignment for the content within the box.
+ * @param indicator Refresh indicator composable, centered by default.
+ * @param content The main content to display inside the container.
+ */
+@Composable
+@ExperimentalMaterial3Api
+fun PullToRefreshBox(
+    isRefreshing: Boolean,
+    onRefresh: () -> Unit,
+    modifier: Modifier = Modifier,
+    state: PullToRefreshState = rememberPullToRefreshState(),
+    contentAlignment: Alignment = Alignment.TopStart,
+    indicator: @Composable (BoxScope.() -> Unit) = {
+      Indicator(
+          modifier = Modifier.align(Alignment.TopCenter).testTag("refreshIndicator"),
+          isRefreshing = isRefreshing,
+          state = state)
+    },
+    content: @Composable (BoxScope.() -> Unit)
+) {
+
+  Box(
+      modifier.pullToRefresh(state = state, isRefreshing = isRefreshing) { onRefresh() },
+      contentAlignment = contentAlignment) {
+        content()
+        indicator()
+      }
+}

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -32,6 +32,12 @@
 
     <string name="Already_Met_Button_Text">"I Already Met This Person"</string>
     <string name="Already_Met_Settings_Button">People You Already Met</string>
+    <string name="Already_Met_Button_Success">You successfully added this user to your already met list</string>
+    <string name="no_already_met_users">You haven\'t met anyone yet. Go explore the world!</string>
+    <string name="unmeet_confirm">Did you add this user by mistake?</string>
+    <string name="unmeet_confirm_message">Remove from your already met list?</string>
+    <string name="unmeet_yes">Yes</string>
+    <string name="unmeet_no">No</string>
 
     <string name="blocked_profiles">Blocked Profiles</string>
 


### PR DESCRIPTION
## Changes Made:

- Created a shared UI componenst ProfileListScreen.kt to modularise unblockScreen that is very similar to alreadyMetScreen
- Added a list to the Profile that tracks the already met users' profiles
- Added the methods to add remove already met user
- Check connectivity when user clicks on the already met page button in the settings and on the "i already met this person" button in the otherProfileView
- Filter out the already met users from the around you page