### PR TITLE
feat: add a map location selector

### DIFF
--- a/app/src/androidTest/java/com/github/se/icebreakrr/ui/map/HeatMapTest.kt
+++ b/app/src/androidTest/java/com/github/se/icebreakrr/ui/map/HeatMapTest.kt
@@ -67,6 +67,5 @@ class HeatMapTest {
 
     // Verify bottom navigation is displayed
     composeTestRule.onNodeWithTag("bottomNavigationMenu").assertIsDisplayed()
-    composeTestRule.onNodeWithTag("topBar").assertIsDisplayed()
   }
 }

--- a/app/src/androidTest/java/com/github/se/icebreakrr/ui/map/HeatMapTest.kt
+++ b/app/src/androidTest/java/com/github/se/icebreakrr/ui/map/HeatMapTest.kt
@@ -67,5 +67,6 @@ class HeatMapTest {
 
     // Verify bottom navigation is displayed
     composeTestRule.onNodeWithTag("bottomNavigationMenu").assertIsDisplayed()
+    composeTestRule.onNodeWithTag("topBar").assertIsDisplayed()
   }
 }

--- a/app/src/androidTest/java/com/github/se/icebreakrr/ui/map/LocationMapSelectorTest.kt
+++ b/app/src/androidTest/java/com/github/se/icebreakrr/ui/map/LocationMapSelectorTest.kt
@@ -1,0 +1,184 @@
+package com.github.se.icebreakrr.ui.map
+
+import android.util.Log
+import androidx.compose.ui.test.assertHasClickAction
+import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.compose.ui.test.onNodeWithTag
+import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.test.performClick
+import androidx.compose.ui.test.performTextInput
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.github.se.icebreakrr.model.location.ILocationService
+import com.github.se.icebreakrr.model.location.LocationRepository
+import com.github.se.icebreakrr.model.location.LocationViewModel
+import com.github.se.icebreakrr.model.message.MeetingRequestViewModel
+import com.github.se.icebreakrr.model.profile.Gender
+import com.github.se.icebreakrr.model.profile.Profile
+import com.github.se.icebreakrr.model.profile.ProfilePicRepository
+import com.github.se.icebreakrr.model.profile.ProfilesRepository
+import com.github.se.icebreakrr.model.profile.ProfilesViewModel
+import com.github.se.icebreakrr.ui.navigation.NavigationActions
+import com.github.se.icebreakrr.ui.navigation.Route
+import com.github.se.icebreakrr.ui.sections.DEFAULT_USER_LATITUDE
+import com.github.se.icebreakrr.ui.sections.DEFAULT_USER_LONGITUDE
+import com.github.se.icebreakrr.utils.IPermissionManager
+import com.google.firebase.Timestamp
+import com.google.firebase.auth.FirebaseAuth
+import com.google.firebase.auth.FirebaseUser
+import com.google.firebase.functions.FirebaseFunctions
+import org.junit.Assert.assertEquals
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.mockito.Mockito.mock
+import org.mockito.Mockito.verify
+import org.mockito.Mockito.`when`
+import org.mockito.kotlin.anyOrNull
+
+@RunWith(AndroidJUnit4::class)
+class LocationMapSelectorTest {
+
+  @get:Rule val composeTestRule = createComposeRule()
+  private lateinit var profilesViewModel: ProfilesViewModel
+  private lateinit var mockProfileRepository: ProfilesRepository
+  private lateinit var mockAuth: FirebaseAuth
+  private lateinit var mockNavigationActions: NavigationActions
+  private lateinit var meetingRequestViewModel: MeetingRequestViewModel
+  private lateinit var locationViewModel: LocationViewModel
+  private lateinit var mockLocationRepository: LocationRepository
+  private lateinit var mockUser: FirebaseUser
+  private lateinit var mockFunctions: FirebaseFunctions
+
+  private val profile1 =
+      Profile(
+          uid = "1",
+          name = "John Doe",
+          gender = Gender.MEN,
+          birthDate = Timestamp.now(), // 22 years old
+          catchPhrase = "Just a friendly guy",
+          description = "I love meeting new people.",
+          tags = listOf("friendly", "outgoing"),
+          profilePictureUrl = "http://example.com/profile.jpg",
+          meetingRequestInbox = mapOf(),
+          meetingRequestPendingLocation = listOf(),
+          meetingRequestChosenLocalisation = mapOf(),
+          meetingRequestSent = listOf(),
+          fcmToken = "11")
+
+  private val profile2 =
+      Profile(
+          uid = "2",
+          name = "Jane Smith",
+          gender = Gender.WOMEN,
+          birthDate = Timestamp.now(),
+          catchPhrase = "Adventure awaits!",
+          description = "Always looking for new experiences.",
+          tags = listOf("adventurous", "outgoing"),
+          profilePictureUrl = null,
+          fcmToken = "22")
+
+  private var profile1Changeable =
+      Profile(
+          uid = "1",
+          name = "John Doe",
+          gender = Gender.MEN,
+          birthDate = Timestamp.now(), // 22 years old
+          catchPhrase = "Just a friendly guy",
+          description = "I love meeting new people.",
+          tags = listOf("friendly", "outgoing"),
+          profilePictureUrl = "http://example.com/profile.jpg",
+          meetingRequestInbox = mapOf(),
+          meetingRequestPendingLocation = listOf(),
+          meetingRequestChosenLocalisation = mapOf(),
+          meetingRequestSent = listOf(),
+          fcmToken = "11")
+
+  @Before
+  fun setup() {
+    mockProfileRepository = mock(ProfilesRepository::class.java)
+    mockAuth = mock(FirebaseAuth::class.java)
+    mockUser = mock(FirebaseUser::class.java)
+    mockFunctions = mock(FirebaseFunctions::class.java)
+    mockLocationRepository = mock(LocationRepository::class.java)
+
+    `when`(mockProfileRepository.getProfileByUid(anyOrNull(), anyOrNull(), anyOrNull()))
+        .thenAnswer {
+          val uid = it.getArgument<(String)>(0)
+          val onSuccess = it.getArgument<(Profile) -> Unit>(1)
+          if (uid == "1") {
+            onSuccess(profile1Changeable)
+          } else if (uid == "2") {
+            onSuccess(profile2)
+          } else {
+            Log.d("TESTEST", "new uid : ${uid}")
+          }
+        }
+    `when`(mockProfileRepository.updateProfile(anyOrNull(), anyOrNull(), anyOrNull())).thenAnswer {
+      val onSuccess = it.getArgument<() -> Unit>(1)
+      val newProfile = it.getArgument<Profile>(0)
+      profile1Changeable = newProfile
+      onSuccess()
+    }
+    `when`(mockProfileRepository.getMultipleProfiles(anyOrNull(), anyOrNull(), anyOrNull()))
+        .thenAnswer {
+          val onSuccess = it.getArgument<(List<Profile>) -> Unit>(1)
+          val uidList = it.getArgument<List<String>>(0)
+          if (uidList == listOf("2")) {
+            onSuccess(listOf(profile2))
+          } else {
+            Log.d("TESTEST", "new uid list : ${uidList}")
+          }
+        }
+    `when`(mockAuth.currentUser).thenReturn(mockUser)
+    `when`(mockUser.uid).thenReturn("1")
+
+    profilesViewModel =
+        ProfilesViewModel(mockProfileRepository, mock(ProfilePicRepository::class.java), mockAuth)
+    meetingRequestViewModel = MeetingRequestViewModel(profilesViewModel, mockFunctions)
+
+    mockNavigationActions = mock(NavigationActions::class.java)
+    locationViewModel =
+        LocationViewModel(
+            mock(ILocationService::class.java),
+            mockLocationRepository,
+            mock(IPermissionManager::class.java))
+    composeTestRule.setContent {
+      LocationSelectorMapScreen(
+          profilesViewModel,
+          mockNavigationActions,
+          meetingRequestViewModel,
+          null,
+          locationViewModel,
+          true)
+    }
+  }
+
+  @Test
+  fun locationSelectorTest() {
+    composeTestRule.waitForIdle()
+    composeTestRule.onNodeWithTag("LocationSelectorMapScreen").assertIsDisplayed()
+    composeTestRule.onNodeWithTag("addTextAndSendLocationBox").assertIsDisplayed()
+    composeTestRule
+        .onNodeWithTag("addDetailsTextField")
+        .assertIsDisplayed()
+        .performTextInput("Let's meet on the second floor")
+    composeTestRule.onNodeWithText("Let's meet on the second floor").assertIsDisplayed()
+    composeTestRule
+        .onNodeWithTag("buttonSendMessageLocation")
+        .assertIsDisplayed()
+        .assertHasClickAction()
+        .performClick()
+
+    assertEquals(
+        profilesViewModel.chosenLocalisations.value,
+        mapOf(
+            profile2 to
+                Pair(
+                    "Let's meet on the second floor",
+                    Pair(DEFAULT_USER_LATITUDE, DEFAULT_USER_LONGITUDE))))
+    verify(mockFunctions).getHttpsCallable("sendMeetingConfirmation")
+    verify(mockNavigationActions).navigateTo(Route.HEAT_MAP)
+  }
+}

--- a/app/src/androidTest/java/com/github/se/icebreakrr/ui/map/LocationMapSelectorTest.kt
+++ b/app/src/androidTest/java/com/github/se/icebreakrr/ui/map/LocationMapSelectorTest.kt
@@ -1,6 +1,5 @@
 package com.github.se.icebreakrr.ui.map
 
-import android.util.Log
 import androidx.compose.ui.test.assertHasClickAction
 import androidx.compose.ui.test.assertIsDisplayed
 import androidx.compose.ui.test.junit4.createComposeRule
@@ -111,8 +110,6 @@ class LocationMapSelectorTest {
             onSuccess(profile1Changeable)
           } else if (uid == "2") {
             onSuccess(profile2)
-          } else {
-            Log.d("TESTEST", "new uid : ${uid}")
           }
         }
     `when`(mockProfileRepository.updateProfile(anyOrNull(), anyOrNull(), anyOrNull())).thenAnswer {
@@ -127,8 +124,6 @@ class LocationMapSelectorTest {
           val uidList = it.getArgument<List<String>>(0)
           if (uidList == listOf("2")) {
             onSuccess(listOf(profile2))
-          } else {
-            Log.d("TESTEST", "new uid list : ${uidList}")
           }
         }
     `when`(mockAuth.currentUser).thenReturn(mockUser)

--- a/app/src/androidTest/java/com/github/se/icebreakrr/ui/sections/NotificationTest.kt
+++ b/app/src/androidTest/java/com/github/se/icebreakrr/ui/sections/NotificationTest.kt
@@ -67,7 +67,9 @@ class NotificationTest {
           fcmToken = "TokenUser1",
           geohash = "LocationProfile1",
           meetingRequestSent = listOf(),
-          meetingRequestInbox = mapOf())
+          meetingRequestInbox = mapOf(),
+          meetingRequestPendingLocation = listOf(),
+          meetingRequestChosenLocalisation = mapOf())
 
   private val profile2 =
       Profile(
@@ -212,6 +214,48 @@ class NotificationTest {
 
     composeTestRule.onNodeWithTag("navItem_${R.string.around_you}").performClick()
     verify(navigationActions).navigateTo(TopLevelDestinations.AROUND_YOU)
+  }
+
+  @Test
+  fun badgeDisplayWhen1PendingAnd1Inbox() {
+    val updatedProfile =
+        profile1.copy(
+            meetingRequestPendingLocation = listOf("2"),
+            meetingRequestInbox = mapOf("2" to "Hey, wanna meat?"))
+    `when`(mockProfilesRepository.getProfileByUid(eq("1"), any(), any())).thenAnswer {
+      val onSuccess = it.getArgument<(Profile) -> Unit>(1)
+      onSuccess(updatedProfile)
+    }
+    `when`(mockProfilesRepository.getMultipleProfiles(any(), any(), any())).thenAnswer {
+      val onSuccess = it.getArgument<(List<Profile>) -> Unit>(1)
+      onSuccess(listOf(profile2))
+    }
+    composeTestRule.setContent {
+      NotificationScreen(navigationActions, profilesViewModel, meetingRequestViewModel)
+    }
+    composeTestRule.waitForIdle()
+    composeTestRule.onNodeWithTag("profileCard").assertIsDisplayed()
+    composeTestRule
+        .onNodeWithTag("MeetingRequestOptionsDropdown_Selected")
+        .assertIsDisplayed()
+        .performClick()
+    composeTestRule
+        .onNodeWithTag("MeetingRequestOptionsDropdown_Option_CHOOSE_LOCATION")
+        .assertIsDisplayed()
+        .performClick()
+    composeTestRule.onNodeWithTag("profileCard").assertIsDisplayed()
+    composeTestRule
+        .onNodeWithTag("MeetingRequestOptionsDropdown_Selected")
+        .assertIsDisplayed()
+        .performClick()
+    composeTestRule
+        .onNodeWithTag("MeetingRequestOptionsDropdown_Option_SENT")
+        .assertIsDisplayed()
+        .performClick()
+    composeTestRule
+        .onNodeWithTag("MeetingRequestOptionsDropdown_Selected")
+        .assertIsDisplayed()
+        .performClick()
   }
 
   // Helper function to create a mock profile

--- a/app/src/main/java/com/github/se/icebreakrr/MainActivity.kt
+++ b/app/src/main/java/com/github/se/icebreakrr/MainActivity.kt
@@ -337,7 +337,12 @@ fun IcebreakrrNavHost(
       composable(Screen.MAP_MEETING_LOCATION_SCREEN + "?userId={userId}") { navBackStackEntry ->
         if (meetingRequestViewModel != null) {
           LocationSelectorMapScreen(
-              profileViewModel, navigationActions, meetingRequestViewModel, navBackStackEntry, locationViewModel)
+              profileViewModel,
+              navigationActions,
+              meetingRequestViewModel,
+              navBackStackEntry,
+              locationViewModel,
+              isTesting)
         } else {
           throw IllegalStateException(
               "The Meeting Request View Model shouldn't be null : Bad initialization")

--- a/app/src/main/java/com/github/se/icebreakrr/MainActivity.kt
+++ b/app/src/main/java/com/github/se/icebreakrr/MainActivity.kt
@@ -337,7 +337,7 @@ fun IcebreakrrNavHost(
       composable(Screen.MAP_MEETING_LOCATION_SCREEN + "?userId={userId}") { navBackStackEntry ->
         if (meetingRequestViewModel != null) {
           LocationSelectorMapScreen(
-              profileViewModel, navigationActions, meetingRequestViewModel, navBackStackEntry)
+              profileViewModel, navigationActions, meetingRequestViewModel, navBackStackEntry, locationViewModel)
         } else {
           throw IllegalStateException(
               "The Meeting Request View Model shouldn't be null : Bad initialization")

--- a/app/src/main/java/com/github/se/icebreakrr/MainActivity.kt
+++ b/app/src/main/java/com/github/se/icebreakrr/MainActivity.kt
@@ -34,6 +34,7 @@ import com.github.se.icebreakrr.model.profile.ProfilesViewModel
 import com.github.se.icebreakrr.model.sort.SortViewModel
 import com.github.se.icebreakrr.model.tags.TagsViewModel
 import com.github.se.icebreakrr.ui.authentication.SignInScreen
+import com.github.se.icebreakrr.ui.map.LocationSelectorMapScreen
 import com.github.se.icebreakrr.ui.navigation.NavigationActions
 import com.github.se.icebreakrr.ui.navigation.Route
 import com.github.se.icebreakrr.ui.navigation.Screen
@@ -328,6 +329,15 @@ fun IcebreakrrNavHost(
               tagsViewModel,
               meetingRequestViewModel,
               isTesting)
+        } else {
+          throw IllegalStateException(
+              "The Meeting Request View Model shouldn't be null : Bad initialization")
+        }
+      }
+      composable(Screen.MAP_MEETING_LOCATION_SCREEN + "?userId={userId}") { navBackStackEntry ->
+        if (meetingRequestViewModel != null) {
+          LocationSelectorMapScreen(
+              profileViewModel, navigationActions, meetingRequestViewModel, navBackStackEntry)
         } else {
           throw IllegalStateException(
               "The Meeting Request View Model shouldn't be null : Bad initialization")

--- a/app/src/main/java/com/github/se/icebreakrr/mock/MockProfiles.kt
+++ b/app/src/main/java/com/github/se/icebreakrr/mock/MockProfiles.kt
@@ -275,7 +275,9 @@ fun Profile.Companion.getMockedProfiles(): List<Profile> {
             tags = tagsList[i],
             profilePictureUrl = null,
             hasBlocked = hasBlockedList[i],
-            hasAlreadyMet = hasAlreadyMetList[i]))
+            hasAlreadyMet = hasAlreadyMetList[i],
+            meetingRequestPendingLocation = emptyList(),
+            meetingRequestChosenLocalisation = emptyMap()))
   }
   return profiles
 }

--- a/app/src/main/java/com/github/se/icebreakrr/model/message/MeetingRequestService.kt
+++ b/app/src/main/java/com/github/se/icebreakrr/model/message/MeetingRequestService.kt
@@ -50,11 +50,12 @@ class MeetingRequestService : FirebaseMessagingService() {
         val accepted = remoteMessage.data["accepted"]?.toBoolean() ?: false
         val senderToken = remoteMessage.data["senderToken"] ?: "null"
 
-        MeetingRequestManager.meetingRequestViewModel?.removeFromMeetingRequestSent(senderUid)
+        MeetingRequestManager.meetingRequestViewModel?.removeFromMeetingRequestSent(senderUid){
+          MeetingRequestManager.meetingRequestViewModel?.updateInboxOfMessages() {}
+        }
         if (accepted) {
           showNotification(name + MSG_RESPONSE_ACCEPTED, "")
           MeetingRequestManager.meetingRequestViewModel?.addPendingLocation(senderUid) {
-            MeetingRequestManager.meetingRequestViewModel?.updateInboxOfMessages() {}
           }
         } else {
           showNotification(name + MSG_RESPONSE_REJECTED, "")
@@ -80,7 +81,7 @@ class MeetingRequestService : FirebaseMessagingService() {
             }
         showNotification("Cancelled meeting with $name", stringReason)
         MeetingRequestManager.meetingRequestViewModel?.removeFromMeetingRequestInbox(senderUid)
-        MeetingRequestManager.meetingRequestViewModel?.removeFromMeetingRequestSent(senderUid)
+        MeetingRequestManager.meetingRequestViewModel?.removeFromMeetingRequestSent(senderUid){}
       }
       "ENGAGEMENT NOTIFICATION" -> {
         val name = remoteMessage.data["senderName"] ?: "null"

--- a/app/src/main/java/com/github/se/icebreakrr/model/message/MeetingRequestService.kt
+++ b/app/src/main/java/com/github/se/icebreakrr/model/message/MeetingRequestService.kt
@@ -63,12 +63,13 @@ class MeetingRequestService : FirebaseMessagingService() {
       }
       "MEETING CONFIRMATION" -> {
         val name = remoteMessage.data["senderName"] ?: "null"
-        val senderUid = remoteMessage.data["senderUID"] ?: "null"
+        val mewSenderUid = remoteMessage.data["senderUID"] ?: "null"
         val locationString = remoteMessage.data["location"] ?: "null"
+        val newMessage = remoteMessage.data["message"] ?: ""
         val latitudeString = locationString.split(", ")[0]
         val longitudeString = locationString.split(", ")[1]
         MeetingRequestManager.meetingRequestViewModel?.confirmMeetingLocation(
-            senderUid, Pair(latitudeString.toDouble(), longitudeString.toDouble()))
+            senderUid, Pair(newMessage, Pair(latitudeString.toDouble(), longitudeString.toDouble())))
         showNotification(name + MSG_CONFIRMATION, MSG_CONFIRMATION_INFO)
       }
       "MEETING CANCELLATION" -> {

--- a/app/src/main/java/com/github/se/icebreakrr/model/message/MeetingRequestService.kt
+++ b/app/src/main/java/com/github/se/icebreakrr/model/message/MeetingRequestService.kt
@@ -50,13 +50,12 @@ class MeetingRequestService : FirebaseMessagingService() {
         val accepted = remoteMessage.data["accepted"]?.toBoolean() ?: false
         val senderToken = remoteMessage.data["senderToken"] ?: "null"
 
-        MeetingRequestManager.meetingRequestViewModel?.removeFromMeetingRequestSent(senderUid){
+        MeetingRequestManager.meetingRequestViewModel?.removeFromMeetingRequestSent(senderUid) {
           MeetingRequestManager.meetingRequestViewModel?.updateInboxOfMessages() {}
         }
         if (accepted) {
           showNotification(name + MSG_RESPONSE_ACCEPTED, "")
-          MeetingRequestManager.meetingRequestViewModel?.addPendingLocation(senderUid) {
-          }
+          MeetingRequestManager.meetingRequestViewModel?.addPendingLocation(senderUid) {}
         } else {
           showNotification(name + MSG_RESPONSE_REJECTED, "")
         }
@@ -69,7 +68,8 @@ class MeetingRequestService : FirebaseMessagingService() {
         val latitudeString = locationString.split(", ")[0]
         val longitudeString = locationString.split(", ")[1]
         MeetingRequestManager.meetingRequestViewModel?.confirmMeetingLocation(
-            senderUid, Pair(newMessage, Pair(latitudeString.toDouble(), longitudeString.toDouble())))
+            senderUid,
+            Pair(newMessage, Pair(latitudeString.toDouble(), longitudeString.toDouble())))
         showNotification(name + MSG_CONFIRMATION, MSG_CONFIRMATION_INFO)
       }
       "MEETING CANCELLATION" -> {
@@ -82,7 +82,7 @@ class MeetingRequestService : FirebaseMessagingService() {
             }
         showNotification("Cancelled meeting with $name", stringReason)
         MeetingRequestManager.meetingRequestViewModel?.removeFromMeetingRequestInbox(senderUid)
-        MeetingRequestManager.meetingRequestViewModel?.removeFromMeetingRequestSent(senderUid){}
+        MeetingRequestManager.meetingRequestViewModel?.removeFromMeetingRequestSent(senderUid) {}
       }
       "ENGAGEMENT NOTIFICATION" -> {
         val name = remoteMessage.data["senderName"] ?: "null"

--- a/app/src/main/java/com/github/se/icebreakrr/model/message/MeetingRequestViewModel.kt
+++ b/app/src/main/java/com/github/se/icebreakrr/model/message/MeetingRequestViewModel.kt
@@ -76,6 +76,7 @@ class MeetingRequestViewModel(
     this.senderToken = senderToken
     this.senderUID = senderUID
     this.senderName = senderName
+    Log.d("TESTEST", "init values. token : ${senderToken}, UID : ${senderUID}, name : ${senderName}")
   }
 
   /**
@@ -146,11 +147,11 @@ class MeetingRequestViewModel(
    * @param targetToken: the FCM token of the target user
    * @param newLocation: the chosen location to send in the form "latitude, longitude"
    */
-  fun setMeetingConfirmation(targetToken: String, newLocation: String) {
+  fun setMeetingConfirmation(targetToken: String, newLocation: String, newMessage: String) {
     meetingConfirmationState =
         meetingConfirmationState.copy(
             targetToken = targetToken,
-            message = "meeting request successfull",
+            message = if (newLocation.isNotEmpty()) newMessage else "|",
             location = newLocation)
   }
 
@@ -355,8 +356,10 @@ class MeetingRequestViewModel(
     profilesViewModel.addPendingLocation(newUid) { onComplete() }
   }
 
-  fun confirmMeetingLocation(uid: String, loc: Pair<Double, Double>) {
-    profilesViewModel.confirmMeetingLocation(uid, loc)
+  fun confirmMeetingLocation(uid: String, locAndMessage: Pair<String, Pair<Double, Double>>) {
+    profilesViewModel.confirmMeetingLocation(uid, locAndMessage){
+        updateChosenLocalisations()
+    }
   }
 
   fun removeChosenLocalisation(uid: String) {

--- a/app/src/main/java/com/github/se/icebreakrr/model/message/MeetingRequestViewModel.kt
+++ b/app/src/main/java/com/github/se/icebreakrr/model/message/MeetingRequestViewModel.kt
@@ -276,7 +276,7 @@ class MeetingRequestViewModel(
    *
    * @param receiverUID: the uid of the target user
    */
-  fun removeFromMeetingRequestSent(receiverUID: String) {
+  fun removeFromMeetingRequestSent(receiverUID: String, onComplete: () -> Unit) {
     val currentMeetingRequestSent =
         profilesViewModel.selfProfile.value?.meetingRequestSent ?: listOf()
     if (currentMeetingRequestSent.contains(receiverUID)) {
@@ -284,7 +284,9 @@ class MeetingRequestViewModel(
       val updatedProfile =
           profilesViewModel.selfProfile.value?.copy(meetingRequestSent = updatedMeetingRequestSend)
       if (updatedProfile != null) {
-        profilesViewModel.updateProfile(updatedProfile) {}
+        profilesViewModel.updateProfile(updatedProfile) {
+            onComplete()
+        }
       } else {
         Log.e("SENT MEETING REQUEST", "Removing the meeting request of our sent list failed")
       }
@@ -337,7 +339,10 @@ class MeetingRequestViewModel(
   fun updateInboxOfMessages(onComplete: () -> Unit) {
     profilesViewModel.getSelfProfile() {
       profilesViewModel.getInboxOfSelfProfile() {
-        profilesViewModel.getMessageCancellationUsers() { onComplete() }
+        profilesViewModel.getMessageCancellationUsers() {
+            profilesViewModel.getInboxOfPendingLocations(){
+                onComplete()
+            } }
       }
     }
   }
@@ -375,7 +380,7 @@ class MeetingRequestViewModel(
       mapUserDistance.forEach {
         if (it.value >= FIVE_HUNDRED_METERS_IN_KM) {
           removeFromMeetingRequestInbox(it.key.uid)
-          removeFromMeetingRequestSent(it.key.uid)
+          removeFromMeetingRequestSent(it.key.uid){}
           val targetToken = it.key.fcmToken ?: "null"
           val targetName = it.key.name
           setMeetingCancellation(

--- a/app/src/main/java/com/github/se/icebreakrr/model/message/MeetingRequestViewModel.kt
+++ b/app/src/main/java/com/github/se/icebreakrr/model/message/MeetingRequestViewModel.kt
@@ -76,8 +76,6 @@ class MeetingRequestViewModel(
     this.senderToken = senderToken
     this.senderUID = senderUID
     this.senderName = senderName
-    Log.d(
-        "TESTEST", "init values. token : ${senderToken}, UID : ${senderUID}, name : ${senderName}")
   }
 
   /**
@@ -147,6 +145,7 @@ class MeetingRequestViewModel(
    *
    * @param targetToken: the FCM token of the target user
    * @param newLocation: the chosen location to send in the form "latitude, longitude"
+   * @param newMessage : message sent when choosing location
    */
   fun setMeetingConfirmation(targetToken: String, newLocation: String, newMessage: String) {
     meetingConfirmationState =
@@ -333,7 +332,11 @@ class MeetingRequestViewModel(
     }
   }
 
-  /** Refreshes the content of the inbox to have it available locally */
+  /**
+   * Refreshes the content of the inbox to have it available locally
+   *
+   * @param onComplete : callback function to remove racing conditions
+   */
   fun updateInboxOfMessages(onComplete: () -> Unit) {
     profilesViewModel.getSelfProfile() {
       profilesViewModel.getInboxOfSelfProfile() {
@@ -344,18 +347,40 @@ class MeetingRequestViewModel(
     }
   }
 
+  /**
+   * private functions called when we have set the meeting confirmation It fetches the chosen
+   * locations from the database
+   */
   private fun updateChosenLocalisations() {
     profilesViewModel.getSelfProfile() { profilesViewModel.getChosenLocations() }
   }
 
+  /**
+   * function used to add a pending location. Called when someone accepts your meeting request
+   *
+   * @param newUid: uid of the user that accepted your request
+   * @param onComplete: callback function to avoid race conditions
+   */
   fun addPendingLocation(newUid: String, onComplete: () -> Unit) {
     profilesViewModel.addPendingLocation(newUid) { onComplete() }
   }
 
+  /**
+   * method called when you receive a meeting confirmation
+   *
+   * @param uid : uid of the user with whom you want to have a meeting
+   * @param locAndMessage : variable that contains the uid of the other user, the message he sent
+   *   you and the location he has chosen
+   */
   fun confirmMeetingLocation(uid: String, locAndMessage: Pair<String, Pair<Double, Double>>) {
     profilesViewModel.confirmMeetingLocation(uid, locAndMessage) { updateChosenLocalisations() }
   }
 
+  /**
+   * function that we need to call when two people have met
+   *
+   * @param uid : uid of the user you have met
+   */
   fun removeChosenLocalisation(uid: String) {
     profilesViewModel.removeChosenLocalisation(uid)
   }

--- a/app/src/main/java/com/github/se/icebreakrr/model/message/MeetingRequestViewModel.kt
+++ b/app/src/main/java/com/github/se/icebreakrr/model/message/MeetingRequestViewModel.kt
@@ -73,7 +73,7 @@ class MeetingRequestViewModel(
     val currentProfile = profilesViewModel.getSelfProfileValue()
     if (currentProfile != null) {
       val updatedProfile = currentProfile.copy(fcmToken = newToken)
-      profilesViewModel.updateProfile(updatedProfile)
+      profilesViewModel.updateProfile(updatedProfile) {}
     }
   }
   /**
@@ -109,17 +109,14 @@ class MeetingRequestViewModel(
    * Sets the message of the meeting confirmation
    *
    * @param targetToken: the FCM token of the target user
-   * @param newMessage: the response message we want to send
+   * @param newLocation: the chosen location to send in the form "latitude, longitude"
    */
-  fun setMeetingConfirmation(targetToken: String, newMessage: String) {
-    val location = profilesViewModel.getSelfGeoHash()
-    if (location != null) {
-      meetingConfirmationState =
-          meetingConfirmationState.copy(
-              targetToken = targetToken, message = newMessage, location = location)
-    } else {
-      Log.e("MEETING CONFIRMATION", "geohash null for sender profile")
-    }
+  fun setMeetingConfirmation(targetToken: String, newLocation: String) {
+    meetingConfirmationState =
+        meetingConfirmationState.copy(
+            targetToken = targetToken,
+            message = "meeting request successfull",
+            location = newLocation)
   }
 
   /** Send a meeting request to the target user, by calling a Firebase Cloud Function */
@@ -191,7 +188,7 @@ class MeetingRequestViewModel(
         profilesViewModel.selfProfile.value?.copy(
             meetingRequestSent = currentMeetingRequestSent + receiverUID)
     if (updatedProfile != null) {
-      profilesViewModel.updateProfile(updatedProfile)
+      profilesViewModel.updateProfile(updatedProfile) {}
     } else {
       Log.e("SENT MEETING REQUEST", "Adding the new meeting request to our sent list failed")
     }
@@ -209,7 +206,7 @@ class MeetingRequestViewModel(
     val updatedProfile =
         profilesViewModel.selfProfile.value?.copy(meetingRequestSent = updatedMeetingRequestSend)
     if (updatedProfile != null) {
-      profilesViewModel.updateProfile(updatedProfile)
+      profilesViewModel.updateProfile(updatedProfile) {}
     } else {
       Log.e("SENT MEETING REQUEST", "Removing the meeting request of our sent list failed")
     }
@@ -221,14 +218,14 @@ class MeetingRequestViewModel(
    * @param senderUID: the uid of the sender
    * @param message: the received message
    */
-  fun addToMeetingRequestInbox(senderUID: String, message: String) {
+  fun addToMeetingRequestInbox(senderUID: String, message: String, onComplete: () -> Unit) {
     val currentMeetingRequestInbox =
         profilesViewModel.selfProfile.value?.meetingRequestInbox ?: mapOf()
     val updatedProfile =
         profilesViewModel.selfProfile.value?.copy(
             meetingRequestInbox = currentMeetingRequestInbox + (senderUID to message))
     if (updatedProfile != null) {
-      profilesViewModel.updateProfile(updatedProfile)
+      profilesViewModel.updateProfile(updatedProfile) { onComplete() }
     } else {
       Log.e("INBOX MEETING REQUEST", "Adding the new meeting request to our inbox list failed")
     }
@@ -246,7 +243,7 @@ class MeetingRequestViewModel(
     val updatedProfile =
         profilesViewModel.selfProfile.value?.copy(meetingRequestInbox = updatedMeetingRequestInbox)
     if (updatedProfile != null) {
-      profilesViewModel.updateProfile(updatedProfile)
+      profilesViewModel.updateProfile(updatedProfile) {}
     } else {
       Log.e("INBOX MEETING REQUEST", "Removing the meeting request in our inbox list failed")
     }
@@ -256,5 +253,23 @@ class MeetingRequestViewModel(
   fun updateInboxOfMessages() {
     profilesViewModel.getSelfProfile()
     profilesViewModel.getInboxOfSelfProfile()
+    profilesViewModel.getInboxOfPendingLocations()
+  }
+
+  fun updateChosenLocalisations() {
+    profilesViewModel.getSelfProfile()
+    profilesViewModel.getChosenLocations()
+  }
+
+  fun addPendingLocation(newUid: String) {
+    profilesViewModel.addPendingLocation(newUid)
+  }
+
+  fun confirmMeetingLocation(uid: String, loc: Pair<Double, Double>) {
+    profilesViewModel.confirmMeetingLocation(uid, loc)
+  }
+
+  fun removeChosenLocalisation(uid: String) {
+    profilesViewModel.removeChosenLocalisation(uid)
   }
 }

--- a/app/src/main/java/com/github/se/icebreakrr/model/message/MeetingRequestViewModel.kt
+++ b/app/src/main/java/com/github/se/icebreakrr/model/message/MeetingRequestViewModel.kt
@@ -76,7 +76,8 @@ class MeetingRequestViewModel(
     this.senderToken = senderToken
     this.senderUID = senderUID
     this.senderName = senderName
-    Log.d("TESTEST", "init values. token : ${senderToken}, UID : ${senderUID}, name : ${senderName}")
+    Log.d(
+        "TESTEST", "init values. token : ${senderToken}, UID : ${senderUID}, name : ${senderName}")
   }
 
   /**
@@ -150,9 +151,7 @@ class MeetingRequestViewModel(
   fun setMeetingConfirmation(targetToken: String, newLocation: String, newMessage: String) {
     meetingConfirmationState =
         meetingConfirmationState.copy(
-            targetToken = targetToken,
-            message = if (newLocation.isNotEmpty()) newMessage else "|",
-            location = newLocation)
+            targetToken = targetToken, message = newMessage, location = newLocation)
   }
 
   /** Send a meeting request to the target user, by calling a Firebase Cloud Function */
@@ -285,9 +284,7 @@ class MeetingRequestViewModel(
       val updatedProfile =
           profilesViewModel.selfProfile.value?.copy(meetingRequestSent = updatedMeetingRequestSend)
       if (updatedProfile != null) {
-        profilesViewModel.updateProfile(updatedProfile) {
-            onComplete()
-        }
+        profilesViewModel.updateProfile(updatedProfile) { onComplete() }
       } else {
         Log.e("SENT MEETING REQUEST", "Removing the meeting request of our sent list failed")
       }
@@ -341,14 +338,13 @@ class MeetingRequestViewModel(
     profilesViewModel.getSelfProfile() {
       profilesViewModel.getInboxOfSelfProfile() {
         profilesViewModel.getMessageCancellationUsers() {
-            profilesViewModel.getInboxOfPendingLocations(){
-                onComplete()
-            } }
+          profilesViewModel.getInboxOfPendingLocations() { onComplete() }
+        }
       }
     }
   }
 
-  fun updateChosenLocalisations() {
+  private fun updateChosenLocalisations() {
     profilesViewModel.getSelfProfile() { profilesViewModel.getChosenLocations() }
   }
 
@@ -357,9 +353,7 @@ class MeetingRequestViewModel(
   }
 
   fun confirmMeetingLocation(uid: String, locAndMessage: Pair<String, Pair<Double, Double>>) {
-    profilesViewModel.confirmMeetingLocation(uid, locAndMessage){
-        updateChosenLocalisations()
-    }
+    profilesViewModel.confirmMeetingLocation(uid, locAndMessage) { updateChosenLocalisations() }
   }
 
   fun removeChosenLocalisation(uid: String) {
@@ -383,7 +377,7 @@ class MeetingRequestViewModel(
       mapUserDistance.forEach {
         if (it.value >= FIVE_HUNDRED_METERS_IN_KM) {
           removeFromMeetingRequestInbox(it.key.uid)
-          removeFromMeetingRequestSent(it.key.uid){}
+          removeFromMeetingRequestSent(it.key.uid) {}
           val targetToken = it.key.fcmToken ?: "null"
           val targetName = it.key.name
           setMeetingCancellation(

--- a/app/src/main/java/com/github/se/icebreakrr/model/message/MeetingRequestViewModel.kt
+++ b/app/src/main/java/com/github/se/icebreakrr/model/message/MeetingRequestViewModel.kt
@@ -14,7 +14,6 @@ import kotlin.math.atan2
 import kotlin.math.cos
 import kotlin.math.sin
 import kotlin.math.sqrt
-import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.tasks.await
 
@@ -338,29 +337,6 @@ class MeetingRequestViewModel(
   }
 
   /**
-   * Refreshes the content of the inbox to have it available locally
-   *
-   * @param onComplete : callback function to remove racing conditions
-   */
-  fun updateInboxOfMessages(onComplete: () -> Unit) {
-    profilesViewModel.getSelfProfile() {
-      profilesViewModel.getInboxOfSelfProfile() {
-        profilesViewModel.getMessageCancellationUsers() {
-          profilesViewModel.getInboxOfPendingLocations() { onComplete() }
-        }
-      }
-    }
-  }
-
-  /**
-   * private functions called when we have set the meeting confirmation It fetches the chosen
-   * locations from the database
-   */
-  private fun updateChosenLocalisations() {
-    profilesViewModel.getSelfProfile() { profilesViewModel.getChosenLocations() }
-  }
-
-  /**
    * function used to add a pending location. Called when someone accepts your meeting request
    *
    * @param newUid: uid of the user that accepted your request
@@ -368,6 +344,23 @@ class MeetingRequestViewModel(
    */
   fun addPendingLocation(newUid: String, onComplete: () -> Unit) {
     profilesViewModel.addPendingLocation(newUid) { onComplete() }
+  }
+
+  /**
+   * function that we need to call when two people have met
+   *
+   * @param uid : uid of the user you have met
+   */
+  fun removeChosenLocalisation(uid: String) {
+    profilesViewModel.removeChosenLocalisation(uid)
+  }
+
+  /**
+   * private functions called when we have set the meeting confirmation It fetches the chosen
+   * locations from the database
+   */
+  private fun getChosenLocalisations() {
+    profilesViewModel.getSelfProfile() { profilesViewModel.getChosenLocationsUsers() }
   }
 
   /**
@@ -384,16 +377,20 @@ class MeetingRequestViewModel(
       onFailure: (Exception) -> Unit
   ) {
     profilesViewModel.confirmMeetingLocation(
-        uid, locAndMessage, { updateChosenLocalisations() }, { onFailure(it) })
+        uid, locAndMessage, { getChosenLocalisations() }, { onFailure(it) })
   }
 
   /**
-   * function that we need to call when two people have met
+   * Refreshes the content of the inbox to have it available locally
    *
-   * @param uid : uid of the user you have met
+   * @param onComplete : callback function to remove racing conditions
    */
-  fun removeChosenLocalisation(uid: String) {
-    profilesViewModel.removeChosenLocalisation(uid)
+  fun updateInboxOfMessages(onComplete: () -> Unit) {
+    profilesViewModel.getSelfProfile() {
+      profilesViewModel.getInboxOfSelfProfile() {
+        profilesViewModel.getMessageCancellationUsers() { onComplete() }
+      }
+    }
   }
 
   /**

--- a/app/src/main/java/com/github/se/icebreakrr/model/message/cloudFunction/cloudFunction.js
+++ b/app/src/main/java/com/github/se/icebreakrr/model/message/cloudFunction/cloudFunction.js
@@ -1,4 +1,4 @@
-/**
+
 const functions = require('firebase-functions/v2');
 const admin = require('firebase-admin');
 
@@ -74,7 +74,7 @@ exports.sendMeetingConfirmation = functions.https.onRequest(async (request, resp
     // Access the data object within the request body
     const { targetToken, senderUID, senderName, message, location} = request.body.data;
     // Validate input
-    if (!targetToken || !senderUID || !senderName || !message || !location) {
+    if (!targetToken || !senderUID || !senderName || !location) {
         console.error('Missing targetToken or body or senderUid');
         response.status(400).json({ data: { error: 'Token or message or senderUid' } }); // Wrap error in data
         return;
@@ -165,4 +165,4 @@ exports.sendEngagementNotification = functions.https.onRequest(async (request, r
         response.status(500).json({ data: { error: `Error sending message: ${error.message}` } }); // Wrap error in data
     }
 });
-*/
+

--- a/app/src/main/java/com/github/se/icebreakrr/model/profile/Profile.kt
+++ b/app/src/main/java/com/github/se/icebreakrr/model/profile/Profile.kt
@@ -45,7 +45,9 @@ data class Profile(
     var hasAlreadyMet: List<String> = listOf(),
     var reports: Map<String, reportType> = mapOf(),
     val meetingRequestSent: List<String> = listOf(),
-    val meetingRequestInbox: Map<String, String> = mapOf()
+    val meetingRequestInbox: Map<String, String> = mapOf(),
+    val meetingRequestPendingLocation: List<String> = listOf(),
+    val meetingRequestChosenLocalisation: Map<String, Pair<Double, Double>> = mapOf()
 ) {
   /**
    * Calculates the user's age based on their birth date.

--- a/app/src/main/java/com/github/se/icebreakrr/model/profile/Profile.kt
+++ b/app/src/main/java/com/github/se/icebreakrr/model/profile/Profile.kt
@@ -47,7 +47,7 @@ data class Profile(
     val meetingRequestSent: List<String> = listOf(),
     val meetingRequestInbox: Map<String, String> = mapOf(),
     val meetingRequestPendingLocation: List<String> = listOf(),
-    val meetingRequestChosenLocalisation: Map<String, Pair<Double, Double>> = mapOf()
+    val meetingRequestChosenLocalisation: Map<String, Pair<String, Pair<Double, Double>>> = mapOf()
 ) {
   /**
    * Calculates the user's age based on their birth date.

--- a/app/src/main/java/com/github/se/icebreakrr/model/profile/ProfilesRepositoryFirestore.kt
+++ b/app/src/main/java/com/github/se/icebreakrr/model/profile/ProfilesRepositoryFirestore.kt
@@ -375,16 +375,18 @@ class ProfilesRepositoryFirestore(
       val meetingRequestPendingLocation =
           (document.get("meetingRequestPendingLocation") as? List<*>)?.filterIsInstance<String>()
               ?: listOf()
-        val meetingRequestChosenLocation =
-            (document.get("meetingRequestChosenLocalisation") as? Map<String, Map<String, Any>>)
-                ?.mapNotNull { (key, value) ->
-                    val message = (value["first"] as? String)
-                    val loc = (value["second"] as? Map<String, Any>)
-                    val latitude = (loc?.get("first") as? Double)
-                    val longitude = (loc?.get("second") as? Double)
-                    if (latitude == null || longitude == null) throw Exception("Could not retrieve location from chosen location")
-                     key to Pair(message?:"", Pair(latitude, longitude))
-                }?.toMap() ?: mapOf()
+      val meetingRequestChosenLocation =
+          (document.get("meetingRequestChosenLocalisation") as? Map<String, Map<String, Any>>)
+              ?.mapNotNull { (key, value) ->
+                val message = (value["first"] as? String)
+                val loc = (value["second"] as? Map<String, Any>)
+                val latitude = (loc?.get("first") as? Double)
+                val longitude = (loc?.get("second") as? Double)
+                if (latitude == null || longitude == null)
+                    throw Exception("Could not retrieve location from chosen location")
+                key to Pair(message ?: "", Pair(latitude, longitude))
+              }
+              ?.toMap() ?: mapOf()
       Profile(
           uid = uid,
           name = name,

--- a/app/src/main/java/com/github/se/icebreakrr/model/profile/ProfilesRepositoryFirestore.kt
+++ b/app/src/main/java/com/github/se/icebreakrr/model/profile/ProfilesRepositoryFirestore.kt
@@ -372,6 +372,22 @@ class ProfilesRepositoryFirestore(
               ?.filter { (key, value) -> key is String && value is String }
               ?.map { (key, value) -> key as String to value as String }
               ?.toMap() ?: mapOf()
+      val meetingRequestPendingLocation =
+          (document.get("meetingRequestPendingLocation") as? List<*>)?.filterIsInstance<String>()
+              ?: listOf()
+      val meetingRequestChosenLocation =
+          (document.get("meetingRequestChosenLocalisation") as? Map<*, *>)
+              ?.filter { (key, value) ->
+                key is String &&
+                    value is Map<*, *> &&
+                    value["latitude"] is Double &&
+                    value["longitude"] is Double
+              }
+              ?.map { (key, value) ->
+                key as String to
+                    Pair((value as Map<*, *>)["latitude"] as Double, value["longitude"] as Double)
+              }
+              ?.toMap() ?: mapOf()
       Profile(
           uid = uid,
           name = name,
@@ -388,7 +404,9 @@ class ProfilesRepositoryFirestore(
           hasAlreadyMet = hasAlreadyMet,
           reports = reports,
           meetingRequestSent = meetingRequestSent,
-          meetingRequestInbox = meetingRequestInbox)
+          meetingRequestInbox = meetingRequestInbox,
+          meetingRequestPendingLocation = meetingRequestPendingLocation,
+          meetingRequestChosenLocalisation = meetingRequestChosenLocation)
     } catch (e: Exception) {
       Log.e("ProfileRepositoryFirestore", "Error converting document to Profile", e)
       null

--- a/app/src/main/java/com/github/se/icebreakrr/model/profile/ProfilesRepositoryFirestore.kt
+++ b/app/src/main/java/com/github/se/icebreakrr/model/profile/ProfilesRepositoryFirestore.kt
@@ -375,19 +375,16 @@ class ProfilesRepositoryFirestore(
       val meetingRequestPendingLocation =
           (document.get("meetingRequestPendingLocation") as? List<*>)?.filterIsInstance<String>()
               ?: listOf()
-      val meetingRequestChosenLocation =
-          (document.get("meetingRequestChosenLocalisation") as? Map<*, *>)
-              ?.filter { (key, value) ->
-                key is String &&
-                    value is Map<*, *> &&
-                    value["latitude"] is Double &&
-                    value["longitude"] is Double
-              }
-              ?.map { (key, value) ->
-                key as String to
-                    Pair((value as Map<*, *>)["latitude"] as Double, value["longitude"] as Double)
-              }
-              ?.toMap() ?: mapOf()
+        val meetingRequestChosenLocation =
+            (document.get("meetingRequestChosenLocalisation") as? Map<String, Map<String, Any>>)
+                ?.mapNotNull { (key, value) ->
+                    val message = (value["first"] as? String)
+                    val loc = (value["second"] as? Map<String, Any>)
+                    val latitude = (loc?.get("first") as? Double)
+                    val longitude = (loc?.get("second") as? Double)
+                    if (latitude == null || longitude == null) throw Exception("Could not retrieve location from chosen location")
+                     key to Pair(message?:"", Pair(latitude, longitude))
+                }?.toMap() ?: mapOf()
       Profile(
           uid = uid,
           name = name,

--- a/app/src/main/java/com/github/se/icebreakrr/model/profile/ProfilesViewModel.kt
+++ b/app/src/main/java/com/github/se/icebreakrr/model/profile/ProfilesViewModel.kt
@@ -80,8 +80,8 @@ open class ProfilesViewModel(
   open var pendingLocalisations: StateFlow<List<Profile>> = _pendingLocalisations
 
   private val _chosenLocalisations =
-      MutableStateFlow<Map<Profile, Pair<Double, Double>>>(emptyMap())
-  open var chosenLocalisations: StateFlow<Map<Profile, Pair<Double, Double>>> = _chosenLocalisations
+      MutableStateFlow<Map<Profile, Pair<String, Pair<Double, Double>>>>(emptyMap())
+  open var chosenLocalisations: StateFlow<Map<Profile, Pair<String, Pair<Double, Double>>>> = _chosenLocalisations
 
   fun updateIsConnected(boolean: Boolean) {
     _isConnected.value = boolean
@@ -543,7 +543,6 @@ open class ProfilesViewModel(
         inboxUserUid,
         onSuccess = { profileList ->
           _pendingLocalisations.value = profileList
-            Log.d("TESTEST", "profile view model pending location size : ${profileList.size}")
           _loading.value = false
           _isConnected.value = true
           onComplete()
@@ -552,7 +551,7 @@ open class ProfilesViewModel(
   }
 
   private fun getChosenLocations(
-      inboxUserUid: Map<String, Pair<Double, Double>>,
+      inboxUserUid: Map<String, Pair<String, Pair<Double, Double>>>,
   ) {
     _loading.value = true
     repository.getMultipleProfiles(
@@ -661,7 +660,7 @@ open class ProfilesViewModel(
                     ?: emptyMap())!!) {}
   }
 
-  fun confirmMeetingLocation(uid: String, loc: Pair<Double, Double>) {
+  fun confirmMeetingLocation(uid: String, loc: Pair<String, Pair<Double, Double>>, onComplete: () -> Unit) {
     updateProfile(
         _selfProfile.value?.copy(
             meetingRequestChosenLocalisation =
@@ -669,7 +668,7 @@ open class ProfilesViewModel(
                     ?: emptyMap(),
             meetingRequestPendingLocation =
                 _selfProfile.value?.meetingRequestPendingLocation?.filter { it != uid }
-                    ?: emptyList())!!) {}
+                    ?: emptyList())!!) {onComplete()}
   }
 
   /** Fetches the current user's profile from the repository. */

--- a/app/src/main/java/com/github/se/icebreakrr/model/profile/ProfilesViewModel.kt
+++ b/app/src/main/java/com/github/se/icebreakrr/model/profile/ProfilesViewModel.kt
@@ -537,14 +537,16 @@ open class ProfilesViewModel(
         })
   }
 
-  private fun getPendingLocationUsers(inboxUserUid: List<String>) {
+  private fun getPendingLocationUsers(inboxUserUid: List<String>, onComplete: () -> Unit) {
     _loading.value = true
     repository.getMultipleProfiles(
         inboxUserUid,
         onSuccess = { profileList ->
           _pendingLocalisations.value = profileList
+            Log.d("TESTEST", "profile view model pending location size : ${profileList.size}")
           _loading.value = false
           _isConnected.value = true
+          onComplete()
         },
         onFailure = { e -> handleError(e) })
   }
@@ -626,10 +628,12 @@ open class ProfilesViewModel(
     }
   }
 
-  fun getInboxOfPendingLocations() {
+  fun getInboxOfPendingLocations(onComplete: () -> Unit) {
     val pendingLocationUid = selfProfile.value?.meetingRequestPendingLocation
     if (pendingLocationUid != null) {
-      getPendingLocationUsers(pendingLocationUid)
+      getPendingLocationUsers(pendingLocationUid){
+          onComplete()
+      }
     }
   }
 

--- a/app/src/main/java/com/github/se/icebreakrr/model/profile/ProfilesViewModel.kt
+++ b/app/src/main/java/com/github/se/icebreakrr/model/profile/ProfilesViewModel.kt
@@ -9,7 +9,6 @@ import android.widget.Toast
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.ViewModelProvider
 import com.github.se.icebreakrr.model.profile.ProfilesViewModel.ProfilePictureState.TO_DELETE
-import com.github.se.icebreakrr.model.profile.ProfilesViewModel.ProfilePictureState.UNCHANGED
 import com.github.se.icebreakrr.ui.sections.DEFAULT_RADIUS
 import com.github.se.icebreakrr.ui.sections.DEFAULT_USER_LATITUDE
 import com.github.se.icebreakrr.ui.sections.DEFAULT_USER_LONGITUDE
@@ -562,7 +561,7 @@ open class ProfilesViewModel(
    * @param inboxUserUid : list of users to fetch from database with the message and localisation
    *   they have sent
    */
-  private fun getChosenLocations(
+  private fun getChosenLocationsUsers(
       inboxUserUid: Map<String, Pair<String, Pair<Double, Double>>>,
   ) {
     _loading.value = true
@@ -634,7 +633,8 @@ open class ProfilesViewModel(
   fun getInboxOfSelfProfile(onComplete: () -> Unit) {
     val inboxUidList = selfProfile.value?.meetingRequestInbox
     val sentUidList = selfProfile.value?.meetingRequestSent
-    if (inboxUidList != null && sentUidList != null) {
+    val pendingLocationUid = selfProfile.value?.meetingRequestPendingLocation
+    if (inboxUidList != null && sentUidList != null && pendingLocationUid != null) {
       val uidsMessageList = inboxUidList.toList()
       val uidsList = uidsMessageList.map { it.first }
       val messageList = uidsMessageList.map { it.second }
@@ -642,29 +642,17 @@ open class ProfilesViewModel(
         _inboxItems.value = _inboxProfiles.value.filterNotNull().zip(messageList).toMap()
         getSentUsers(sentUidList) {
           _sentItems.value = _sentProfiles.value.filterNotNull()
-          onComplete()
+          getPendingLocationUsers(pendingLocationUid) { onComplete() }
         }
       }
     }
   }
 
-  /**
-   * function that fetches the pending profiles in the databse from the local self profile
-   *
-   * @param onComplete : callback used to avoid race conditions
-   */
-  fun getInboxOfPendingLocations(onComplete: () -> Unit) {
-    val pendingLocationUid = selfProfile.value?.meetingRequestPendingLocation
-    if (pendingLocationUid != null) {
-      getPendingLocationUsers(pendingLocationUid) { onComplete() }
-    }
-  }
-
   /** function that fetches the profiles in the database from the local self profile */
-  fun getChosenLocations() {
+  fun getChosenLocationsUsers() {
     val chosenLocationsUid = selfProfile.value?.meetingRequestChosenLocalisation
     if (chosenLocationsUid != null) {
-      getChosenLocations(chosenLocationsUid)
+      getChosenLocationsUsers(chosenLocationsUid)
     }
   }
 

--- a/app/src/main/java/com/github/se/icebreakrr/model/profile/ProfilesViewModel.kt
+++ b/app/src/main/java/com/github/se/icebreakrr/model/profile/ProfilesViewModel.kt
@@ -81,7 +81,8 @@ open class ProfilesViewModel(
 
   private val _chosenLocalisations =
       MutableStateFlow<Map<Profile, Pair<String, Pair<Double, Double>>>>(emptyMap())
-  open var chosenLocalisations: StateFlow<Map<Profile, Pair<String, Pair<Double, Double>>>> = _chosenLocalisations
+  open var chosenLocalisations: StateFlow<Map<Profile, Pair<String, Pair<Double, Double>>>> =
+      _chosenLocalisations
 
   fun updateIsConnected(boolean: Boolean) {
     _isConnected.value = boolean
@@ -256,6 +257,7 @@ open class ProfilesViewModel(
    * @param uid The unique ID of the user whose profile is being retrieved.
    */
   fun getProfileByUid(uid: String) {
+    Log.d("TESTEST", "get profile by uid : ${uid}")
     _loading.value = true
     repository.getProfileByUid(
         uid,
@@ -522,6 +524,7 @@ open class ProfilesViewModel(
    * @param inboxUserUid: The list of UID of the profiles that have sent a message to our user inbox
    */
   private fun getInboxUsers(inboxUserUid: List<String>, onComplete: () -> Unit) {
+    Log.d("TESTEST", "get inbox user : ${inboxUserUid}")
     _loading.value = true
     repository.getMultipleProfiles(
         inboxUserUid,
@@ -539,6 +542,7 @@ open class ProfilesViewModel(
 
   private fun getPendingLocationUsers(inboxUserUid: List<String>, onComplete: () -> Unit) {
     _loading.value = true
+    Log.d("TESTEST", "get pending location users : ${inboxUserUid}")
     repository.getMultipleProfiles(
         inboxUserUid,
         onSuccess = { profileList ->
@@ -630,9 +634,7 @@ open class ProfilesViewModel(
   fun getInboxOfPendingLocations(onComplete: () -> Unit) {
     val pendingLocationUid = selfProfile.value?.meetingRequestPendingLocation
     if (pendingLocationUid != null) {
-      getPendingLocationUsers(pendingLocationUid){
-          onComplete()
-      }
+      getPendingLocationUsers(pendingLocationUid) { onComplete() }
     }
   }
 
@@ -660,7 +662,11 @@ open class ProfilesViewModel(
                     ?: emptyMap())!!) {}
   }
 
-  fun confirmMeetingLocation(uid: String, loc: Pair<String, Pair<Double, Double>>, onComplete: () -> Unit) {
+  fun confirmMeetingLocation(
+      uid: String,
+      loc: Pair<String, Pair<Double, Double>>,
+      onComplete: () -> Unit
+  ) {
     updateProfile(
         _selfProfile.value?.copy(
             meetingRequestChosenLocalisation =
@@ -668,7 +674,9 @@ open class ProfilesViewModel(
                     ?: emptyMap(),
             meetingRequestPendingLocation =
                 _selfProfile.value?.meetingRequestPendingLocation?.filter { it != uid }
-                    ?: emptyList())!!) {onComplete()}
+                    ?: emptyList())!!) {
+          onComplete()
+        }
   }
 
   /** Fetches the current user's profile from the repository. */

--- a/app/src/main/java/com/github/se/icebreakrr/ui/authentication/ProfileCreation.kt
+++ b/app/src/main/java/com/github/se/icebreakrr/ui/authentication/ProfileCreation.kt
@@ -312,7 +312,9 @@ fun ProfileCreationScreen(
                           tags = selectedTags,
                           fcmToken = fcmToken,
                           meetingRequestSent = listOf(),
-                          meetingRequestInbox = mapOf())
+                          meetingRequestInbox = mapOf(),
+                          meetingRequestPendingLocation = emptyList(),
+                          meetingRequestChosenLocalisation = emptyMap())
                   // Creates profile in DB
                   profilesViewModel.addNewProfile(newProfile)
                   // Navigate to AroundYou screen

--- a/app/src/main/java/com/github/se/icebreakrr/ui/authentication/SignIn.kt
+++ b/app/src/main/java/com/github/se/icebreakrr/ui/authentication/SignIn.kt
@@ -162,7 +162,7 @@ fun SignInScreen(
                         navigationActions.navigateTo(Screen.PROFILE_CREATION)
                       } else {
                         val updatedProfile = profile.copy(fcmToken = fcmToken)
-                        profilesViewModel.updateProfile(updatedProfile)
+                        profilesViewModel.updateProfile(updatedProfile) {}
                         navigationActions.navigateTo(TopLevelDestinations.AROUND_YOU)
                       }
                     }

--- a/app/src/main/java/com/github/se/icebreakrr/ui/authentication/SignIn.kt
+++ b/app/src/main/java/com/github/se/icebreakrr/ui/authentication/SignIn.kt
@@ -162,7 +162,7 @@ fun SignInScreen(
                         navigationActions.navigateTo(Screen.PROFILE_CREATION)
                       } else {
                         val updatedProfile = profile.copy(fcmToken = fcmToken)
-                        profilesViewModel.updateProfile(updatedProfile) {}
+                        profilesViewModel.updateProfile(updatedProfile, {}, {})
                         navigationActions.navigateTo(TopLevelDestinations.AROUND_YOU)
                       }
                     }

--- a/app/src/main/java/com/github/se/icebreakrr/ui/map/HeatMap.kt
+++ b/app/src/main/java/com/github/se/icebreakrr/ui/map/HeatMap.kt
@@ -92,7 +92,8 @@ fun HeatMap(
             },
             tabList = LIST_TOP_LEVEL_DESTINATIONS,
             selectedItem = Route.HEAT_MAP,
-            notificationCount = myProfile.value?.meetingRequestInbox?.size ?: 0)
+            notificationCount = myProfile.value?.meetingRequestInbox?.size ?: 0,
+            heatMapCount = myProfile.value?.meetingRequestChosenLocalisation?.size?:0)
       }) { paddingValues ->
         if (userLocation.value == null) {
           // Show loading box when location is not available

--- a/app/src/main/java/com/github/se/icebreakrr/ui/map/HeatMap.kt
+++ b/app/src/main/java/com/github/se/icebreakrr/ui/map/HeatMap.kt
@@ -136,7 +136,6 @@ fun HeatMap(
               Log.w("HeatMap", "No valid locations to display on the heatmap.")
             }
           }
-
           GoogleMap(
               modifier = Modifier.fillMaxSize().padding(paddingValues).testTag("googleMap"),
               cameraPositionState = cameraPositionState,

--- a/app/src/main/java/com/github/se/icebreakrr/ui/map/HeatMap.kt
+++ b/app/src/main/java/com/github/se/icebreakrr/ui/map/HeatMap.kt
@@ -93,7 +93,7 @@ fun HeatMap(
             tabList = LIST_TOP_LEVEL_DESTINATIONS,
             selectedItem = Route.HEAT_MAP,
             notificationCount = myProfile.value?.meetingRequestInbox?.size ?: 0,
-            heatMapCount = myProfile.value?.meetingRequestChosenLocalisation?.size?:0)
+            heatMapCount = myProfile.value?.meetingRequestChosenLocalisation?.size ?: 0)
       }) { paddingValues ->
         if (userLocation.value == null) {
           // Show loading box when location is not available

--- a/app/src/main/java/com/github/se/icebreakrr/ui/map/LocationSelectorMap.kt
+++ b/app/src/main/java/com/github/se/icebreakrr/ui/map/LocationSelectorMap.kt
@@ -1,26 +1,19 @@
 package com.github.se.icebreakrr.ui.map
 
+import android.util.Log
 import android.widget.Toast
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.absoluteOffset
-import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.layout.size
-import androidx.compose.foundation.layout.width
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Check
-import androidx.compose.material3.Button
-import androidx.compose.material3.FloatingActionButton
-import androidx.compose.material3.FloatingActionButtonDefaults
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
-import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextField
@@ -34,14 +27,11 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.shadow
-import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.graphics.Color
-import androidx.compose.ui.graphics.RectangleShape
 import androidx.compose.ui.platform.LocalConfiguration
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.unit.dp
-import androidx.compose.ui.zIndex
 import androidx.navigation.NavBackStackEntry
 import com.github.se.icebreakrr.model.location.LocationViewModel
 import com.github.se.icebreakrr.model.message.MeetingRequestViewModel
@@ -52,11 +42,9 @@ import com.github.se.icebreakrr.ui.sections.DEFAULT_USER_LATITUDE
 import com.github.se.icebreakrr.ui.sections.DEFAULT_USER_LONGITUDE
 import com.github.se.icebreakrr.ui.sections.shared.TopBar
 import com.github.se.icebreakrr.ui.theme.IceBreakrrBlue
-import com.google.android.gms.maps.model.BitmapDescriptorFactory
 import com.google.android.gms.maps.model.CameraPosition
 import com.google.android.gms.maps.model.LatLng
 import com.google.maps.android.compose.Circle
-import com.google.maps.android.compose.DragState
 import com.google.maps.android.compose.GoogleMap
 import com.google.maps.android.compose.MapUiSettings
 import com.google.maps.android.compose.Marker
@@ -69,8 +57,9 @@ fun LocationSelectorMapScreen(
     profilesViewModel: ProfilesViewModel,
     navigationActions: NavigationActions,
     meetingRequestViewModel: MeetingRequestViewModel,
-    navBackStackEntry: NavBackStackEntry,
-    locationViewModel: LocationViewModel
+    navBackStackEntry: NavBackStackEntry?,
+    locationViewModel: LocationViewModel,
+    isTesting: Boolean
 ) {
   val configuration = LocalConfiguration.current
 
@@ -80,106 +69,129 @@ fun LocationSelectorMapScreen(
   val centerLongitude =
       profilesViewModel.selfProfile.value?.location?.longitude ?: DEFAULT_USER_LONGITUDE
   var markerState by remember { mutableStateOf<MarkerState?>(null) }
-  var showConfirmButton by remember { mutableStateOf(false) }
-  val profileId = navBackStackEntry.arguments?.getString("userId")
+  val profileId = if (!isTesting) navBackStackEntry?.arguments?.getString("userId") else "2"
   val profile = profilesViewModel.selectedProfile.collectAsState()
   val context = LocalContext.current
   val lastKnownLocation = locationViewModel.lastKnownLocation.collectAsState()
   var mapLoaded by remember { mutableStateOf(false) }
   var stringQuery by remember { mutableStateOf("") }
 
+  Log.d("TESTEST", "profile Id : ${profileId}")
+
   LaunchedEffect(Unit) {
-    profilesViewModel.getSelfProfile(){}
+    profilesViewModel.getSelfProfile() {}
     profilesViewModel.getProfileByUid(profileId ?: "null")
-    markerState = MarkerState(position = LatLng(lastKnownLocation.value?.latitude?: DEFAULT_USER_LATITUDE, lastKnownLocation.value?.longitude?: DEFAULT_USER_LONGITUDE))
+    markerState =
+        MarkerState(
+            position =
+                LatLng(
+                    lastKnownLocation.value?.latitude ?: DEFAULT_USER_LATITUDE,
+                    lastKnownLocation.value?.longitude ?: DEFAULT_USER_LONGITUDE))
   }
 
   val cameraPositionState = rememberCameraPositionState {
     position = CameraPosition.fromLatLngZoom(LatLng(centerLatitude, centerLongitude), 16F)
   }
 
-    Scaffold(
-        modifier = Modifier.fillMaxSize().background(Color.White),
-        topBar = { TopBar("Select Meeting Point", false, {}) },
-        bottomBar = {
-            Box(
-                modifier = Modifier
-                    .fillMaxWidth()
-                    .height(150.dp).background(
-                        color = IceBreakrrBlue),
-            ) {
-                TextField(
-                    value = stringQuery,
-                    onValueChange = {
-                        if (it.length < 113){
-                            stringQuery = it
-                        }
-                    },
-                    label = { Text("Add Details...", modifier = Modifier.testTag("labelTagSelector")) },
-                    placeholder = {
-                        Text("", modifier = Modifier.testTag("placeholderTagSelector"))
-                    },
-                    modifier = Modifier
-                        .padding(start = 16.dp, end = 16.dp, top = 8.dp, bottom = 8.dp) // Adds padding on the left
-                        .fillMaxSize().shadow(
-                            elevation = 8.dp, // Adjust shadow intensity
-                            shape = androidx.compose.foundation.shape.RoundedCornerShape(8.dp) // Optional: Rounded corners
-                        ),
-                    trailingIcon = {
-                    }// Reduces the width to leave space for the FAB
-                )
-                IconButton(onClick = {
-                    meetingRequestViewModel.confirmMeetingLocation(
-                        profileId!!,
-                        Pair(stringQuery, Pair(markerState?.position?.latitude!!, markerState?.position?.longitude!!)))
-                    meetingRequestViewModel.setMeetingConfirmation(
-                        profile.value?.fcmToken!!,
-                        markerState?.position?.latitude!!.toString() +
-                                ", " +
-                                markerState?.position?.longitude!!.toString(), stringQuery
-                    )
-                    meetingRequestViewModel.sendMeetingConfirmation()
-                    navigationActions.navigateTo(Route.HEAT_MAP)},
-                    modifier = Modifier
-                        .align(Alignment.BottomEnd)
-                        .padding(end = 16.dp, bottom = 8.dp)) {
-                    Icon(Icons.Default.Check, contentDescription = "Confirm")
+  Scaffold(
+      modifier =
+          Modifier.fillMaxSize().background(Color.White).testTag("LocationSelectorMapScreen"),
+      topBar = { TopBar("Select Meeting Point", false, {}) },
+      bottomBar = {
+        Box(
+            modifier =
+                Modifier.fillMaxWidth()
+                    .height(150.dp)
+                    .background(color = IceBreakrrBlue)
+                    .testTag("addTextAndSendLocationBox"),
+        ) {
+          TextField(
+              value = stringQuery,
+              onValueChange = {
+                if (it.length < 113) {
+                  stringQuery = it
                 }
-            }
+              },
+              label = { Text("Add Details...", modifier = Modifier.testTag("labelTagSelector")) },
+              placeholder = { Text("", modifier = Modifier.testTag("placeholderTagSelector")) },
+              modifier =
+                  Modifier.padding(
+                          start = 16.dp,
+                          end = 16.dp,
+                          top = 8.dp,
+                          bottom = 8.dp) // Adds padding on the left
+                      .fillMaxSize()
+                      .shadow(
+                          elevation = 8.dp, // Adjust shadow intensity
+                          shape =
+                              androidx.compose.foundation.shape.RoundedCornerShape(
+                                  8.dp) // Optional: Rounded corners
+                          )
+                      .testTag("addDetailsTextField"),
+              trailingIcon = {} // Reduces the width to leave space for the FAB
+              )
+          IconButton(
+              onClick = {
+                if (mapLoaded || isTesting) {
+                  meetingRequestViewModel.confirmMeetingLocation(
+                      profileId!!,
+                      Pair(
+                          stringQuery,
+                          Pair(
+                              markerState?.position?.latitude!!,
+                              markerState?.position?.longitude!!)))
+                  meetingRequestViewModel.setMeetingConfirmation(
+                      profile.value?.fcmToken!!,
+                      markerState?.position?.latitude!!.toString() +
+                          ", " +
+                          markerState?.position?.longitude!!.toString(),
+                      stringQuery)
+                  meetingRequestViewModel.sendMeetingConfirmation()
+                  navigationActions.navigateTo(Route.HEAT_MAP)
+                }
+              },
+              modifier =
+                  Modifier.align(Alignment.BottomEnd)
+                      .padding(end = 16.dp, bottom = 8.dp)
+                      .testTag("buttonSendMessageLocation")) {
+                Icon(Icons.Default.Check, contentDescription = "Confirm")
+              }
         }
-    ) { paddingValues ->
+      }) { paddingValues ->
         if (!loadingSelfProfile.value) {
-            Column(verticalArrangement = Arrangement.Top) {
-                GoogleMap(
-                    modifier = Modifier.fillMaxSize().padding(paddingValues).testTag("normalMap"),
-                    cameraPositionState = cameraPositionState,
-                    onMapClick = { latLong ->
-                        if (LatLng(centerLatitude, centerLongitude).sphericalDistance(latLong) < 500) {
-                            markerState?.position = latLong
-                        } else {
-                            Toast.makeText(
-                                context,
-                                "You should select a meeting point inside the white circle!",
-                                Toast.LENGTH_SHORT
-                            ).show()
-                        }
-                    },
-                    onMapLoaded = { mapLoaded = true },
-                    onMapLongClick = { markerState?.position = it },
-                    uiSettings = MapUiSettings(zoomControlsEnabled = false)
-                ) {
-                    if (mapLoaded) {
-                        Circle(
-                            LatLng(centerLatitude, centerLongitude),
-                            radius = 500.0,
-                            fillColor = Color(0x11FFFFFF),
-                            strokeColor = Color.Black,
-                            strokeWidth = 2f
-                        )
-                        Marker(state = markerState!!, title = "Selected Position", onClick = { true }, draggable = true)
-                    }
+          Column(verticalArrangement = Arrangement.Top) {
+            GoogleMap(
+                modifier = Modifier.fillMaxSize().padding(paddingValues).testTag("normalMap"),
+                cameraPositionState = cameraPositionState,
+                onMapClick = { latLong ->
+                  if (LatLng(centerLatitude, centerLongitude).sphericalDistance(latLong) < 500) {
+                    markerState?.position = latLong
+                  } else {
+                    Toast.makeText(
+                            context,
+                            "You should select a meeting point inside the white circle!",
+                            Toast.LENGTH_SHORT)
+                        .show()
+                  }
+                },
+                onMapLoaded = { mapLoaded = true },
+                onMapLongClick = { markerState?.position = it },
+                uiSettings = MapUiSettings(zoomControlsEnabled = false)) {
+                  if (mapLoaded) {
+                    Circle(
+                        LatLng(centerLatitude, centerLongitude),
+                        radius = 500.0,
+                        fillColor = Color(0x11FFFFFF),
+                        strokeColor = Color.Black,
+                        strokeWidth = 2f)
+                    Marker(
+                        state = markerState!!,
+                        title = "Selected Position",
+                        onClick = { true },
+                        draggable = true)
+                  }
                 }
-            }
+          }
         }
-    }
-    }
+      }
+}

--- a/app/src/main/java/com/github/se/icebreakrr/ui/map/LocationSelectorMap.kt
+++ b/app/src/main/java/com/github/se/icebreakrr/ui/map/LocationSelectorMap.kt
@@ -1,0 +1,131 @@
+package com.github.se.icebreakrr.ui.map
+
+import android.widget.Toast
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.absoluteOffset
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Check
+import androidx.compose.material3.FloatingActionButton
+import androidx.compose.material3.Icon
+import androidx.compose.material3.Scaffold
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.platform.LocalConfiguration
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.unit.dp
+import androidx.navigation.NavBackStackEntry
+import com.github.se.icebreakrr.model.message.MeetingRequestViewModel
+import com.github.se.icebreakrr.model.profile.ProfilesViewModel
+import com.github.se.icebreakrr.ui.navigation.NavigationActions
+import com.github.se.icebreakrr.ui.navigation.Route
+import com.github.se.icebreakrr.ui.sections.DEFAULT_USER_LATITUDE
+import com.github.se.icebreakrr.ui.sections.DEFAULT_USER_LONGITUDE
+import com.github.se.icebreakrr.ui.sections.shared.TopBar
+import com.google.android.gms.maps.model.CameraPosition
+import com.google.android.gms.maps.model.LatLng
+import com.google.maps.android.compose.Circle
+import com.google.maps.android.compose.GoogleMap
+import com.google.maps.android.compose.Marker
+import com.google.maps.android.compose.MarkerState
+import com.google.maps.android.compose.rememberCameraPositionState
+import com.google.maps.android.ktx.utils.sphericalDistance
+
+@Composable
+fun LocationSelectorMapScreen(
+    profilesViewModel: ProfilesViewModel,
+    navigationActions: NavigationActions,
+    meetingRequestViewModel: MeetingRequestViewModel,
+    navBackStackEntry: NavBackStackEntry
+) {
+  val configuration = LocalConfiguration.current
+  val screenHeight = configuration.screenHeightDp
+  val screenWidth = configuration.screenWidthDp
+
+  val loadingSelfProfile = profilesViewModel.loadingSelf.collectAsState()
+  val centerLatitude =
+      profilesViewModel.selfProfile.value?.location?.latitude ?: DEFAULT_USER_LATITUDE
+  val centerLongitude =
+      profilesViewModel.selfProfile.value?.location?.longitude ?: DEFAULT_USER_LONGITUDE
+  var markerState by remember { mutableStateOf<MarkerState?>(null) }
+  var showConfirmButton by remember { mutableStateOf(false) }
+  val profileId = navBackStackEntry.arguments?.getString("userId")
+  val profile = profilesViewModel.selectedProfile.collectAsState()
+  val context = LocalContext.current
+  var buttonOffset by remember { mutableStateOf(Offset.Zero) }
+
+  LaunchedEffect(Unit) {
+    profilesViewModel.getSelfProfile()
+    profilesViewModel.getProfileByUid(profileId ?: "null")
+  }
+
+  val cameraPositionState = rememberCameraPositionState {
+    position = CameraPosition.fromLatLngZoom(LatLng(centerLatitude, centerLongitude), 15F)
+  }
+
+  Scaffold(
+      modifier = Modifier.fillMaxSize().background(Color.White),
+      topBar = { TopBar("Select Meeting Point", false, {}) }) { paddingValues ->
+        if (!loadingSelfProfile.value) {
+          GoogleMap(
+              modifier = Modifier.fillMaxSize().padding(paddingValues).testTag("normalMap"),
+              cameraPositionState = cameraPositionState,
+              onMapClick = { latLong ->
+                if (LatLng(centerLatitude, centerLongitude).sphericalDistance(latLong) < 500) {
+                  markerState = MarkerState(position = latLong)
+                  showConfirmButton = true
+                } else {
+                  Toast.makeText(
+                          context,
+                          "You should select a meeting point inside the white circle!",
+                          Toast.LENGTH_SHORT)
+                      .show()
+                }
+              },
+          ) {
+            Circle(
+                LatLng(centerLatitude, centerLongitude),
+                radius = 500.0,
+                fillColor = Color(0x11FFFFFF),
+                strokeColor = Color.Black,
+                strokeWidth = 2f)
+            markerState?.let { state ->
+              Marker(state = state, title = "Selected Position", onClick = { true })
+            }
+          }
+
+          if (showConfirmButton) {
+            FloatingActionButton(
+                onClick = {
+                  showConfirmButton = false
+                  meetingRequestViewModel.confirmMeetingLocation(
+                      profileId!!,
+                      Pair(markerState?.position?.latitude!!, markerState?.position?.longitude!!))
+                  meetingRequestViewModel.setMeetingConfirmation(
+                      profile.value?.fcmToken!!,
+                      markerState?.position?.latitude!!.toString() +
+                          ", " +
+                          markerState?.position?.longitude!!.toString())
+                  meetingRequestViewModel.sendMeetingConfirmation()
+                  navigationActions.navigateTo(Route.HEAT_MAP)
+                },
+                modifier =
+                    Modifier.absoluteOffset(x = (screenWidth - 75).dp, y = (screenHeight - 170).dp)
+                        .size(60.dp)) {
+                  Icon(Icons.Default.Check, contentDescription = "Confirm Pin")
+                }
+          }
+        }
+      }
+}

--- a/app/src/main/java/com/github/se/icebreakrr/ui/map/LocationSelectorMap.kt
+++ b/app/src/main/java/com/github/se/icebreakrr/ui/map/LocationSelectorMap.kt
@@ -2,15 +2,27 @@ package com.github.se.icebreakrr.ui.map
 
 import android.widget.Toast
 import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.absoluteOffset
+import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Check
+import androidx.compose.material3.Button
 import androidx.compose.material3.FloatingActionButton
+import androidx.compose.material3.FloatingActionButtonDefaults
 import androidx.compose.material3.Icon
+import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextField
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
@@ -18,13 +30,17 @@ import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.shadow
 import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.RectangleShape
 import androidx.compose.ui.platform.LocalConfiguration
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.unit.dp
+import androidx.compose.ui.zIndex
 import androidx.navigation.NavBackStackEntry
 import com.github.se.icebreakrr.model.location.LocationViewModel
 import com.github.se.icebreakrr.model.message.MeetingRequestViewModel
@@ -34,6 +50,7 @@ import com.github.se.icebreakrr.ui.navigation.Route
 import com.github.se.icebreakrr.ui.sections.DEFAULT_USER_LATITUDE
 import com.github.se.icebreakrr.ui.sections.DEFAULT_USER_LONGITUDE
 import com.github.se.icebreakrr.ui.sections.shared.TopBar
+import com.github.se.icebreakrr.ui.theme.IceBreakrrBlue
 import com.google.android.gms.maps.model.BitmapDescriptorFactory
 import com.google.android.gms.maps.model.CameraPosition
 import com.google.android.gms.maps.model.LatLng
@@ -70,6 +87,7 @@ fun LocationSelectorMapScreen(
   val context = LocalContext.current
   val lastKnownLocation = locationViewModel.lastKnownLocation.collectAsState()
   var mapLoaded by remember { mutableStateOf(false) }
+  var stringQuery by remember { mutableStateOf("") }
 
   LaunchedEffect(Unit) {
     profilesViewModel.getSelfProfile(){}
@@ -81,60 +99,97 @@ fun LocationSelectorMapScreen(
     position = CameraPosition.fromLatLngZoom(LatLng(centerLatitude, centerLongitude), 16F)
   }
 
-  Scaffold(
-      modifier = Modifier.fillMaxSize().background(Color.White),
-      topBar = { TopBar("Select Meeting Point", false, {}) }) { paddingValues ->
-        if (!loadingSelfProfile.value) {
-          GoogleMap(
-              modifier = Modifier.fillMaxSize().padding(paddingValues).testTag("normalMap"),
-              cameraPositionState = cameraPositionState,
-              onMapClick = { latLong ->
-                if (LatLng(centerLatitude, centerLongitude).sphericalDistance(latLong) < 500) {
-                  markerState?.position = latLong
-                } else {
-                  Toast.makeText(
-                          context,
-                          "You should select a meeting point inside the white circle!",
-                          Toast.LENGTH_SHORT)
-                      .show()
+    Scaffold(
+        modifier = Modifier.fillMaxSize().background(Color.White),
+        topBar = { TopBar("Select Meeting Point", false, {}) },
+        bottomBar = {
+            Box(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .height(150.dp).background(
+                        color = IceBreakrrBlue
+                        ),
+                contentAlignment = Alignment.Center
+            ) {
+                // Adjusted OutlinedTextField Modifier
+                TextField(
+                    value = stringQuery,
+                    onValueChange = {
+                        stringQuery = it
+                    },
+                    label = { Text("Add Details...", modifier = Modifier.testTag("labelTagSelector")) },
+                    placeholder = {
+                        Text("", modifier = Modifier.testTag("placeholderTagSelector"))
+                    },
+                    modifier = Modifier
+                        .padding(start = 16.dp, end = 16.dp, top = 8.dp, bottom = 8.dp) // Adds padding on the left
+                        .fillMaxSize().shadow(
+                            elevation = 8.dp, // Adjust shadow intensity
+                            shape = androidx.compose.foundation.shape.RoundedCornerShape(8.dp) // Optional: Rounded corners
+                        ) // Reduces the width to leave space for the FAB
+                )
+                FloatingActionButton(
+                    onClick = {
+                        meetingRequestViewModel.confirmMeetingLocation(
+                            profileId!!,
+                            Pair(markerState?.position?.latitude!!, markerState?.position?.longitude!!)
+                        )
+                        meetingRequestViewModel.setMeetingConfirmation(
+                            profile.value?.fcmToken!!,
+                            markerState?.position?.latitude!!.toString() +
+                                    ", " +
+                                    markerState?.position?.longitude!!.toString()
+                        )
+                        meetingRequestViewModel.sendMeetingConfirmation()
+                        navigationActions.navigateTo(Route.HEAT_MAP)
+                    },
+                    modifier = Modifier
+                        .size(40.dp)
+                        .zIndex(1f)
+                        .align(Alignment.BottomEnd)
+                        .padding(bottom = 9.dp, end = 17.dp)
+                        .background(Color.Transparent)
+                        .shadow(elevation = 0.dp, shape = RectangleShape),
+                    shape = RectangleShape,
+                    elevation = FloatingActionButtonDefaults.elevation(0.dp, 0.dp, 0.dp, 0.dp)
+                ) {
+                    Icon(Icons.Default.Check, contentDescription = "Confirm Pin")
                 }
-              },
-              onMapLoaded = {mapLoaded = true},
-              onMapLongClick = {markerState?.position = it },
-              uiSettings = MapUiSettings(zoomControlsEnabled = false)
-          ) {
-              if (mapLoaded){
-                  Circle(
-                      LatLng(centerLatitude, centerLongitude),
-                      radius = 500.0,
-                      fillColor = Color(0x11FFFFFF),
-                      strokeColor = Color.Black,
-                      strokeWidth = 2f)
-                      Marker(state = markerState!!, title = "Selected Position", onClick = { true },
-                          draggable = true)
-                  }
-              }
-          }
-      if (mapLoaded){
-          FloatingActionButton(
-              onClick = {
-                  meetingRequestViewModel.confirmMeetingLocation(
-                      profileId!!,
-                      Pair(markerState?.position?.latitude!!, markerState?.position?.longitude!!))
-                  meetingRequestViewModel.setMeetingConfirmation(
-                      profile.value?.fcmToken!!,
-                      markerState?.position?.latitude!!.toString() +
-                              ", " +
-                              markerState?.position?.longitude!!.toString())
-                  meetingRequestViewModel.sendMeetingConfirmation()
-                  navigationActions.navigateTo(Route.HEAT_MAP)
-              },
-              modifier =
-              Modifier.absoluteOffset(x = (screenWidth - 75).dp, y = (screenHeight - 75).dp)
-                  .size(60.dp)) {
-              Icon(Icons.Default.Check, contentDescription = "Confirm Pin")
-          }
-      }
-
-  }
-}
+            }
+        }
+    ) { paddingValues ->
+        if (!loadingSelfProfile.value) {
+            Column(verticalArrangement = Arrangement.Top) {
+                GoogleMap(
+                    modifier = Modifier.fillMaxSize().padding(paddingValues).testTag("normalMap"),
+                    cameraPositionState = cameraPositionState,
+                    onMapClick = { latLong ->
+                        if (LatLng(centerLatitude, centerLongitude).sphericalDistance(latLong) < 500) {
+                            markerState?.position = latLong
+                        } else {
+                            Toast.makeText(
+                                context,
+                                "You should select a meeting point inside the white circle!",
+                                Toast.LENGTH_SHORT
+                            ).show()
+                        }
+                    },
+                    onMapLoaded = { mapLoaded = true },
+                    onMapLongClick = { markerState?.position = it },
+                    uiSettings = MapUiSettings(zoomControlsEnabled = false)
+                ) {
+                    if (mapLoaded) {
+                        Circle(
+                            LatLng(centerLatitude, centerLongitude),
+                            radius = 500.0,
+                            fillColor = Color(0x11FFFFFF),
+                            strokeColor = Color.Black,
+                            strokeWidth = 2f
+                        )
+                        Marker(state = markerState!!, title = "Selected Position", onClick = { true }, draggable = true)
+                    }
+                }
+            }
+        }
+    }
+    }

--- a/app/src/main/java/com/github/se/icebreakrr/ui/map/LocationSelectorMap.kt
+++ b/app/src/main/java/com/github/se/icebreakrr/ui/map/LocationSelectorMap.kt
@@ -19,6 +19,7 @@ import androidx.compose.material3.Button
 import androidx.compose.material3.FloatingActionButton
 import androidx.compose.material3.FloatingActionButtonDefaults
 import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
 import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
@@ -72,8 +73,6 @@ fun LocationSelectorMapScreen(
     locationViewModel: LocationViewModel
 ) {
   val configuration = LocalConfiguration.current
-  val screenHeight = configuration.screenHeightDp
-  val screenWidth = configuration.screenWidthDp
 
   val loadingSelfProfile = profilesViewModel.loadingSelf.collectAsState()
   val centerLatitude =
@@ -107,15 +106,14 @@ fun LocationSelectorMapScreen(
                 modifier = Modifier
                     .fillMaxWidth()
                     .height(150.dp).background(
-                        color = IceBreakrrBlue
-                        ),
-                contentAlignment = Alignment.Center
+                        color = IceBreakrrBlue),
             ) {
-                // Adjusted OutlinedTextField Modifier
                 TextField(
                     value = stringQuery,
                     onValueChange = {
-                        stringQuery = it
+                        if (it.length < 113){
+                            stringQuery = it
+                        }
                     },
                     label = { Text("Add Details...", modifier = Modifier.testTag("labelTagSelector")) },
                     placeholder = {
@@ -126,34 +124,26 @@ fun LocationSelectorMapScreen(
                         .fillMaxSize().shadow(
                             elevation = 8.dp, // Adjust shadow intensity
                             shape = androidx.compose.foundation.shape.RoundedCornerShape(8.dp) // Optional: Rounded corners
-                        ) // Reduces the width to leave space for the FAB
+                        ),
+                    trailingIcon = {
+                    }// Reduces the width to leave space for the FAB
                 )
-                FloatingActionButton(
-                    onClick = {
-                        meetingRequestViewModel.confirmMeetingLocation(
-                            profileId!!,
-                            Pair(markerState?.position?.latitude!!, markerState?.position?.longitude!!)
-                        )
-                        meetingRequestViewModel.setMeetingConfirmation(
-                            profile.value?.fcmToken!!,
-                            markerState?.position?.latitude!!.toString() +
-                                    ", " +
-                                    markerState?.position?.longitude!!.toString()
-                        )
-                        meetingRequestViewModel.sendMeetingConfirmation()
-                        navigationActions.navigateTo(Route.HEAT_MAP)
-                    },
+                IconButton(onClick = {
+                    meetingRequestViewModel.confirmMeetingLocation(
+                        profileId!!,
+                        Pair(stringQuery, Pair(markerState?.position?.latitude!!, markerState?.position?.longitude!!)))
+                    meetingRequestViewModel.setMeetingConfirmation(
+                        profile.value?.fcmToken!!,
+                        markerState?.position?.latitude!!.toString() +
+                                ", " +
+                                markerState?.position?.longitude!!.toString(), stringQuery
+                    )
+                    meetingRequestViewModel.sendMeetingConfirmation()
+                    navigationActions.navigateTo(Route.HEAT_MAP)},
                     modifier = Modifier
-                        .size(40.dp)
-                        .zIndex(1f)
                         .align(Alignment.BottomEnd)
-                        .padding(bottom = 9.dp, end = 17.dp)
-                        .background(Color.Transparent)
-                        .shadow(elevation = 0.dp, shape = RectangleShape),
-                    shape = RectangleShape,
-                    elevation = FloatingActionButtonDefaults.elevation(0.dp, 0.dp, 0.dp, 0.dp)
-                ) {
-                    Icon(Icons.Default.Check, contentDescription = "Confirm Pin")
+                        .padding(end = 16.dp, bottom = 8.dp)) {
+                    Icon(Icons.Default.Check, contentDescription = "Confirm")
                 }
             }
         }

--- a/app/src/main/java/com/github/se/icebreakrr/ui/map/LocationSelectorMap.kt
+++ b/app/src/main/java/com/github/se/icebreakrr/ui/map/LocationSelectorMap.kt
@@ -1,5 +1,6 @@
 package com.github.se.icebreakrr.ui.map
 
+import android.util.Log
 import android.widget.Toast
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement
@@ -140,14 +141,25 @@ fun LocationSelectorMapScreen(
                           stringQuery,
                           Pair(
                               markerState?.position?.latitude!!,
-                              markerState?.position?.longitude!!)))
+                              markerState?.position?.longitude!!))) {
+                        Log.e(
+                            "LocationSelectorMap",
+                            "Failed to confirmMeetingLocation : ${it.message}")
+                        Toast.makeText(
+                                context, "Could not confirm meeting location", Toast.LENGTH_SHORT)
+                            .show()
+                      }
                   meetingRequestViewModel.setMeetingConfirmation(
                       profile.value?.fcmToken!!,
                       markerState?.position?.latitude!!.toString() +
                           ", " +
                           markerState?.position?.longitude!!.toString(),
                       stringQuery)
-                  meetingRequestViewModel.sendMeetingConfirmation()
+                  meetingRequestViewModel.sendMeetingConfirmation() {
+                    Log.e("LocationSelectorMap", "Failed to sendMeetingLocation : ${it.message}")
+                    Toast.makeText(context, "Could not send meeting location", Toast.LENGTH_SHORT)
+                        .show()
+                  }
                   navigationActions.navigateTo(Route.HEAT_MAP)
                 }
               },

--- a/app/src/main/java/com/github/se/icebreakrr/ui/navigation/BottomNavigationMenu.kt
+++ b/app/src/main/java/com/github/se/icebreakrr/ui/navigation/BottomNavigationMenu.kt
@@ -1,5 +1,6 @@
 package com.github.se.icebreakrr.ui.navigation
 
+import android.util.Log
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.fillMaxWidth
@@ -48,6 +49,9 @@ fun BottomNavigationMenu(
     notificationCount: Int,
     heatMapCount: Int
 ) {
+  Log.d(
+      "TESTEST",
+      "bottom navigation menu badge notification count : ${notificationCount}, heat map count : ${heatMapCount}")
   NavigationBar(
       modifier = Modifier.fillMaxWidth().height(60.dp).testTag("bottomNavigationMenu"),
       containerColor = IceBreakrrBlue,
@@ -58,10 +62,10 @@ fun BottomNavigationMenu(
                 Box {
                   Icon(tab.icon, contentDescription = stringResource(id = tab.textId))
                   if (tab.route == Route.NOTIFICATIONS && notificationCount > 0) {
-                    Badge(count = notificationCount)
+                    Badge(notificationCount, "badgeNotification")
                   }
-                  if (tab.route == Route.HEAT_MAP && heatMapCount > 0){
-                      Badge(count = heatMapCount)
+                  if (tab.route == Route.HEAT_MAP && heatMapCount > 0) {
+                    Badge(heatMapCount, "badgeHeatmap")
                   }
                 }
               },
@@ -86,16 +90,18 @@ fun BottomNavigationMenu(
  * @param count : number of pending notifications
  */
 @Composable
-fun Badge(count: Int) {
+fun Badge(count: Int, tag: String) {
   Box(
       modifier =
           Modifier.offset(x = BADGE_OFFSET_X.dp, y = (BADGE_OFFSET_Y).dp)
               .size(BADGE_SIZE.dp)
-              .background(Color.Red, shape = CircleShape),
+              .background(Color.Red, shape = CircleShape)
+              .testTag(tag),
       contentAlignment = Alignment.Center) {
         Text(
             text = count.toString(),
             color = Color.White,
-            style = androidx.compose.material3.MaterialTheme.typography.labelSmall)
+            style = androidx.compose.material3.MaterialTheme.typography.labelSmall,
+            modifier = Modifier.testTag(tag))
       }
 }

--- a/app/src/main/java/com/github/se/icebreakrr/ui/navigation/BottomNavigationMenu.kt
+++ b/app/src/main/java/com/github/se/icebreakrr/ui/navigation/BottomNavigationMenu.kt
@@ -45,7 +45,8 @@ fun BottomNavigationMenu(
     onTabSelect: (TopLevelDestination) -> Unit,
     tabList: List<TopLevelDestination>,
     selectedItem: String,
-    notificationCount: Int
+    notificationCount: Int,
+    heatMapCount: Int
 ) {
   NavigationBar(
       modifier = Modifier.fillMaxWidth().height(60.dp).testTag("bottomNavigationMenu"),
@@ -58,6 +59,9 @@ fun BottomNavigationMenu(
                   Icon(tab.icon, contentDescription = stringResource(id = tab.textId))
                   if (tab.route == Route.NOTIFICATIONS && notificationCount > 0) {
                     Badge(count = notificationCount)
+                  }
+                  if (tab.route == Route.HEAT_MAP && heatMapCount > 0){
+                      Badge(count = heatMapCount)
                   }
                 }
               },

--- a/app/src/main/java/com/github/se/icebreakrr/ui/navigation/BottomNavigationMenu.kt
+++ b/app/src/main/java/com/github/se/icebreakrr/ui/navigation/BottomNavigationMenu.kt
@@ -1,6 +1,5 @@
 package com.github.se.icebreakrr.ui.navigation
 
-import android.util.Log
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.fillMaxWidth
@@ -49,9 +48,6 @@ fun BottomNavigationMenu(
     notificationCount: Int,
     heatMapCount: Int
 ) {
-  Log.d(
-      "TESTEST",
-      "bottom navigation menu badge notification count : ${notificationCount}, heat map count : ${heatMapCount}")
   NavigationBar(
       modifier = Modifier.fillMaxWidth().height(60.dp).testTag("bottomNavigationMenu"),
       containerColor = IceBreakrrBlue,

--- a/app/src/main/java/com/github/se/icebreakrr/ui/navigation/TopLevelDestination.kt
+++ b/app/src/main/java/com/github/se/icebreakrr/ui/navigation/TopLevelDestination.kt
@@ -27,6 +27,7 @@ object Route {
   const val CROP = "Crop"
   const val UNBLOCK_PROFILE = "UnblockProfile"
   const val HEAT_MAP = "Heatmap"
+  const val MAP_MEETING_LOCATION = "Map Meeting Location"
 }
 
 object Screen {
@@ -44,6 +45,7 @@ object Screen {
   const val HEAT_MAP = "Heatmap Screen"
   const val ALREADY_MET = "Already Met Screen"
   const val INBOX_PROFILE_VIEW = "Inbox Profile View Screen"
+  const val MAP_MEETING_LOCATION_SCREEN = "Map Meeting Location Screen"
 }
 
 object TopLevelDestinations {

--- a/app/src/main/java/com/github/se/icebreakrr/ui/profile/InboxProfileView.kt
+++ b/app/src/main/java/com/github/se/icebreakrr/ui/profile/InboxProfileView.kt
@@ -89,7 +89,7 @@ fun InboxProfileViewScreen(
     val profileId = navBackStackEntry?.arguments?.getString("userId")
     if (profileId != null || isTesting) {
       profilesViewModel.getProfileByUid(profileId ?: "")
-      meetingRequestViewModel.updateInboxOfMessagesAndThen() {}
+      meetingRequestViewModel.updateInboxOfMessages() {}
     }
   }
 
@@ -158,7 +158,7 @@ fun acceptDeclineCode(
   meetingRequestViewModel.setMeetingResponse(fcm, "accepting/decline request", accepted)
   meetingRequestViewModel.sendMeetingResponse()
   meetingRequestViewModel.removeFromMeetingRequestInbox(uid)
-  meetingRequestViewModel.updateInboxOfMessagesAndThen() {}
+  meetingRequestViewModel.updateInboxOfMessages() {}
   navigationActions.goBack()
 }
 

--- a/app/src/main/java/com/github/se/icebreakrr/ui/profile/InboxProfileView.kt
+++ b/app/src/main/java/com/github/se/icebreakrr/ui/profile/InboxProfileView.kt
@@ -1,5 +1,6 @@
 package com.github.se.icebreakrr.ui.profile
 
+import android.widget.Toast
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
@@ -118,14 +119,17 @@ fun InboxProfileViewScreen(
             {
               acceptDeclineCode(
                   meetingRequestViewModel, navigationActions, profile.uid, true, profile.fcmToken)
+                Toast.makeText(
+                    context,
+                    "You've accepted the request, " +
+                            profile.name +
+                            " is choosing the location of your meeting!",
+                    Toast.LENGTH_SHORT)
+                    .show()
             },
             {
               acceptDeclineCode(
-                  meetingRequestViewModel,
-                  navigationActions,
-                  profile.uid,
-                  false,
-                  profile.fcmToken!!)
+                  meetingRequestViewModel, navigationActions, profile.uid, false, profile.fcmToken)
             })
         InfoSection(profile = profile, tagsViewModel = tagsViewModel)
       }

--- a/app/src/main/java/com/github/se/icebreakrr/ui/profile/OtherProfileView.kt
+++ b/app/src/main/java/com/github/se/icebreakrr/ui/profile/OtherProfileView.kt
@@ -111,7 +111,7 @@ fun OtherProfileView(
                     meetingRequestViewModel.removeChosenLocalisation(profile.uid)
                     Toast.makeText(context, R.string.Already_Met_Button_Success, Toast.LENGTH_SHORT)
                         .show()
-                    profilesViewModel.getSelfProfile(){}
+                    profilesViewModel.getSelfProfile() {}
                     navigationActions.goBack()
                   } else {
                     showNoInternetToast(context = context)

--- a/app/src/main/java/com/github/se/icebreakrr/ui/profile/OtherProfileView.kt
+++ b/app/src/main/java/com/github/se/icebreakrr/ui/profile/OtherProfileView.kt
@@ -108,6 +108,7 @@ fun OtherProfileView(
                 onClick = {
                   if (isNetworkAvailableWithContext(context)) {
                     profilesViewModel.addAlreadyMet(profile.uid)
+                    meetingRequestViewModel.removeChosenLocalisation(profile.uid)
                     Toast.makeText(context, R.string.Already_Met_Button_Success, Toast.LENGTH_SHORT)
                         .show()
                     profilesViewModel.getSelfProfile()

--- a/app/src/main/java/com/github/se/icebreakrr/ui/profile/OtherProfileView.kt
+++ b/app/src/main/java/com/github/se/icebreakrr/ui/profile/OtherProfileView.kt
@@ -111,7 +111,7 @@ fun OtherProfileView(
                     meetingRequestViewModel.removeChosenLocalisation(profile.uid)
                     Toast.makeText(context, R.string.Already_Met_Button_Success, Toast.LENGTH_SHORT)
                         .show()
-                    profilesViewModel.getSelfProfile()
+                    profilesViewModel.getSelfProfile(){}
                     navigationActions.goBack()
                   } else {
                     showNoInternetToast(context = context)

--- a/app/src/main/java/com/github/se/icebreakrr/ui/sections/AlreadyMet.kt
+++ b/app/src/main/java/com/github/se/icebreakrr/ui/sections/AlreadyMet.kt
@@ -73,5 +73,6 @@ fun AlreadyMetScreen(
       selectedProfile = profileToUnmeet,
       periodicRefreshAction = { profilesViewModel.getAlreadyMetUsers() },
       isTestMode = isTestMode,
-      notificationCount = inboxItems.value?.meetingRequestInbox?.size ?: 0)
+      notificationCount = inboxItems.value?.meetingRequestInbox?.size ?: 0,
+      heatMapCount = inboxItems.value?.meetingRequestChosenLocalisation?.size?:0)
 }

--- a/app/src/main/java/com/github/se/icebreakrr/ui/sections/AlreadyMet.kt
+++ b/app/src/main/java/com/github/se/icebreakrr/ui/sections/AlreadyMet.kt
@@ -74,5 +74,5 @@ fun AlreadyMetScreen(
       periodicRefreshAction = { profilesViewModel.getAlreadyMetUsers() },
       isTestMode = isTestMode,
       notificationCount = inboxItems.value?.meetingRequestInbox?.size ?: 0,
-      heatMapCount = inboxItems.value?.meetingRequestChosenLocalisation?.size?:0)
+      heatMapCount = inboxItems.value?.meetingRequestChosenLocalisation?.size ?: 0)
 }

--- a/app/src/main/java/com/github/se/icebreakrr/ui/sections/AroundYou.kt
+++ b/app/src/main/java/com/github/se/icebreakrr/ui/sections/AroundYou.kt
@@ -159,7 +159,8 @@ fun AroundYouScreen(
             selectedItem = Route.AROUND_YOU,
             notificationCount =
                 (myProfile.value?.meetingRequestInbox?.size ?: 0) +
-                    (myProfile.value?.meetingRequestPendingLocation?.size ?: 0))
+                    (myProfile.value?.meetingRequestPendingLocation?.size ?: 0),
+            heatMapCount = myProfile.value?.meetingRequestChosenLocalisation?.size?:0)
       },
       topBar = { TopBar("Around You") },
       content = { innerPadding ->

--- a/app/src/main/java/com/github/se/icebreakrr/ui/sections/AroundYou.kt
+++ b/app/src/main/java/com/github/se/icebreakrr/ui/sections/AroundYou.kt
@@ -157,7 +157,9 @@ fun AroundYouScreen(
             },
             tabList = LIST_TOP_LEVEL_DESTINATIONS,
             selectedItem = Route.AROUND_YOU,
-            notificationCount = myProfile.value?.meetingRequestInbox?.size ?: 0)
+            notificationCount =
+                (myProfile.value?.meetingRequestInbox?.size ?: 0) +
+                    (myProfile.value?.meetingRequestPendingLocation?.size ?: 0))
       },
       topBar = { TopBar("Around You") },
       content = { innerPadding ->

--- a/app/src/main/java/com/github/se/icebreakrr/ui/sections/AroundYou.kt
+++ b/app/src/main/java/com/github/se/icebreakrr/ui/sections/AroundYou.kt
@@ -160,7 +160,7 @@ fun AroundYouScreen(
             notificationCount =
                 (myProfile.value?.meetingRequestInbox?.size ?: 0) +
                     (myProfile.value?.meetingRequestPendingLocation?.size ?: 0),
-            heatMapCount = myProfile.value?.meetingRequestChosenLocalisation?.size?:0)
+            heatMapCount = myProfile.value?.meetingRequestChosenLocalisation?.size ?: 0)
       },
       topBar = { TopBar("Around You") },
       content = { innerPadding ->

--- a/app/src/main/java/com/github/se/icebreakrr/ui/sections/Notifications.kt
+++ b/app/src/main/java/com/github/se/icebreakrr/ui/sections/Notifications.kt
@@ -1,6 +1,7 @@
 package com.github.se.icebreakrr.ui.sections
 
 import android.annotation.SuppressLint
+import android.util.Log
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.padding
@@ -31,7 +32,7 @@ private val HORIZONTAL_PADDING = 7.dp
 private val TEXT_VERTICAL_PADDING = 16.dp
 private val CARD_SPACING = 16.dp
 private const val MEETING_REQUEST_MSG = "Pending meeting requests"
-private const val MEETING_REQUEST_ACCEPTED = "Meeting Request Accepted !"
+private const val MEETING_REQUEST_LOCATION_PENDING = "Choose location"
 
 /**
  * Composable function for displaying the notification screen.
@@ -49,7 +50,9 @@ fun NotificationScreen(
 ) {
   meetingRequestViewModel.updateInboxOfMessages()
   val cardList = profileViewModel.inboxItems.collectAsState()
+  val pendingLocation = profileViewModel.pendingLocalisations.collectAsState()
   val context = LocalContext.current
+  Log.d("TESTEST", "[NotificationScreen] size of cardList (inboxItems) : ${cardList}")
   Scaffold(
       modifier = Modifier.testTag("notificationScreen"),
       topBar = { TopBar("Inbox") },
@@ -62,7 +65,7 @@ fun NotificationScreen(
             },
             tabList = LIST_TOP_LEVEL_DESTINATIONS,
             selectedItem = Route.NOTIFICATIONS,
-            notificationCount = cardList.value.size)
+            notificationCount = cardList.value.size + pendingLocation.value.size)
       },
       content = { innerPadding ->
         LazyColumn(
@@ -85,6 +88,28 @@ fun NotificationScreen(
                           if (isNetworkAvailableWithContext(context)) {
                             navigationActions.navigateTo(
                                 Screen.INBOX_PROFILE_VIEW + "?userId=${p.key.uid}")
+                          } else {
+                            showNoInternetToast(context)
+                          }
+                        })
+                  }
+                }
+              }
+              item {
+                Text(
+                    text = MEETING_REQUEST_LOCATION_PENDING,
+                    fontWeight = FontWeight.Bold,
+                    modifier =
+                        Modifier.padding(vertical = TEXT_VERTICAL_PADDING)
+                            .testTag("notificationSecondText"))
+                Column(verticalArrangement = Arrangement.spacedBy(CARD_SPACING)) {
+                  pendingLocation.value.forEach { p ->
+                    ProfileCard(
+                        p,
+                        onclick = {
+                          if (isNetworkAvailableWithContext(context)) {
+                            navigationActions.navigateTo(
+                                Screen.MAP_MEETING_LOCATION_SCREEN + "?userId=${p.uid}")
                           } else {
                             showNoInternetToast(context)
                           }

--- a/app/src/main/java/com/github/se/icebreakrr/ui/sections/Notifications.kt
+++ b/app/src/main/java/com/github/se/icebreakrr/ui/sections/Notifications.kt
@@ -81,7 +81,7 @@ fun NotificationScreen(
   val pendingLocation = profileViewModel.pendingLocalisations.collectAsState()
   val context = LocalContext.current
   var meetingRequestOption by remember { mutableStateOf(MeetingRequestOption.INBOX) }
-  Log.d("TESTEST", "pending size notification : ${pendingLocation.value.size}")
+  val myProfile = profileViewModel.selfProfile.collectAsState()
   Scaffold(
       modifier = Modifier.testTag("notificationScreen"),
       topBar = { TopBar("Inbox") },
@@ -94,7 +94,8 @@ fun NotificationScreen(
             },
             tabList = LIST_TOP_LEVEL_DESTINATIONS,
             selectedItem = Route.NOTIFICATIONS,
-            notificationCount = inboxCardList.value.size + pendingLocation.value.size)
+            notificationCount = inboxCardList.value.size + pendingLocation.value.size,
+            heatMapCount = myProfile.value?.meetingRequestChosenLocalisation?.size?:0)
       },
       content = { innerPadding ->
         Column(modifier = Modifier.padding(innerPadding).padding(horizontal = HORIZONTAL_PADDING)) {

--- a/app/src/main/java/com/github/se/icebreakrr/ui/sections/Notifications.kt
+++ b/app/src/main/java/com/github/se/icebreakrr/ui/sections/Notifications.kt
@@ -1,10 +1,8 @@
 package com.github.se.icebreakrr.ui.sections
 
 import android.annotation.SuppressLint
-import android.util.Log
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
-import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxWidth
@@ -95,13 +93,13 @@ fun NotificationScreen(
             tabList = LIST_TOP_LEVEL_DESTINATIONS,
             selectedItem = Route.NOTIFICATIONS,
             notificationCount = inboxCardList.value.size + pendingLocation.value.size,
-            heatMapCount = myProfile.value?.meetingRequestChosenLocalisation?.size?:0)
+            heatMapCount = myProfile.value?.meetingRequestChosenLocalisation?.size ?: 0)
       },
       content = { innerPadding ->
         Column(modifier = Modifier.padding(innerPadding).padding(horizontal = HORIZONTAL_PADDING)) {
           MeetingRequestOptionDropdown(
               selectedOption = meetingRequestOption,
-              onOptionSelected = { meetingRequestOption = it},
+              onOptionSelected = { meetingRequestOption = it },
               modifier =
                   Modifier.fillMaxWidth()
                       .padding(
@@ -240,26 +238,26 @@ fun MeetingRequestOptionDropdown(
                   if (expanded) Icons.Filled.KeyboardArrowUp else Icons.Filled.KeyboardArrowDown,
               contentDescription = "Icon of the MeetingRequest option dropdown menu",
               modifier = Modifier.testTag("MeetingRequestOptionsDropdown_Arrow"))
-        if (!expanded) {
-            when (selectedOption){
-                MeetingRequestOption.SENT -> {
-                    if (pendingLocationsSize + inboxSize > 0){
-                        Badge(count = pendingLocationsSize + inboxSize)
-                    }
+          if (!expanded) {
+            when (selectedOption) {
+              MeetingRequestOption.SENT -> {
+                if (pendingLocationsSize + inboxSize > 0) {
+                  Badge(pendingLocationsSize + inboxSize, "badgeSent")
                 }
-                MeetingRequestOption.INBOX -> {
-                    if (pendingLocationsSize > 0){
-                        Badge(count = pendingLocationsSize)
-                    }
+              }
+              MeetingRequestOption.INBOX -> {
+                if (pendingLocationsSize > 0) {
+                  Badge(pendingLocationsSize, "badgeInbox")
                 }
-                MeetingRequestOption.CHOOSE_LOCATION -> {
-                    if (inboxSize > 0){
-                        Badge(count = inboxSize)
-                    }
+              }
+              MeetingRequestOption.CHOOSE_LOCATION -> {
+                if (inboxSize > 0) {
+                  Badge(inboxSize, "badgePendingAndInbox")
                 }
+              }
             }
+          }
         }
-    }
 
     if (expanded) {
       otherOptions.forEach { meetingRequestOption ->
@@ -286,19 +284,19 @@ fun MeetingRequestOptionDropdown(
                       },
               fontSize = TEXT_SMALL_SIZE,
               color = Color.Gray)
-            when (meetingRequestOption){
-                MeetingRequestOption.CHOOSE_LOCATION ->{
-                    if (pendingLocationsSize > 0){
-                         Badge(count = pendingLocationsSize)
-                    }
-                }
-                MeetingRequestOption.INBOX -> {
-                    if (inboxSize > 0){
-                        Badge(count = inboxSize)
-                    }
-                }
-                MeetingRequestOption.SENT -> {}
+          when (meetingRequestOption) {
+            MeetingRequestOption.CHOOSE_LOCATION -> {
+              if (pendingLocationsSize > 0) {
+                Badge(pendingLocationsSize, "badgeChooseLocation")
+              }
             }
+            MeetingRequestOption.INBOX -> {
+              if (inboxSize > 0) {
+                Badge(inboxSize, "badgeInbox")
+              }
+            }
+            MeetingRequestOption.SENT -> {}
+          }
         }
       }
     }

--- a/app/src/main/java/com/github/se/icebreakrr/ui/sections/Notifications.kt
+++ b/app/src/main/java/com/github/se/icebreakrr/ui/sections/Notifications.kt
@@ -1,8 +1,10 @@
 package com.github.se.icebreakrr.ui.sections
 
 import android.annotation.SuppressLint
+import android.util.Log
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxWidth
@@ -30,6 +32,7 @@ import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import com.github.se.icebreakrr.model.message.MeetingRequestViewModel
 import com.github.se.icebreakrr.model.profile.ProfilesViewModel
+import com.github.se.icebreakrr.ui.navigation.Badge
 import com.github.se.icebreakrr.ui.navigation.BottomNavigationMenu
 import com.github.se.icebreakrr.ui.navigation.LIST_TOP_LEVEL_DESTINATIONS
 import com.github.se.icebreakrr.ui.navigation.NavigationActions
@@ -78,6 +81,7 @@ fun NotificationScreen(
   val pendingLocation = profileViewModel.pendingLocalisations.collectAsState()
   val context = LocalContext.current
   var meetingRequestOption by remember { mutableStateOf(MeetingRequestOption.INBOX) }
+  Log.d("TESTEST", "pending size notification : ${pendingLocation.value.size}")
   Scaffold(
       modifier = Modifier.testTag("notificationScreen"),
       topBar = { TopBar("Inbox") },
@@ -96,12 +100,14 @@ fun NotificationScreen(
         Column(modifier = Modifier.padding(innerPadding).padding(horizontal = HORIZONTAL_PADDING)) {
           MeetingRequestOptionDropdown(
               selectedOption = meetingRequestOption,
-              onOptionSelected = { meetingRequestOption = it },
+              onOptionSelected = { meetingRequestOption = it},
               modifier =
                   Modifier.fillMaxWidth()
                       .padding(
                           horizontal = DROPDOWN_HORIZONTAL_PADDING,
-                          vertical = DROPDOWN_VERTICAL_PADDING))
+                          vertical = DROPDOWN_VERTICAL_PADDING),
+              pendingLocationsSize = pendingLocation.value.size,
+              inboxSize = inboxCardList.value.size)
           when (meetingRequestOption) {
             MeetingRequestOption.INBOX -> {
               LazyColumn(
@@ -175,7 +181,7 @@ fun NotificationScreen(
                                 navigationActions.navigateTo(
                                     Screen.MAP_MEETING_LOCATION_SCREEN + "?userId=${p.uid}")
                               },
-                              greyedOut = true)
+                              greyedOut = false)
                         }
                       }
                     }
@@ -204,7 +210,9 @@ fun NotificationScreen(
 fun MeetingRequestOptionDropdown(
     selectedOption: MeetingRequestOption,
     onOptionSelected: (MeetingRequestOption) -> Unit,
-    modifier: Modifier = Modifier
+    modifier: Modifier = Modifier,
+    pendingLocationsSize: Int,
+    inboxSize: Int
 ) {
   var expanded by remember { mutableStateOf(false) }
 
@@ -231,7 +239,26 @@ fun MeetingRequestOptionDropdown(
                   if (expanded) Icons.Filled.KeyboardArrowUp else Icons.Filled.KeyboardArrowDown,
               contentDescription = "Icon of the MeetingRequest option dropdown menu",
               modifier = Modifier.testTag("MeetingRequestOptionsDropdown_Arrow"))
+        if (!expanded) {
+            when (selectedOption){
+                MeetingRequestOption.SENT -> {
+                    if (pendingLocationsSize + inboxSize > 0){
+                        Badge(count = pendingLocationsSize + inboxSize)
+                    }
+                }
+                MeetingRequestOption.INBOX -> {
+                    if (pendingLocationsSize > 0){
+                        Badge(count = pendingLocationsSize)
+                    }
+                }
+                MeetingRequestOption.CHOOSE_LOCATION -> {
+                    if (inboxSize > 0){
+                        Badge(count = inboxSize)
+                    }
+                }
+            }
         }
+    }
 
     if (expanded) {
       otherOptions.forEach { meetingRequestOption ->
@@ -258,6 +285,19 @@ fun MeetingRequestOptionDropdown(
                       },
               fontSize = TEXT_SMALL_SIZE,
               color = Color.Gray)
+            when (meetingRequestOption){
+                MeetingRequestOption.CHOOSE_LOCATION ->{
+                    if (pendingLocationsSize > 0){
+                         Badge(count = pendingLocationsSize)
+                    }
+                }
+                MeetingRequestOption.INBOX -> {
+                    if (inboxSize > 0){
+                        Badge(count = inboxSize)
+                    }
+                }
+                MeetingRequestOption.SENT -> {}
+            }
         }
       }
     }

--- a/app/src/main/java/com/github/se/icebreakrr/ui/sections/Notifications.kt
+++ b/app/src/main/java/com/github/se/icebreakrr/ui/sections/Notifications.kt
@@ -1,6 +1,7 @@
 package com.github.se.icebreakrr.ui.sections
 
 import android.annotation.SuppressLint
+import android.content.Context
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
@@ -29,6 +30,7 @@ import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import com.github.se.icebreakrr.model.message.MeetingRequestViewModel
+import com.github.se.icebreakrr.model.profile.Profile
 import com.github.se.icebreakrr.model.profile.ProfilesViewModel
 import com.github.se.icebreakrr.ui.navigation.Badge
 import com.github.se.icebreakrr.ui.navigation.BottomNavigationMenu
@@ -109,82 +111,24 @@ fun NotificationScreen(
               inboxSize = inboxCardList.value.size)
           when (meetingRequestOption) {
             MeetingRequestOption.INBOX -> {
-              LazyColumn(
-                  modifier =
-                      Modifier.padding()
-                          .padding(horizontal = HORIZONTAL_PADDING)
-                          .testTag("notificationScroll")) {
-                    item {
-                      Text(
-                          text = MEETING_REQUEST_MSG,
-                          fontWeight = FontWeight.Bold,
-                          modifier =
-                              Modifier.padding(vertical = TEXT_VERTICAL_PADDING)
-                                  .testTag("notificationFirstText"))
-                      Column(verticalArrangement = Arrangement.spacedBy(CARD_SPACING)) {
-                        inboxCardList.value.forEach { p ->
-                          ProfileCard(
-                              p.key,
-                              onclick = {
-                                if (isNetworkAvailableWithContext(context)) {
-                                  navigationActions.navigateTo(
-                                      Screen.INBOX_PROFILE_VIEW + "?userId=${p.key.uid}")
-                                } else {
-                                  showNoInternetToast(context)
-                                }
-                              })
-                        }
-                      }
-                    }
-                  }
+              DisplayTextAndCard(
+                  MEETING_REQUEST_MSG,
+                  inboxCardList.value.map { it.key },
+                  Screen.INBOX_PROFILE_VIEW,
+                  context,
+                  navigationActions)
             }
             MeetingRequestOption.SENT -> {
-              LazyColumn(
-                  modifier =
-                      Modifier.padding()
-                          .padding(horizontal = HORIZONTAL_PADDING)
-                          .testTag("notificationScroll")) {
-                    item {
-                      Text(
-                          text = MEETING_REQUEST_SENT,
-                          fontWeight = FontWeight.Bold,
-                          modifier =
-                              Modifier.padding(vertical = TEXT_VERTICAL_PADDING)
-                                  .testTag("notificationFirstText"))
-                      Column(verticalArrangement = Arrangement.spacedBy(CARD_SPACING)) {
-                        sentCardList.value.forEach { p ->
-                          ProfileCard(profile = p, onclick = {}, greyedOut = true)
-                        }
-                      }
-                    }
-                  }
+              DisplayTextAndCard(
+                  MEETING_REQUEST_SENT, sentCardList.value, "", context, navigationActions)
             }
             MeetingRequestOption.CHOOSE_LOCATION -> {
-              LazyColumn(
-                  modifier =
-                      Modifier.padding()
-                          .padding(horizontal = HORIZONTAL_PADDING)
-                          .testTag("notificationScroll")) {
-                    item {
-                      Text(
-                          text = MEETING_REQUEST_LOCATION_PENDING,
-                          fontWeight = FontWeight.Bold,
-                          modifier =
-                              Modifier.padding(vertical = TEXT_VERTICAL_PADDING)
-                                  .testTag("notificationFirstText"))
-                      Column(verticalArrangement = Arrangement.spacedBy(CARD_SPACING)) {
-                        pendingLocation.value.forEach { p ->
-                          ProfileCard(
-                              profile = p,
-                              onclick = {
-                                navigationActions.navigateTo(
-                                    Screen.MAP_MEETING_LOCATION_SCREEN + "?userId=${p.uid}")
-                              },
-                              greyedOut = false)
-                        }
-                      }
-                    }
-                  }
+              DisplayTextAndCard(
+                  MEETING_REQUEST_LOCATION_PENDING,
+                  pendingLocation.value,
+                  Screen.MAP_MEETING_LOCATION_SCREEN,
+                  context,
+                  navigationActions)
             }
           }
         }
@@ -308,4 +252,51 @@ enum class MeetingRequestOption {
   INBOX,
   SENT,
   CHOOSE_LOCATION
+}
+
+/**
+ * Function that shows the next saying on which inbox we are and the profile cards associate with it
+ *
+ * @param text: text to write over the cards
+ * @param profiles: profiles to show in cards
+ * @param onClick : function to call when we click on a card
+ */
+@Composable
+private fun DisplayTextAndCard(
+    text: String,
+    profiles: List<Profile>,
+    screenToNavigate: String,
+    context: Context,
+    navigationActions: NavigationActions
+) {
+  LazyColumn(
+      modifier =
+          Modifier.padding()
+              .padding(horizontal = HORIZONTAL_PADDING)
+              .testTag("notificationScroll")) {
+        item {
+          Text(
+              text = text,
+              fontWeight = FontWeight.Bold,
+              modifier =
+                  Modifier.padding(vertical = TEXT_VERTICAL_PADDING)
+                      .testTag("notificationFirstText"))
+          Column(verticalArrangement = Arrangement.spacedBy(CARD_SPACING)) {
+            profiles.forEach { p ->
+              ProfileCard(
+                  profile = p,
+                  onclick = {
+                    if (screenToNavigate != "") {
+                      if (isNetworkAvailableWithContext(context)) {
+                        navigationActions.navigateTo(screenToNavigate + "?userId=${p.uid}")
+                      } else {
+                        showNoInternetToast(context)
+                      }
+                    }
+                  },
+                  greyedOut = false)
+            }
+          }
+        }
+      }
 }

--- a/app/src/main/java/com/github/se/icebreakrr/ui/sections/Settings.kt
+++ b/app/src/main/java/com/github/se/icebreakrr/ui/sections/Settings.kt
@@ -111,7 +111,8 @@ fun SettingsScreen(
             selectedItem = Route.SETTINGS,
             notificationCount =
                 (myProfile.value?.meetingRequestInbox?.size ?: 0) +
-                    (myProfile.value?.meetingRequestPendingLocation?.size ?: 0))
+                    (myProfile.value?.meetingRequestPendingLocation?.size ?: 0),
+            heatMapCount = myProfile.value?.meetingRequestChosenLocalisation?.size?:0)
       },
   ) { innerPadding ->
     Column(

--- a/app/src/main/java/com/github/se/icebreakrr/ui/sections/Settings.kt
+++ b/app/src/main/java/com/github/se/icebreakrr/ui/sections/Settings.kt
@@ -109,7 +109,9 @@ fun SettingsScreen(
             },
             tabList = LIST_TOP_LEVEL_DESTINATIONS,
             selectedItem = Route.SETTINGS,
-            notificationCount = myProfile.value?.meetingRequestInbox?.size ?: 0)
+            notificationCount =
+                (myProfile.value?.meetingRequestInbox?.size ?: 0) +
+                    (myProfile.value?.meetingRequestPendingLocation?.size ?: 0))
       },
   ) { innerPadding ->
     Column(

--- a/app/src/main/java/com/github/se/icebreakrr/ui/sections/Settings.kt
+++ b/app/src/main/java/com/github/se/icebreakrr/ui/sections/Settings.kt
@@ -112,7 +112,7 @@ fun SettingsScreen(
             notificationCount =
                 (myProfile.value?.meetingRequestInbox?.size ?: 0) +
                     (myProfile.value?.meetingRequestPendingLocation?.size ?: 0),
-            heatMapCount = myProfile.value?.meetingRequestChosenLocalisation?.size?:0)
+            heatMapCount = myProfile.value?.meetingRequestChosenLocalisation?.size ?: 0)
       },
   ) { innerPadding ->
     Column(

--- a/app/src/main/java/com/github/se/icebreakrr/ui/sections/UnblockProfile.kt
+++ b/app/src/main/java/com/github/se/icebreakrr/ui/sections/UnblockProfile.kt
@@ -55,7 +55,7 @@ fun UnblockProfileScreen(
       isLoading = isLoading,
       isConnected = isConnected,
       onRefresh = { profilesViewModel.getBlockedUsers() },
-      additionalRefreshAction = { profilesViewModel.getSelfProfile(){} },
+      additionalRefreshAction = { profilesViewModel.getSelfProfile() {} },
       showConfirmDialog = profileToUnblock != null,
       confirmDialogTitle = stringResource(R.string.unblock_confirm),
       confirmDialogMessage =
@@ -73,5 +73,5 @@ fun UnblockProfileScreen(
       periodicRefreshAction = { profilesViewModel.getBlockedUsers() },
       isTestMode = isTestMode,
       notificationCount = inboxItems.value?.meetingRequestInbox?.size ?: 0,
-      heatMapCount = inboxItems.value?.meetingRequestChosenLocalisation?.size?:0)
+      heatMapCount = inboxItems.value?.meetingRequestChosenLocalisation?.size ?: 0)
 }

--- a/app/src/main/java/com/github/se/icebreakrr/ui/sections/UnblockProfile.kt
+++ b/app/src/main/java/com/github/se/icebreakrr/ui/sections/UnblockProfile.kt
@@ -55,7 +55,7 @@ fun UnblockProfileScreen(
       isLoading = isLoading,
       isConnected = isConnected,
       onRefresh = { profilesViewModel.getBlockedUsers() },
-      additionalRefreshAction = { profilesViewModel.getSelfProfile() },
+      additionalRefreshAction = { profilesViewModel.getSelfProfile(){} },
       showConfirmDialog = profileToUnblock != null,
       confirmDialogTitle = stringResource(R.string.unblock_confirm),
       confirmDialogMessage =

--- a/app/src/main/java/com/github/se/icebreakrr/ui/sections/UnblockProfile.kt
+++ b/app/src/main/java/com/github/se/icebreakrr/ui/sections/UnblockProfile.kt
@@ -72,5 +72,6 @@ fun UnblockProfileScreen(
       selectedProfile = profileToUnblock,
       periodicRefreshAction = { profilesViewModel.getBlockedUsers() },
       isTestMode = isTestMode,
-      notificationCount = inboxItems.value?.meetingRequestInbox?.size ?: 0)
+      notificationCount = inboxItems.value?.meetingRequestInbox?.size ?: 0,
+      heatMapCount = inboxItems.value?.meetingRequestChosenLocalisation?.size?:0)
 }

--- a/app/src/main/java/com/github/se/icebreakrr/ui/sections/shared/DisplayProfile.kt
+++ b/app/src/main/java/com/github/se/icebreakrr/ui/sections/shared/DisplayProfile.kt
@@ -353,7 +353,7 @@ fun ProfileHeader(
                                               R.string.block_success_message,
                                               Toast.LENGTH_SHORT)
                                           .show()
-                                      profilesViewModel.getSelfProfile(){}
+                                      profilesViewModel.getSelfProfile() {}
                                       navigationActions.goBack()
                                     } else {
                                       showNoInternetToast(context = context)

--- a/app/src/main/java/com/github/se/icebreakrr/ui/sections/shared/DisplayProfile.kt
+++ b/app/src/main/java/com/github/se/icebreakrr/ui/sections/shared/DisplayProfile.kt
@@ -353,7 +353,7 @@ fun ProfileHeader(
                                               R.string.block_success_message,
                                               Toast.LENGTH_SHORT)
                                           .show()
-                                      profilesViewModel.getSelfProfile()
+                                      profilesViewModel.getSelfProfile(){}
                                       navigationActions.goBack()
                                     } else {
                                       showNoInternetToast(context = context)

--- a/app/src/main/java/com/github/se/icebreakrr/ui/sections/shared/ProfileListScreen.kt
+++ b/app/src/main/java/com/github/se/icebreakrr/ui/sections/shared/ProfileListScreen.kt
@@ -93,7 +93,8 @@ fun ProfileListScreen(
     selectedProfile: Profile? = null,
     periodicRefreshAction: (() -> Unit)? = null,
     isTestMode: Boolean = false,
-    notificationCount: Int
+    notificationCount: Int,
+    heatMapCount: Int
 ) {
   LaunchedEffect(isConnected.value) {
     if (!isTestMode && !isNetworkAvailable()) {
@@ -139,7 +140,8 @@ fun ProfileListScreen(
             },
             tabList = LIST_TOP_LEVEL_DESTINATIONS,
             selectedItem = Route.UNBLOCK_PROFILE,
-            notificationCount = notificationCount)
+            notificationCount = notificationCount,
+            heatMapCount = heatMapCount)
       },
       topBar = { TopBar(title, true) { navigationActions.goBack() } },
       content = { innerPadding ->

--- a/app/src/main/java/com/github/se/icebreakrr/ui/sections/shared/TopBar.kt
+++ b/app/src/main/java/com/github/se/icebreakrr/ui/sections/shared/TopBar.kt
@@ -51,7 +51,7 @@ fun TopBar(s: String, needBackButton: Boolean = false, backButtonOnClick: () -> 
       modifier =
           Modifier.background(TOP_BAR_BACKGROUND_COLOR)
               .fillMaxWidth()
-              .heightIn(TOP_BAR_HEIGHT)
+              .heightIn(if (s.length < 15) TOP_BAR_HEIGHT else 60.dp)
               .testTag("topBar")) {
         Row(verticalAlignment = Alignment.CenterVertically, modifier = Modifier.fillMaxWidth()) {
           if (needBackButton) {
@@ -68,9 +68,10 @@ fun TopBar(s: String, needBackButton: Boolean = false, backButtonOnClick: () -> 
                       modifier = Modifier.size(BACK_BUTTON_ICON_SIZE))
                 }
           }
+            val topBarSize = if (s.length < 15) TOP_BAR_TEXT_SIZE else 25.sp
           Text(
               text = s,
-              fontSize = TOP_BAR_TEXT_SIZE,
+              fontSize = topBarSize,
               color = TOP_BAR_TEXT_COLOR,
               fontWeight = FontWeight.Bold,
               textAlign = TextAlign.Center,

--- a/app/src/main/java/com/github/se/icebreakrr/ui/sections/shared/TopBar.kt
+++ b/app/src/main/java/com/github/se/icebreakrr/ui/sections/shared/TopBar.kt
@@ -26,16 +26,19 @@ import androidx.compose.ui.unit.sp
 import com.github.se.icebreakrr.ui.theme.IceBreakrrBlue
 
 // Define constants for layout dimensions
-private val TOP_BAR_HEIGHT = 90.dp
+private val TOP_BAR_HEIGHT_1LINE = 90.dp
 private val BACK_BUTTON_PADDING_START = 8.dp
 private val BACK_BUTTON_SIZE = 48.dp
 private val BACK_BUTTON_ICON_SIZE = 32.dp
 
 // Define constants for font sizes and colors
-private val TOP_BAR_TEXT_SIZE = 40.sp
+private val TOP_BAR_TEXT_SIZE_BIG = 40.sp
+private val TOP_BAR_TEXT_SIZE_SMALL = 25.sp
 private val TOP_BAR_TEXT_COLOR = Color.White
 private val TOP_BAR_BACKGROUND_COLOR = IceBreakrrBlue
 private val TITLE_TEXT_WEIGHT = 1f
+private const val MAX_CHAR_ONE_LINE = 15
+private val TOP_BAR_HEIGHT_2LINES = 60.dp
 
 /**
  * Displays the TopBar of each screen, used to show to the user in which screen he is
@@ -51,7 +54,8 @@ fun TopBar(s: String, needBackButton: Boolean = false, backButtonOnClick: () -> 
       modifier =
           Modifier.background(TOP_BAR_BACKGROUND_COLOR)
               .fillMaxWidth()
-              .heightIn(if (s.length < 15) TOP_BAR_HEIGHT else 60.dp)
+              .heightIn(
+                  if (s.length < MAX_CHAR_ONE_LINE) TOP_BAR_HEIGHT_1LINE else TOP_BAR_HEIGHT_2LINES)
               .testTag("topBar")) {
         Row(verticalAlignment = Alignment.CenterVertically, modifier = Modifier.fillMaxWidth()) {
           if (needBackButton) {
@@ -68,7 +72,8 @@ fun TopBar(s: String, needBackButton: Boolean = false, backButtonOnClick: () -> 
                       modifier = Modifier.size(BACK_BUTTON_ICON_SIZE))
                 }
           }
-          val topBarSize = if (s.length < 15) TOP_BAR_TEXT_SIZE else 25.sp
+          val topBarSize =
+              if (s.length < MAX_CHAR_ONE_LINE) TOP_BAR_TEXT_SIZE_BIG else TOP_BAR_TEXT_SIZE_SMALL
           Text(
               text = s,
               fontSize = topBarSize,

--- a/app/src/main/java/com/github/se/icebreakrr/ui/sections/shared/TopBar.kt
+++ b/app/src/main/java/com/github/se/icebreakrr/ui/sections/shared/TopBar.kt
@@ -68,7 +68,7 @@ fun TopBar(s: String, needBackButton: Boolean = false, backButtonOnClick: () -> 
                       modifier = Modifier.size(BACK_BUTTON_ICON_SIZE))
                 }
           }
-            val topBarSize = if (s.length < 15) TOP_BAR_TEXT_SIZE else 25.sp
+          val topBarSize = if (s.length < 15) TOP_BAR_TEXT_SIZE else 25.sp
           Text(
               text = s,
               fontSize = topBarSize,

--- a/app/src/test/java/com/github/se/icebreakrr/model/message/MeetingRequestServiceTest.kt
+++ b/app/src/test/java/com/github/se/icebreakrr/model/message/MeetingRequestServiceTest.kt
@@ -44,7 +44,7 @@ class MeetingRequestServiceTest {
     meetingRequestService.onMessageReceived(mockRemoteMessage)
 
     // Verify that ViewModel methods were called
-    verify(mockMeetingRequestViewModel)?.addToMeetingRequestInbox("1", "hello")
+    verify(mockMeetingRequestViewModel)?.addToMeetingRequestInbox("1", "hello") {}
     verify(mockMeetingRequestViewModel)?.updateInboxOfMessages()
   }
 }

--- a/app/src/test/java/com/github/se/icebreakrr/model/message/MeetingRequestViewModelTest.kt
+++ b/app/src/test/java/com/github/se/icebreakrr/model/message/MeetingRequestViewModelTest.kt
@@ -301,7 +301,7 @@ class MeetingRequestViewModelTest {
     meetingRequestViewModel.meetingConfirmationState = meetingConfirmationState
 
     // Act: Call the method under test
-    meetingRequestViewModel.sendMeetingConfirmation()
+    meetingRequestViewModel.sendMeetingConfirmation {}
     // Assert: Verify that the cloud function was called with the correct data
     verify(functions).getHttpsCallable("sendMeetingConfirmation")
 

--- a/app/src/test/java/com/github/se/icebreakrr/model/message/MeetingRequestViewModelTest.kt
+++ b/app/src/test/java/com/github/se/icebreakrr/model/message/MeetingRequestViewModelTest.kt
@@ -165,7 +165,7 @@ class MeetingRequestViewModelTest {
     }
     profilesViewModel.getSelfProfile()
     meetingRequestViewModel.setMeetingConfirmation(
-        targetToken = profile2.fcmToken ?: "null", newMessage = message)
+        targetToken = profile2.fcmToken ?: "null", newLocation = message)
     assert(meetingRequestViewModel.meetingConfirmationState.message == message)
     assert(
         (meetingRequestViewModel.meetingConfirmationState.targetToken) ==
@@ -383,7 +383,7 @@ class MeetingRequestViewModelTest {
       onSuccess(profile1)
     }
     profilesViewModel.getSelfProfile()
-    meetingRequestViewModel.addToMeetingRequestInbox("2", "hello")
+    meetingRequestViewModel.addToMeetingRequestInbox("2", "hello") {}
     verify(profilesRepository).getProfileByUid(eq("1"), any(), any())
     verify(profilesRepository).updateProfile(eq(updatedProfile1), any(), any())
   }

--- a/app/src/test/java/com/github/se/icebreakrr/model/message/MeetingRequestViewModelTest.kt
+++ b/app/src/test/java/com/github/se/icebreakrr/model/message/MeetingRequestViewModelTest.kt
@@ -159,18 +159,19 @@ class MeetingRequestViewModelTest {
   @Test
   fun onMeetingConfirmationSetTest() = runBlocking {
     val message = "New Message"
+    val newLocation = "6.35838, 46.28495"
     `when`(profilesRepository.getProfileByUid(eq("1"), any(), any())).thenAnswer {
       val onSuccess = it.getArgument<(Profile) -> Unit>(1)
       onSuccess(profile1)
     }
-    profilesViewModel.getSelfProfile()
+    profilesViewModel.getSelfProfile() {}
     meetingRequestViewModel.setMeetingConfirmation(
-        targetToken = profile2.fcmToken ?: "null", newLocation = message)
+        targetToken = profile2.fcmToken ?: "null", newLocation = newLocation, newMessage = message)
     assert(meetingRequestViewModel.meetingConfirmationState.message == message)
     assert(
         (meetingRequestViewModel.meetingConfirmationState.targetToken) ==
             (profile2.fcmToken ?: "null"))
-    assert(profile1.geohash == meetingRequestViewModel.meetingConfirmationState.location)
+    assert(newLocation == meetingRequestViewModel.meetingConfirmationState.location)
   }
 
   @Test
@@ -181,7 +182,7 @@ class MeetingRequestViewModelTest {
       val onSuccess = it.getArgument<(Profile) -> Unit>(1)
       onSuccess(profile1)
     }
-    profilesViewModel.getSelfProfile()
+    profilesViewModel.getSelfProfile() {}
 
     meetingRequestViewModel.onRemoteTokenChange(newToken)
 
@@ -356,7 +357,7 @@ class MeetingRequestViewModelTest {
       val onSuccess = it.getArgument<(Profile) -> Unit>(1)
       onSuccess(profile1)
     }
-    profilesViewModel.getSelfProfile()
+    profilesViewModel.getSelfProfile() {}
     meetingRequestViewModel.addToMeetingRequestSent(profile2.uid)
     verify(profilesRepository).getProfileByUid(eq("1"), any(), any())
     verify(profilesRepository).updateProfile(eq(updatedProfile1), any(), any())
@@ -369,8 +370,8 @@ class MeetingRequestViewModelTest {
       val onSuccess = it.getArgument<(Profile) -> Unit>(1)
       onSuccess(updatedProfile1)
     }
-    profilesViewModel.getSelfProfile()
-    meetingRequestViewModel.removeFromMeetingRequestSent("2")
+    profilesViewModel.getSelfProfile() {}
+    meetingRequestViewModel.removeFromMeetingRequestSent("2") {}
     verify(profilesRepository).getProfileByUid(eq("1"), any(), any())
     verify(profilesRepository).updateProfile(eq(profile1), any(), any())
   }
@@ -382,7 +383,7 @@ class MeetingRequestViewModelTest {
       val onSuccess = it.getArgument<(Profile) -> Unit>(1)
       onSuccess(profile1)
     }
-    profilesViewModel.getSelfProfile()
+    profilesViewModel.getSelfProfile() {}
     meetingRequestViewModel.addToMeetingRequestInbox("2", "hello") {}
     verify(profilesRepository).getProfileByUid(eq("1"), any(), any())
     verify(profilesRepository).updateProfile(eq(updatedProfile1), any(), any())
@@ -395,7 +396,7 @@ class MeetingRequestViewModelTest {
       val onSuccess = it.getArgument<(Profile) -> Unit>(1)
       onSuccess(updatedProfile1)
     }
-    profilesViewModel.getSelfProfile()
+    profilesViewModel.getSelfProfile() {}
     meetingRequestViewModel.removeFromMeetingRequestInbox("2")
     verify(profilesRepository).getProfileByUid(eq("1"), any(), any())
     verify(profilesRepository).updateProfile(eq(profile1), any(), any())
@@ -407,7 +408,7 @@ class MeetingRequestViewModelTest {
       val onSuccess = it.getArgument<(Profile) -> Unit>(1)
       onSuccess(profile1)
     }
-    meetingRequestViewModel.updateInboxOfMessagesAndThen() {}
+    meetingRequestViewModel.updateInboxOfMessages() {}
     verify(profilesRepository).getProfileByUid(eq("1"), any(), any())
   }
 }

--- a/app/src/test/java/com/github/se/icebreakrr/model/profile/ProfilesViewModelTest.kt
+++ b/app/src/test/java/com/github/se/icebreakrr/model/profile/ProfilesViewModelTest.kt
@@ -196,7 +196,7 @@ class ProfilesViewModelTest {
 
   @Test
   fun updateProfileCallsRepository() = runBlocking {
-    profilesViewModel.updateProfile(profile1) {}
+    profilesViewModel.updateProfile(profile1, {}) {}
 
     verify(profilesRepository).updateProfile(eq(profile1), any(), any())
   }
@@ -258,7 +258,7 @@ class ProfilesViewModelTest {
       onFailure(exception)
     }
 
-    profilesViewModel.updateProfile(profile1) {}
+    profilesViewModel.updateProfile(profile1, {}) {}
 
     assertThat(profilesViewModel.error.value, `is`(exception))
   }
@@ -476,8 +476,8 @@ class ProfilesViewModelTest {
             meetingRequestPendingLocation = listOf(),
             meetingRequestChosenLocalisation =
                 mapOf("2" to Pair("we can meat here", Pair(5.0, 6.0))))
-    profilesViewModel.updateProfile(updatedProfile) {}
-    profilesViewModel.confirmMeetingLocation("2", Pair("we can meat here", Pair(5.0, 6.0))) {}
+    profilesViewModel.updateProfile(updatedProfile, {}) {}
+    profilesViewModel.confirmMeetingLocation("2", Pair("we can meat here", Pair(5.0, 6.0)), {}) {}
     verify(profilesRepository).updateProfile(eq(finalProfile), any(), any())
   }
 
@@ -488,7 +488,7 @@ class ProfilesViewModelTest {
             meetingRequestChosenLocalisation =
                 mapOf("2" to Pair("we can meat here", Pair(5.0, 6.0))))
     val finalProfile = profile1.copy(meetingRequestChosenLocalisation = mapOf())
-    profilesViewModel.updateProfile(updatedProfile) {}
+    profilesViewModel.updateProfile(updatedProfile, {}) {}
     profilesViewModel.removeChosenLocalisation("2")
     verify(profilesRepository).updateProfile(eq(finalProfile), any(), any())
   }
@@ -496,7 +496,7 @@ class ProfilesViewModelTest {
   @Test
   fun addPendingLocationTest() {
     val finalProfile = profile1.copy(meetingRequestPendingLocation = listOf("2"))
-    profilesViewModel.updateProfile(profile1) {}
+    profilesViewModel.updateProfile(profile1, {}) {}
     profilesViewModel.addPendingLocation("2") {
       verify(profilesRepository).updateProfile(eq(finalProfile), any(), any())
     }
@@ -512,7 +512,7 @@ class ProfilesViewModelTest {
       val onSuccess = it.getArgument<(List<Profile>) -> Unit>(1)
       onSuccess(listOf(profile2))
     }
-    profilesViewModel.updateProfile(updatedProfile) {}
+    profilesViewModel.updateProfile(updatedProfile, {}) {}
     profilesViewModel.getChosenLocationsUsers()
     assertEquals(
         profilesViewModel.chosenLocalisations.value,

--- a/app/src/test/java/com/github/se/icebreakrr/model/profile/ProfilesViewModelTest.kt
+++ b/app/src/test/java/com/github/se/icebreakrr/model/profile/ProfilesViewModelTest.kt
@@ -513,7 +513,7 @@ class ProfilesViewModelTest {
       onSuccess(listOf(profile2))
     }
     profilesViewModel.updateProfile(updatedProfile) {}
-    profilesViewModel.getChosenLocations()
+    profilesViewModel.getChosenLocationsUsers()
     assertEquals(
         profilesViewModel.chosenLocalisations.value,
         mapOf(profile2 to Pair("we can meat here", Pair(5.0, 6.0))))


### PR DESCRIPTION
This PR introduces a new screen to chose the location of the meeting and send a message to precise it. It also refactors some code to add `onComplete()` callback functions on some view model functions to avoid racing conditions. Some logic has been added for the badges (to indicate notifications) in the notification screen and the bottom navigation bar

 hese are the principal files I have changed : 

- `Profile` : added `meetingRequestPendingLocation`, which contains all the meetings where you need to select the location and 
     `meetingRequestChosenLocalisation` which contains the information of the meeting that is ready, so uid, location, and a 
     message.
- `TopLevelDestination` : add a new screen and route for the new map
- `ProfileRepositoryFirestore` : I needed to modify `documentToProfile` to take into account the two new attributes of the `Profile`
- `ProfileViewModel` : Added two functions to fetch the pending profiles and the chosen locations. I also added some 
    `onComplete` callbacks to avoid racing conditions and added other helper functions related to that
- `MainActivity` : add `LocationSelectorMapScreen` to the navigation graph
- `MeetingRequestService` : Modified to to fit our new messaging system.
- `MeetingRequestViewModel` : add functions to deal with the pending locations and chosen locations. I also modified 
     `updateProfile` to have a `onComplete` callback
- `HeatMap`, `AroundYou`, `Settings`, `AlreadyMet`, `UnblockProfile` : modifier parameters in the `BottomNavigationBar` to update the notification badge on the heatmap (the number of meeting that are ready with a localisation and a message) and on the inbox
- `LocationSelectorMap` : added this composable to be able to select a meeting point in a range of 500m and send a message to the other user
- `BottomNavigationMenu` : add logic for the badges
- `Notifications` : add logic to handle the badges
- `TopBar` : make it adaptable to the size of the text
- `LocationMapSelectorTest` : File that tests the `LocationSelectorMapScreen`
- `NotificationTest` : Add tests to check if inbox, pending, and sent get appropriately updated
- `ProfilesViewModelTest` : added tests for the new functions



https://github.com/user-attachments/assets/77ec1a4b-09e2-4573-8786-4ee58af174a0


It seems like my SonarCloud still doesn't take into account my new tests because it tells me that 0% of the code has been covered on the file `LocationSelectorMap`, but jacoco doesn't tell me the same thing as you can see : 

![image](https://github.com/user-attachments/assets/ba0e7df0-766d-4950-825c-4465af3771f0)





