### PR TITLE
fix: display correct string values in notification

### DIFF
--- a/app/src/main/java/com/github/se/icebreakrr/model/location/LocationService.kt
+++ b/app/src/main/java/com/github/se/icebreakrr/model/location/LocationService.kt
@@ -157,8 +157,8 @@ class LocationService(
    */
   private fun createNotification(): Notification {
     return Notification.Builder(this, NOTIFICATION_CHANNEL_ID)
-        .setContentTitle(R.string.app_name.toString())
-        .setContentText(R.string.background_notification.toString())
+        .setContentTitle(getString(R.string.app_name))
+        .setContentText(getString(R.string.background_notification))
         .setSmallIcon(android.R.drawable.ic_menu_mylocation)
         .setOngoing(true)
         .build()


### PR DESCRIPTION
- Replaced R.string.resource_id.toString() with getString(resource_id) to ensure proper retrieval of string values in the notification's title and content text.