### PR TITLE
Feature/crop image part 2/2

### DIFF
--- a/app/src/androidTest/java/com/github/se/icebreakrr/ui/profile/profileEditTest.kt
+++ b/app/src/androidTest/java/com/github/se/icebreakrr/ui/profile/profileEditTest.kt
@@ -17,12 +17,14 @@ import com.google.firebase.Firebase
 import com.google.firebase.auth.FirebaseAuth
 import com.google.firebase.firestore.FirebaseFirestore
 import com.google.firebase.storage.storage
+import kotlinx.coroutines.flow.MutableStateFlow
 import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.mockito.Mockito
 import org.mockito.Mockito.mock
+import org.mockito.Mockito.`when`
 import org.mockito.kotlin.verify
 
 @RunWith(AndroidJUnit4::class)
@@ -54,6 +56,7 @@ class ProfileEditingScreenTest {
     var mockProfile = Profile.getMockedProfiles()[0]
     fakeProfilesViewModel.setSelectedProfile(mockProfile)
     fakeProfilesViewModel.setLoading(false)
+    fakeProfilesViewModel.setSelfProfile(mockProfile)
   }
 
   @Test

--- a/app/src/androidTest/java/com/github/se/icebreakrr/ui/profile/profileEditTest.kt
+++ b/app/src/androidTest/java/com/github/se/icebreakrr/ui/profile/profileEditTest.kt
@@ -17,14 +17,12 @@ import com.google.firebase.Firebase
 import com.google.firebase.auth.FirebaseAuth
 import com.google.firebase.firestore.FirebaseFirestore
 import com.google.firebase.storage.storage
-import kotlinx.coroutines.flow.MutableStateFlow
 import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.mockito.Mockito
 import org.mockito.Mockito.mock
-import org.mockito.Mockito.`when`
 import org.mockito.kotlin.verify
 
 @RunWith(AndroidJUnit4::class)

--- a/app/src/main/java/com/github/se/icebreakrr/model/profile/ProfilesViewModel.kt
+++ b/app/src/main/java/com/github/se/icebreakrr/model/profile/ProfilesViewModel.kt
@@ -269,7 +269,10 @@ open class ProfilesViewModel(
    * @param imageData The byte array representing the image data.
    * @param onSuccess A callback function that is invoked when the upload is successful.
    */
-  private fun uploadCurrentUserProfilePicture(imageData: ByteArray, onSuccess: (url: String?) -> Unit) {
+  private fun uploadCurrentUserProfilePicture(
+      imageData: ByteArray,
+      onSuccess: (url: String?) -> Unit
+  ) {
     val userId = _selfProfile.value?.uid ?: throw IllegalStateException("User not logged in")
     ppRepository.uploadProfilePicture(
         userId = userId,

--- a/app/src/main/java/com/github/se/icebreakrr/model/profile/ProfilesViewModel.kt
+++ b/app/src/main/java/com/github/se/icebreakrr/model/profile/ProfilesViewModel.kt
@@ -103,6 +103,11 @@ open class ProfilesViewModel(
     TO_DELETE
   }
 
+  /**
+   * Updates the profile picture change state.
+   *
+   * @param state The new state of the profile picture change.
+   */
   fun setPictureChangeState(state: ProfilePictureState) {
     _pictureChangeState.value = state
   }
@@ -261,8 +266,8 @@ open class ProfilesViewModel(
   /**
    * Uploads the current user's profile picture to the remote storage system.
    *
-   * @param imageData The byte array of the image file to be uploaded.
-   * @throws IllegalStateException if the user is not logged in.
+   * @param imageData The byte array representing the image data.
+   * @param onSuccess A callback function that is invoked when the upload is successful.
    */
   fun uploadCurrentUserProfilePicture(imageData: ByteArray, onSuccess: (url: String?) -> Unit) {
     val userId = _selfProfile.value?.uid ?: throw IllegalStateException("User not logged in")
@@ -320,6 +325,11 @@ open class ProfilesViewModel(
     _pictureChangeState.value = ProfilePictureState.TO_UPLOAD
   }
 
+  /**
+   * Validates the profile changes and updates both the image and the profile repository.
+   *
+   * @param context The context used to show a Toast message in case of failure.
+   */
   fun validateProfileChanges(context: Context) {
     when (_pictureChangeState.value) {
       ProfilePictureState.TO_UPLOAD ->
@@ -334,7 +344,7 @@ open class ProfilesViewModel(
 
             resetProfileEditionState()
           }
-      ProfilePictureState.TO_DELETE ->
+      TO_DELETE ->
           deleteCurrentUserProfilePicture() {
             val newProfile = _editedCurrentProfile.value?.copy(profilePictureUrl = null)
             updateProfile(newProfile!!)
@@ -352,9 +362,10 @@ open class ProfilesViewModel(
   }
 
   /**
-   * Validates and uploads the profile picture if a temporary profile picture Bitmap exists.
+   * Validates and uploads the profile picture to the remote storage system.
    *
    * @param context The context used to show a Toast message in case of failure.
+   * @param onSuccess A callback function that is invoked when the upload is successful.
    */
   fun validateAndUploadProfilePicture(context: Context, onSuccess: (url: String?) -> Unit) {
     val imageData = bitmapToJpgByteArray(tempProfilePictureBitmap.value ?: return)
@@ -368,7 +379,7 @@ open class ProfilesViewModel(
   /**
    * Deletes the current user's profile picture from the remote storage system.
    *
-   * @throws IllegalStateException if the user is not logged in.
+   * @param onSuccess A callback function that is invoked when the deletion is successful.
    */
   fun deleteCurrentUserProfilePicture(onSuccess: () -> Unit) {
     ppRepository.deleteProfilePicture(

--- a/app/src/main/java/com/github/se/icebreakrr/model/profile/ProfilesViewModel.kt
+++ b/app/src/main/java/com/github/se/icebreakrr/model/profile/ProfilesViewModel.kt
@@ -8,6 +8,8 @@ import android.util.Log
 import android.widget.Toast
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.ViewModelProvider
+import com.github.se.icebreakrr.model.profile.ProfilesViewModel.ProfilePictureState.TO_DELETE
+import com.github.se.icebreakrr.model.profile.ProfilesViewModel.ProfilePictureState.UNCHANGED
 import com.github.se.icebreakrr.ui.sections.DEFAULT_RADIUS
 import com.github.se.icebreakrr.ui.sections.DEFAULT_USER_LATITUDE
 import com.github.se.icebreakrr.ui.sections.DEFAULT_USER_LONGITUDE

--- a/app/src/main/java/com/github/se/icebreakrr/model/profile/ProfilesViewModel.kt
+++ b/app/src/main/java/com/github/se/icebreakrr/model/profile/ProfilesViewModel.kt
@@ -269,7 +269,7 @@ open class ProfilesViewModel(
    * @param imageData The byte array representing the image data.
    * @param onSuccess A callback function that is invoked when the upload is successful.
    */
-  fun uploadCurrentUserProfilePicture(imageData: ByteArray, onSuccess: (url: String?) -> Unit) {
+  private fun uploadCurrentUserProfilePicture(imageData: ByteArray, onSuccess: (url: String?) -> Unit) {
     val userId = _selfProfile.value?.uid ?: throw IllegalStateException("User not logged in")
     ppRepository.uploadProfilePicture(
         userId = userId,
@@ -381,7 +381,7 @@ open class ProfilesViewModel(
    *
    * @param onSuccess A callback function that is invoked when the deletion is successful.
    */
-  fun deleteCurrentUserProfilePicture(onSuccess: () -> Unit) {
+  private fun deleteCurrentUserProfilePicture(onSuccess: () -> Unit) {
     ppRepository.deleteProfilePicture(
         userId = _selfProfile.value?.uid ?: throw IllegalStateException("User not logged in"),
         onSuccess = onSuccess,

--- a/app/src/main/java/com/github/se/icebreakrr/ui/profile/ProfileEdit.kt
+++ b/app/src/main/java/com/github/se/icebreakrr/ui/profile/ProfileEdit.kt
@@ -110,10 +110,6 @@ fun ProfileEditingScreen(
         catchPhrase = catchphrase.text, description = description.text, tags = selectedTags)
   }
 
-  fun updateProfile() {
-    profilesViewModel.updateProfile(getEditedProfile())
-  }
-
   if (isLoading) {
     Box(
         modifier = Modifier.fillMaxSize().background(Color.LightGray).testTag("loadingBox"),
@@ -176,7 +172,16 @@ fun ProfileEditingScreen(
                       Toast.makeText(context, "Failed to select image", Toast.LENGTH_SHORT).show()
                     },
                     onDeletion = {
-                      // todo
+                        when (pictureChangeState) {
+                          UNCHANGED -> { // delete current profile picture
+                              if (user.profilePictureUrl != null) {
+                                  profilesViewModel.setPictureChangeState(TO_DELETE)
+                                  isModified = true
+                              }
+                          }
+                            // else cancel changes
+                          else -> profilesViewModel.setPictureChangeState(UNCHANGED)
+                        }
                     })
 
                 Spacer(modifier = Modifier.height(padding))

--- a/app/src/main/java/com/github/se/icebreakrr/ui/profile/ProfileEdit.kt
+++ b/app/src/main/java/com/github/se/icebreakrr/ui/profile/ProfileEdit.kt
@@ -43,6 +43,7 @@ import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import com.github.se.icebreakrr.model.profile.Profile
 import com.github.se.icebreakrr.model.profile.ProfilesViewModel
+import com.github.se.icebreakrr.model.profile.ProfilesViewModel.ProfilePictureState.*
 import com.github.se.icebreakrr.model.tags.TagsViewModel
 import com.github.se.icebreakrr.ui.navigation.NavigationActions
 import com.github.se.icebreakrr.ui.navigation.Screen
@@ -82,27 +83,35 @@ fun ProfileEditingScreen(
   }
 
   val isLoading = profilesViewModel.loading.collectAsState(initial = true).value
-  val user = profilesViewModel.selectedProfile.collectAsState().value
+  val pictureChangeState = profilesViewModel.pictureChangeState.collectAsState().value
+  val user = profilesViewModel.selfProfile.collectAsState().value!!
+  val editedCurrentProfile = profilesViewModel.editedCurrentProfile.collectAsState().value
   val tempBitmap = profilesViewModel.tempProfilePictureBitmap.collectAsState().value
 
-  var catchphrase by remember { mutableStateOf(TextFieldValue(user!!.catchPhrase)) }
-  var description by remember { mutableStateOf(TextFieldValue(user!!.description)) }
+  var catchphrase by remember {
+    mutableStateOf(TextFieldValue(editedCurrentProfile?.catchPhrase ?: user.catchPhrase))
+  }
+  var description by remember {
+    mutableStateOf(TextFieldValue(editedCurrentProfile?.description ?: user.description))
+  }
   val expanded = remember { mutableStateOf(false) }
 
   var showDialog by remember { mutableStateOf(false) }
-  var isModified by remember { mutableStateOf(false) }
+  var isModified by remember {
+    mutableStateOf(editedCurrentProfile != null || pictureChangeState != UNCHANGED)
+  }
 
   val selectedTags = tagsViewModel.filteringTags.collectAsState().value
   val tagsSuggestions = tagsViewModel.tagsSuggestions.collectAsState()
   val stringQuery = remember { mutableStateOf("") }
 
-  fun getCopyOfProfile(): Profile {
-    return user!!.copy(
+  fun getEditedProfile(): Profile {
+    return user.copy(
         catchPhrase = catchphrase.text, description = description.text, tags = selectedTags)
   }
 
   fun updateProfile() {
-    profilesViewModel.updateProfile(getCopyOfProfile())
+    profilesViewModel.updateProfile(getEditedProfile())
   }
 
   if (isLoading) {
@@ -111,7 +120,7 @@ fun ProfileEditingScreen(
         contentAlignment = Alignment.Center) {
           Text("Loading profile...", textAlign = TextAlign.Center)
         }
-  } else if (user != null) {
+  } else {
 
     Scaffold(
         modifier = Modifier.testTag("profileEditScreen"),
@@ -127,7 +136,8 @@ fun ProfileEditingScreen(
                           isModified = isModified,
                           setShowDialog = { showDialog = it },
                           tagsViewModel = tagsViewModel,
-                          navigationActions = navigationActions)
+                          navigationActions = navigationActions,
+                          profilesViewModel = profilesViewModel)
                     }) {
                       Icon(Icons.Default.ArrowBack, contentDescription = "Back")
                     }
@@ -136,10 +146,12 @@ fun ProfileEditingScreen(
                 IconButton(
                     modifier = Modifier.testTag("checkButton"),
                     onClick = {
-                      updateProfile()
-                      profilesViewModel.validateAndUploadProfilePicture(context)
+                      if (isModified) {
+                        profilesViewModel.saveEditedProfile(getEditedProfile())
+                        profilesViewModel.validateProfileChanges(context)
+                      }
                       tagsViewModel.leaveUI()
-                      navigationActions.goBack()
+                      navigationActions.goBack() // todo: block with loading until done (uploading)
                     }) {
                       Icon(Icons.Default.Check, contentDescription = "Save")
                     }
@@ -152,10 +164,12 @@ fun ProfileEditingScreen(
                 ProfilePictureSelector(
                     url = user.profilePictureUrl,
                     localBitmap = tempBitmap,
+                    pictureChangeState = pictureChangeState,
                     size = profilePictureSize,
                     onSelectionSuccess = { uri ->
                       profilesViewModel.generateTempProfilePictureBitmap(context, uri)
-                      isModified = true
+                      // save modification and implicitly sets isModified at next recomposition:
+                      profilesViewModel.saveEditedProfile(getEditedProfile())
                       navigationActions.navigateTo(Screen.CROP)
                     },
                     onSelectionFailure = {
@@ -243,7 +257,7 @@ fun ProfileEditingScreen(
                     onConfirm = {
                       showDialog = false
                       tagsViewModel.leaveUI()
-                      profilesViewModel.clearTempProfilePictureBitmap()
+                      profilesViewModel.resetProfileEditionState()
                       navigationActions.goBack()
                     })
               }
@@ -256,6 +270,7 @@ fun ProfileEditingScreen(
         isModified = isModified,
         setShowDialog = { showDialog = it },
         tagsViewModel = tagsViewModel,
-        navigationActions = navigationActions)
+        navigationActions = navigationActions,
+        profilesViewModel = profilesViewModel)
   }
 }

--- a/app/src/main/java/com/github/se/icebreakrr/ui/profile/ProfileEdit.kt
+++ b/app/src/main/java/com/github/se/icebreakrr/ui/profile/ProfileEdit.kt
@@ -172,16 +172,16 @@ fun ProfileEditingScreen(
                       Toast.makeText(context, "Failed to select image", Toast.LENGTH_SHORT).show()
                     },
                     onDeletion = {
-                        when (pictureChangeState) {
-                          UNCHANGED -> { // delete current profile picture
-                              if (user.profilePictureUrl != null) {
-                                  profilesViewModel.setPictureChangeState(TO_DELETE)
-                                  isModified = true
-                              }
+                      when (pictureChangeState) {
+                        UNCHANGED -> { // delete current profile picture
+                          if (user.profilePictureUrl != null) {
+                            profilesViewModel.setPictureChangeState(TO_DELETE)
+                            isModified = true
                           }
-                            // else cancel changes
-                          else -> profilesViewModel.setPictureChangeState(UNCHANGED)
                         }
+                        // else cancel changes
+                        else -> profilesViewModel.setPictureChangeState(UNCHANGED)
+                      }
                     })
 
                 Spacer(modifier = Modifier.height(padding))

--- a/app/src/main/java/com/github/se/icebreakrr/ui/profile/ProfileEdit.kt
+++ b/app/src/main/java/com/github/se/icebreakrr/ui/profile/ProfileEdit.kt
@@ -70,7 +70,7 @@ fun ProfileEditingScreen(
   val padding = screenWidth * 0.02f
   val textSize = screenWidth * 0.08f
 
-  val profilePictureSize = screenWidth * 0.25f
+  val profilePictureSize = screenWidth * 0.40f
   val catchphraseHeight = screenHeight * 0.10f
   val descriptionHeight = screenHeight * 0.16f
 
@@ -174,6 +174,9 @@ fun ProfileEditingScreen(
                     },
                     onSelectionFailure = {
                       Toast.makeText(context, "Failed to select image", Toast.LENGTH_SHORT).show()
+                    },
+                    onDeletion = {
+                      // todo
                     })
 
                 Spacer(modifier = Modifier.height(padding))

--- a/app/src/main/java/com/github/se/icebreakrr/ui/profile/ProfileEdit.kt
+++ b/app/src/main/java/com/github/se/icebreakrr/ui/profile/ProfileEdit.kt
@@ -104,7 +104,6 @@ fun ProfileEditingScreen(
   val selectedTags = tagsViewModel.filteringTags.collectAsState().value
   val tagsSuggestions = tagsViewModel.tagsSuggestions.collectAsState()
   val stringQuery = remember { mutableStateOf("") }
-
   fun getEditedProfile(): Profile {
     return user.copy(
         catchPhrase = catchphrase.text, description = description.text, tags = selectedTags)

--- a/app/src/main/java/com/github/se/icebreakrr/ui/profile/ProfilePictureSelector.kt
+++ b/app/src/main/java/com/github/se/icebreakrr/ui/profile/ProfilePictureSelector.kt
@@ -33,14 +33,16 @@ import com.github.se.icebreakrr.model.profile.ProfilesViewModel.ProfilePictureSt
 import com.github.se.icebreakrr.ui.theme.IceBreakrrBlue
 
 /**
- * A composable function that displays a profile picture with an option to select a new image from
- * gallery.
+ * A composable that displays a profile picture with an edit icon to allow the user to change the
+ * picture. The user can also remove the picture by clicking on the remove icon.
  *
- * @param url The URL of the profile picture to display. If null, a placeholder image is shown.
+ * @param url The URL of the profile picture.
+ * @param localBitmap The local bitmap of the profile picture.
+ * @param pictureChangeState The state of the profile picture.
  * @param size The size of the profile picture.
- * @param onSelectionSuccess A callback function that is invoked when an image is successfully
- *   selected.
- * @param onSelectionFailure A callback function that is invoked when image selection fails.
+ * @param onSelectionSuccess Callback when the user successfully selects a new picture.
+ * @param onSelectionFailure Callback when the user fails to select a new picture.
+ * @param onDeletion Callback when the taps the cancel/delete button.
  */
 private val ICON_PADDING = 5.dp
 

--- a/app/src/main/java/com/github/se/icebreakrr/ui/profile/profilePictureEdit.kt
+++ b/app/src/main/java/com/github/se/icebreakrr/ui/profile/profilePictureEdit.kt
@@ -1,3 +1,4 @@
+import androidx.activity.compose.BackHandler
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.padding
@@ -63,6 +64,13 @@ fun ImageCropperScreen(
           profilesViewModel.processCroppedImage(imageBitmap.asAndroidBitmap())
           navigationActions.goBack()
         })
+  }
+
+  BackHandler {
+    // for now makes impossible to quit the screen without cropping (as this may discard a
+    // valid temporary profile picture). A possible improvement for the future could be to add
+    // a slot to save the not cropped image so it doesn't discard the valid actual
+    // temporary image.
   }
 }
 

--- a/app/src/main/java/com/github/se/icebreakrr/ui/sections/Filter.kt
+++ b/app/src/main/java/com/github/se/icebreakrr/ui/sections/Filter.kt
@@ -273,7 +273,8 @@ fun FilterScreen(
         isModified = isModified,
         setShowDialog = { showDialog = it },
         tagsViewModel = tagsViewModel,
-        navigationActions = navigationActions)
+        navigationActions = navigationActions,
+        profilesViewModel = profilesViewModel)
   }
 
   Scaffold(
@@ -290,7 +291,8 @@ fun FilterScreen(
                         isModified = isModified,
                         setShowDialog = { showDialog = it },
                         tagsViewModel = tagsViewModel,
-                        navigationActions = navigationActions)
+                        navigationActions = navigationActions,
+                        profilesViewModel = profilesViewModel)
                   },
                   modifier = Modifier.testTag("Back Button")) {
                     Icon(

--- a/app/src/main/java/com/github/se/icebreakrr/ui/sections/shared/NavigationUtils.kt
+++ b/app/src/main/java/com/github/se/icebreakrr/ui/sections/shared/NavigationUtils.kt
@@ -1,5 +1,6 @@
 package com.github.se.icebreakrr.ui.sections.shared
 
+import com.github.se.icebreakrr.model.profile.ProfilesViewModel
 import com.github.se.icebreakrr.model.tags.TagsViewModel
 import com.github.se.icebreakrr.ui.navigation.NavigationActions
 
@@ -16,12 +17,14 @@ fun handleSafeBackNavigation(
     isModified: Boolean,
     setShowDialog: (Boolean) -> Unit,
     tagsViewModel: TagsViewModel,
-    navigationActions: NavigationActions
+    navigationActions: NavigationActions,
+    profilesViewModel: ProfilesViewModel
 ) {
   if (isModified) {
     setShowDialog(true)
   } else {
     tagsViewModel.leaveUI()
+    profilesViewModel.resetProfileEditionState()
     navigationActions.goBack()
   }
 }

--- a/app/src/test/java/com/github/se/icebreakrr/model/profile/ProfilesViewModelTest.kt
+++ b/app/src/test/java/com/github/se/icebreakrr/model/profile/ProfilesViewModelTest.kt
@@ -7,6 +7,7 @@ import android.graphics.BitmapFactory
 import android.net.Uri
 import com.google.firebase.Timestamp
 import com.google.firebase.auth.FirebaseAuth
+import com.google.firebase.auth.FirebaseUser
 import com.google.firebase.firestore.GeoPoint
 import java.io.ByteArrayInputStream
 import java.io.ByteArrayOutputStream
@@ -45,6 +46,7 @@ class ProfilesViewModelTest {
   private lateinit var profilesViewModel: ProfilesViewModel
   private lateinit var mockProfileViewModel: ProfilesViewModel
   private lateinit var mockAndThen: () -> Unit
+  private lateinit var mockAuth: FirebaseAuth
   @OptIn(ExperimentalCoroutinesApi::class)
   private val testDispatcher: TestDispatcher = UnconfinedTestDispatcher()
 
@@ -88,8 +90,9 @@ class ProfilesViewModelTest {
     context = mock(Context::class.java)
     profilesRepository = mock(ProfilesRepository::class.java)
     ppRepository = mock(ProfilePicRepository::class.java)
+    mockAuth = mock(FirebaseAuth::class.java)
     profilesViewModel =
-        ProfilesViewModel(profilesRepository, ppRepository, mock(FirebaseAuth::class.java))
+        ProfilesViewModel(profilesRepository, ppRepository, mockAuth)
     mockProfileViewModel = mock(ProfilesViewModel::class.java)
     mockAndThen = mock()
 
@@ -286,184 +289,6 @@ class ProfilesViewModelTest {
     assertThat(profilesViewModel.error.value, `is`(exception))
   }
 
-  @Test
-  fun uploadCurrentUserProfilePictureSucceeds() = runBlocking {
-    val imageData = ByteArray(4) { 0xFF.toByte() }
-
-    whenever(profilesRepository.getProfileByUid(eq("1"), any(), any())).thenAnswer {
-      val onSuccess = it.getArgument<(Profile) -> Unit>(1)
-      onSuccess(profile1)
-    }
-
-    whenever(ppRepository.uploadProfilePicture(any(), any(), any(), any())).thenAnswer {
-      val onSuccess = it.getArgument<(String?) -> Unit>(2)
-      onSuccess("http://example.com/profile.jpg")
-    }
-
-    profilesViewModel.getProfileByUid("1")
-    profilesViewModel.uploadCurrentUserProfilePicture(imageData)
-
-    verify(ppRepository).uploadProfilePicture(eq("1"), eq(imageData), any(), any())
-    assertThat(
-        profilesViewModel.selectedProfile.value?.profilePictureUrl,
-        `is`("http://example.com/profile.jpg"))
-  }
-
-  @Test
-  fun uploadCurrentUserProfilePictureFails() = runBlocking {
-    val imageData = ByteArray(4) { 0xFF.toByte() }
-    val exception = Exception("Failed to upload profile picture")
-
-    whenever(profilesRepository.getProfileByUid(eq("1"), any(), any())).thenAnswer {
-      val onSuccess = it.getArgument<(Profile) -> Unit>(1)
-      onSuccess(profile1)
-    }
-
-    whenever(ppRepository.uploadProfilePicture(any(), any(), any(), any())).thenAnswer {
-      val onFailure = it.getArgument<(Exception) -> Unit>(3)
-      onFailure(exception)
-    }
-
-    profilesViewModel.getProfileByUid("1")
-    profilesViewModel.uploadCurrentUserProfilePicture(imageData)
-
-    verify(ppRepository).uploadProfilePicture(eq("1"), eq(imageData), any(), any())
-    assertThat(profilesViewModel.error.value, `is`(exception))
-  }
-
-  @Test
-  fun uploadCurrentUserProfilePictureThrowsExceptionIfUserNotLoggedIn() {
-    val imageData = ByteArray(4) { 0xFF.toByte() }
-
-    val exception =
-        assertThrows(IllegalStateException::class.java) {
-          profilesViewModel.uploadCurrentUserProfilePicture(imageData)
-        }
-
-    assertThat(exception.message, `is`("User not logged in"))
-  }
-
-  @Test
-  fun deleteCurrentUserProfilePictureSucceeds() = runBlocking {
-    whenever(profilesRepository.getProfileByUid(eq("1"), any(), any())).thenAnswer {
-      val onSuccess = it.getArgument<(Profile) -> Unit>(1)
-      onSuccess(profile1)
-    }
-
-    whenever(ppRepository.deleteProfilePicture(any(), any(), any())).thenAnswer {
-      val onSuccess = it.getArgument<() -> Unit>(1)
-      onSuccess()
-    }
-
-    profilesViewModel.getProfileByUid("1")
-    profilesViewModel.deleteCurrentUserProfilePicture()
-
-    verify(ppRepository).deleteProfilePicture(eq("1"), any(), any())
-    assertThat(profilesViewModel.selectedProfile.value?.profilePictureUrl, `is`(nullValue()))
-  }
-
-  @Test
-  fun deleteCurrentUserProfilePictureFails() = runBlocking {
-    val exception = Exception("Failed to delete profile picture")
-
-    whenever(profilesRepository.getProfileByUid(eq("1"), any(), any())).thenAnswer {
-      val onSuccess = it.getArgument<(Profile) -> Unit>(1)
-      onSuccess(profile1)
-    }
-
-    whenever(ppRepository.deleteProfilePicture(any(), any(), any())).thenAnswer {
-      val onFailure = it.getArgument<(Exception) -> Unit>(2)
-      onFailure(exception)
-    }
-
-    profilesViewModel.getProfileByUid("1")
-    profilesViewModel.deleteCurrentUserProfilePicture()
-
-    verify(ppRepository).deleteProfilePicture(eq("1"), any(), any())
-    assertThat(profilesViewModel.error.value, `is`(exception))
-  }
-
-  @Test
-  fun generateTempProfilePictureBitmapSucceeds() = runBlocking {
-    // Mock ContentResolver and Uri
-    val contentResolver = mock(ContentResolver::class.java)
-    val uri = mock(Uri::class.java)
-    whenever(context.contentResolver).thenReturn(contentResolver)
-
-    // Create a test image as InputStream
-    val testImageBytes = ByteArray(100) { it.toByte() }
-    val inputStream = ByteArrayInputStream(testImageBytes)
-    whenever(contentResolver.openInputStream(uri)).thenReturn(inputStream)
-
-    // Create a mock bitmap that will be "decoded" from the input stream
-    val mockBitmap = mock(Bitmap::class.java)
-    whenever(mockBitmap.width).thenReturn(100)
-    whenever(mockBitmap.height).thenReturn(100)
-
-    // Mock BitmapFactory.decodeStream to return our mock bitmap
-    bitmapFactoryMock.`when`<Bitmap> { BitmapFactory.decodeStream(any()) }.thenReturn(mockBitmap)
-
-    // Mock Bitmap.createBitmap to return the same mock bitmap
-    bitmapMock
-        .`when`<Bitmap> { Bitmap.createBitmap(any<Bitmap>(), any(), any(), any(), any()) }
-        .thenReturn(mockBitmap)
-
-    profilesViewModel.generateTempProfilePictureBitmap(context, uri)
-
-    assertThat(profilesViewModel.tempProfilePictureBitmap.value, `is`(mockBitmap))
-  }
-
-  @Test
-  fun validateAndUploadProfilePictureWithNoTempBitmapDoesNothing() = runBlocking {
-    profilesViewModel.clearTempProfilePictureBitmap() // Ensure no temp bitmap exists
-    profilesViewModel.validateAndUploadProfilePicture(context)
-
-    // Verify no interactions with upload functionality
-    verify(profilesRepository, never()).updateProfile(any(), any(), any())
-  }
-
-  @Test
-  fun validateAndUploadProfilePictureSucceeds() = runBlocking {
-    // Mock successful profile setup
-    whenever(profilesRepository.getProfileByUid(eq("1"), any(), any())).thenAnswer {
-      val onSuccess = it.getArgument<(Profile) -> Unit>(1)
-      onSuccess(profile1)
-    }
-    profilesViewModel.getProfileByUid("1")
-
-    // Create and set a mock bitmap
-    val mockBitmap = mock(Bitmap::class.java)
-    whenever(mockBitmap.compress(eq(Bitmap.CompressFormat.JPEG), eq(100), any())).thenAnswer {
-      val stream = it.getArgument<ByteArrayOutputStream>(2)
-      stream.write(ByteArray(100))
-      true
-    }
-
-    // Set the temp bitmap
-    val field = ProfilesViewModel::class.java.getDeclaredField("_tempProfilePictureBitmap")
-    field.isAccessible = true
-    val tempProfilePictureBitmap = field.get(profilesViewModel) as MutableStateFlow<Bitmap?>
-    tempProfilePictureBitmap.value = mockBitmap
-
-    profilesViewModel.validateAndUploadProfilePicture(context)
-
-    // Verify upload was called and temp bitmap was cleared
-    verify(ppRepository).uploadProfilePicture(eq("1"), any(), any(), any())
-    assertThat(profilesViewModel.tempProfilePictureBitmap.value, `is`(nullValue()))
-  }
-
-  @Test
-  fun clearTempProfilePictureBitmapSucceeds() {
-    val mockBitmap = mock(Bitmap::class.java)
-    val field = ProfilesViewModel::class.java.getDeclaredField("_tempProfilePictureBitmap")
-    field.isAccessible = true
-    val tempProfilePictureBitmap = field.get(profilesViewModel) as MutableStateFlow<Bitmap?>
-    tempProfilePictureBitmap.value = mockBitmap
-
-    profilesViewModel.clearTempProfilePictureBitmap()
-
-    assertThat(profilesViewModel.tempProfilePictureBitmap.value, `is`(nullValue()))
-  }
 
   // Generated with the help of CursorAI
   @OptIn(ExperimentalCoroutinesApi::class)
@@ -547,4 +372,93 @@ class ProfilesViewModelTest {
     // Should still be online because it wasn't the correct error
     assertTrue(profilesViewModel.isConnected.value)
   }
+
+  @Test
+  fun clearTempProfilePictureBitmapSucceeds() {
+    val mockBitmap = mock(Bitmap::class.java)
+    val field = ProfilesViewModel::class.java.getDeclaredField("_tempProfilePictureBitmap")
+    field.isAccessible = true
+    val tempProfilePictureBitmap = field.get(profilesViewModel) as MutableStateFlow<Bitmap?>
+    tempProfilePictureBitmap.value = mockBitmap
+
+    profilesViewModel.clearTempProfilePictureBitmap()
+
+    assertThat(profilesViewModel.tempProfilePictureBitmap.value, `is`(nullValue()))
+  }
+
+  @Test
+  fun generateTempProfilePictureBitmapSucceeds() = runBlocking {
+    // Mock ContentResolver and Uri
+    val contentResolver = mock(ContentResolver::class.java)
+    val uri = mock(Uri::class.java)
+    whenever(context.contentResolver).thenReturn(contentResolver)
+
+    // Create a test image as InputStream
+    val testImageBytes = ByteArray(100) { it.toByte() }
+    val inputStream = ByteArrayInputStream(testImageBytes)
+    whenever(contentResolver.openInputStream(uri)).thenReturn(inputStream)
+
+    // Create a mock bitmap that will be "decoded" from the input stream
+    val mockBitmap = mock(Bitmap::class.java)
+    whenever(mockBitmap.width).thenReturn(100)
+    whenever(mockBitmap.height).thenReturn(100)
+
+    // Mock BitmapFactory.decodeStream to return our mock bitmap
+    bitmapFactoryMock.`when`<Bitmap> { BitmapFactory.decodeStream(any()) }.thenReturn(mockBitmap)
+
+    // Mock Bitmap.createBitmap to return the same mock bitmap
+    bitmapMock
+        .`when`<Bitmap> { Bitmap.createBitmap(any<Bitmap>(), any(), any(), any(), any()) }
+        .thenReturn(mockBitmap)
+
+    profilesViewModel.generateTempProfilePictureBitmap(context, uri)
+
+    assertThat(profilesViewModel.tempProfilePictureBitmap.value, `is`(mockBitmap))
+  }
+
+  @Test
+  fun validateAndUploadProfilePictureWithNoTempBitmapDoesNothing() = runBlocking {
+    profilesViewModel.clearTempProfilePictureBitmap() // Ensure no temp bitmap exists
+    profilesViewModel.validateAndUploadProfilePicture(context){ /*pass*/}
+
+    // Verify no interactions with upload functionality
+    verify(profilesRepository, never()).updateProfile(any(), any(), any())
+  }
+
+  @Test
+fun setPictureChangeStateUpdatesState() {
+    profilesViewModel.setPictureChangeState(ProfilesViewModel.ProfilePictureState.TO_UPLOAD)
+    assertThat(profilesViewModel.pictureChangeState.value, `is`(ProfilesViewModel.ProfilePictureState.TO_UPLOAD))
+}
+
+@Test
+fun saveEditedProfileUpdatesState() {
+    profilesViewModel.saveEditedProfile(profile1)
+    assertThat(profilesViewModel.editedCurrentProfile.value, `is`(profile1))
+}
+
+@Test
+fun resetProfileEditionStateClearsStates() {
+    profilesViewModel.saveEditedProfile(profile1)
+    profilesViewModel.setPictureChangeState(ProfilesViewModel.ProfilePictureState.TO_UPLOAD)
+
+    profilesViewModel.resetProfileEditionState()
+
+    assertThat(profilesViewModel.editedCurrentProfile.value, `is`(nullValue()))
+    assertThat(profilesViewModel.pictureChangeState.value, `is`(ProfilesViewModel.ProfilePictureState.UNCHANGED))
+    assertThat(profilesViewModel.tempProfilePictureBitmap.value, `is`(nullValue()))
+}
+
+@Test
+fun processCroppedImageUpdatesState() {
+    val mockBitmap = mock(Bitmap::class.java)
+    whenever(mockBitmap.width).thenReturn(100)
+    whenever(mockBitmap.height).thenReturn(100)
+
+    profilesViewModel.processCroppedImage(mockBitmap)
+
+    assertThat(profilesViewModel.tempProfilePictureBitmap.value, `is`(mockBitmap))
+    assertThat(profilesViewModel.pictureChangeState.value, `is`(ProfilesViewModel.ProfilePictureState.TO_UPLOAD))
+}
+
 }

--- a/app/src/test/java/com/github/se/icebreakrr/model/profile/ProfilesViewModelTest.kt
+++ b/app/src/test/java/com/github/se/icebreakrr/model/profile/ProfilesViewModelTest.kt
@@ -7,10 +7,8 @@ import android.graphics.BitmapFactory
 import android.net.Uri
 import com.google.firebase.Timestamp
 import com.google.firebase.auth.FirebaseAuth
-import com.google.firebase.auth.FirebaseUser
 import com.google.firebase.firestore.GeoPoint
 import java.io.ByteArrayInputStream
-import java.io.ByteArrayOutputStream
 import java.util.Calendar
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
@@ -26,7 +24,6 @@ import org.hamcrest.CoreMatchers.nullValue
 import org.hamcrest.MatcherAssert.assertThat
 import org.junit.After
 import org.junit.Assert.assertFalse
-import org.junit.Assert.assertThrows
 import org.junit.Assert.assertTrue
 import org.junit.Before
 import org.junit.Test
@@ -91,8 +88,7 @@ class ProfilesViewModelTest {
     profilesRepository = mock(ProfilesRepository::class.java)
     ppRepository = mock(ProfilePicRepository::class.java)
     mockAuth = mock(FirebaseAuth::class.java)
-    profilesViewModel =
-        ProfilesViewModel(profilesRepository, ppRepository, mockAuth)
+    profilesViewModel = ProfilesViewModel(profilesRepository, ppRepository, mockAuth)
     mockProfileViewModel = mock(ProfilesViewModel::class.java)
     mockAndThen = mock()
 
@@ -289,7 +285,6 @@ class ProfilesViewModelTest {
     assertThat(profilesViewModel.error.value, `is`(exception))
   }
 
-
   // Generated with the help of CursorAI
   @OptIn(ExperimentalCoroutinesApi::class)
   @Test
@@ -419,38 +414,42 @@ class ProfilesViewModelTest {
   @Test
   fun validateAndUploadProfilePictureWithNoTempBitmapDoesNothing() = runBlocking {
     profilesViewModel.clearTempProfilePictureBitmap() // Ensure no temp bitmap exists
-    profilesViewModel.validateAndUploadProfilePicture(context){ /*pass*/}
+    profilesViewModel.validateAndUploadProfilePicture(context) { /*pass*/}
 
     // Verify no interactions with upload functionality
     verify(profilesRepository, never()).updateProfile(any(), any(), any())
   }
 
   @Test
-fun setPictureChangeStateUpdatesState() {
+  fun setPictureChangeStateUpdatesState() {
     profilesViewModel.setPictureChangeState(ProfilesViewModel.ProfilePictureState.TO_UPLOAD)
-    assertThat(profilesViewModel.pictureChangeState.value, `is`(ProfilesViewModel.ProfilePictureState.TO_UPLOAD))
-}
+    assertThat(
+        profilesViewModel.pictureChangeState.value,
+        `is`(ProfilesViewModel.ProfilePictureState.TO_UPLOAD))
+  }
 
-@Test
-fun saveEditedProfileUpdatesState() {
+  @Test
+  fun saveEditedProfileUpdatesState() {
     profilesViewModel.saveEditedProfile(profile1)
     assertThat(profilesViewModel.editedCurrentProfile.value, `is`(profile1))
-}
+  }
 
-@Test
-fun resetProfileEditionStateClearsStates() {
+  @Test
+  fun resetProfileEditionStateClearsStates() {
     profilesViewModel.saveEditedProfile(profile1)
     profilesViewModel.setPictureChangeState(ProfilesViewModel.ProfilePictureState.TO_UPLOAD)
 
     profilesViewModel.resetProfileEditionState()
 
     assertThat(profilesViewModel.editedCurrentProfile.value, `is`(nullValue()))
-    assertThat(profilesViewModel.pictureChangeState.value, `is`(ProfilesViewModel.ProfilePictureState.UNCHANGED))
+    assertThat(
+        profilesViewModel.pictureChangeState.value,
+        `is`(ProfilesViewModel.ProfilePictureState.UNCHANGED))
     assertThat(profilesViewModel.tempProfilePictureBitmap.value, `is`(nullValue()))
-}
+  }
 
-@Test
-fun processCroppedImageUpdatesState() {
+  @Test
+  fun processCroppedImageUpdatesState() {
     val mockBitmap = mock(Bitmap::class.java)
     whenever(mockBitmap.width).thenReturn(100)
     whenever(mockBitmap.height).thenReturn(100)
@@ -458,7 +457,8 @@ fun processCroppedImageUpdatesState() {
     profilesViewModel.processCroppedImage(mockBitmap)
 
     assertThat(profilesViewModel.tempProfilePictureBitmap.value, `is`(mockBitmap))
-    assertThat(profilesViewModel.pictureChangeState.value, `is`(ProfilesViewModel.ProfilePictureState.TO_UPLOAD))
-}
-
+    assertThat(
+        profilesViewModel.pictureChangeState.value,
+        `is`(ProfilesViewModel.ProfilePictureState.TO_UPLOAD))
+  }
 }


### PR DESCRIPTION
# Crop Image (2/2)

## Description 
This PR is the last one regarding profile pictures. It brings a whole assortment of fixes and improvements that make choosing, editing and deleting profile pictures perfectly operational.

>[!Note] 
As I am running out of time and energy, I decided that I will take care of the missing tests later, probably during the consolidation phase of the project. 

## What's new
### Features:
- Every major bugs of part 1 are now fixed, for example:
  - Text changes are not discarded anymore after cropping (most of the new code)
  - No more invalid temporary image used as placeholder
  - The profile upload is now far more optimized (only one upload for image and one for data)
- There's now an option to cancel or delete the image (based on the current edition state)

## More in details
### State for modifications
In the first version, cropping an image will discard every other information. For this I added new states to the viewmodel and played with them and the isModified variable to keep track of what was changed, enable the discard prompt if needed and avoid useless uploads.

### Better performances
The first version had race condition, duplicate database upload and a lot of mistakes due to last weeks rush. The code is now cleaner, more performant and using the app feels better.
Here is a diagram to understand how the upload works:
![image](https://github.com/user-attachments/assets/97e4c965-7fa4-43ae-a18b-586dbe57d3ae)


### Delete Button
When entering the edition screen, the user can now delete it's profile picture if needed. If a user added a profile picture. they may want to cancel and go back to the one they had before entering the edition screen and this possible thanks to the "delete" button adapting to become a "revert" button depending on the changes brought to the picture. 

Before change (possible to delete)
![image](https://github.com/user-attachments/assets/52ab7c17-bd46-47f1-b684-947b81fd3a26) 

After change (possible to discard and go back to previous picture)
![image](https://github.com/user-attachments/assets/c2bb413c-dbbe-4693-95ac-a648b44cf8d0)

## Possible improvements
- Buttons may need to be arranged in another way for usability
- For compatibility, I had to add code waiting for the other screens to use `selfProfile` instead of `selectedProfile`. This must be deleted afterward 