### PR TITLE
fix(map-view): resolve text and color issues

### DIFF
--- a/app/src/main/java/com/github/se/icebreakrr/ui/map/MapView.kt
+++ b/app/src/main/java/com/github/se/icebreakrr/ui/map/MapView.kt
@@ -42,6 +42,7 @@ import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.IntOffset
 import androidx.compose.ui.unit.dp
@@ -337,7 +338,10 @@ fun MapScreen(
                       else "${R.string.show_heatmap}",
                   modifier = Modifier.padding(end = 8.dp) // Add padding to the right of the icon
                   )
-              Text(if (isHeatmapVisible) "${R.string.hide_heatmap}" else "${R.string.show_heatmap}")
+              Text(
+                  text =
+                      stringResource(
+                          if (isHeatmapVisible) R.string.hide_heatmap else R.string.show_heatmap))
             }
           }
 
@@ -419,7 +423,7 @@ private fun createUserMarkerBitmap(): BitmapDescriptor {
   // Draw the blue circle
   val bluePaint =
       Paint().apply {
-        color = android.graphics.Color.parseColor(MARKER_COLOR.toString()) // IceBreakrr Blue
+        color = MARKER_COLOR.value.toInt() // IceBreakrr Blue
         isAntiAlias = true // Enable anti-aliasing for smooth edges
       }
   canvas.drawCircle(


### PR DESCRIPTION
# Fix Critical Issues in MapView

## Overview

This PR addresses two critical issues in the `MapView` component:
1. **Button Text Fix**: The Hide/Show Heatmap button now displays the correct text instead of the resource ID.
2. **Color Error Fix**: Resolved a fatal crash caused by an unknown color when navigating to the Map section.

## Observations

These issues reveal gaps in our testing and review process:
- **Insufficient Testing**: No tests detected the navigation crash. While testing the Map is challenging, basic navigation tests should be added.
- **Lack of Manual Testing**: This error would have been obvious with proper manual testing.

This PR fixes the immediate problems but highlights areas to improve for better quality control.
