### PR TITLE
Feature/enhanceengagementandfixoffline

### DIFF
--- a/app/src/androidTest/java/com/github/se/di/module/TestModule.kt
+++ b/app/src/androidTest/java/com/github/se/di/module/TestModule.kt
@@ -20,6 +20,7 @@ import com.google.firebase.firestore.FirebaseFirestore
 import com.google.firebase.firestore.GeoPoint
 import com.google.firebase.firestore.Query
 import com.google.firebase.firestore.QuerySnapshot
+import com.google.firebase.firestore.Source
 import dagger.Module
 import dagger.Provides
 import dagger.hilt.components.SingletonComponent
@@ -158,7 +159,7 @@ object MockFirebaseFirestoreModule {
         .thenReturn(mockProfilesQuery)
     `when`(mockProfilesQuery.whereLessThanOrEqualTo(anyString(), anyString()))
         .thenReturn(mockProfilesQuery)
-    `when`(mockProfilesQuery.get()).thenReturn(mockTaskQuerySnapshotProfiles)
+    `when`(mockProfilesQuery.get(Source.SERVER)).thenReturn(mockTaskQuerySnapshotProfiles)
     doAnswer { invocation ->
           val listener = invocation.arguments[0] as OnSuccessListener<QuerySnapshot>
           listener.onSuccess(mockQuerySnapshotProfiles)

--- a/app/src/main/java/com/github/se/icebreakrr/MainActivity.kt
+++ b/app/src/main/java/com/github/se/icebreakrr/MainActivity.kt
@@ -372,7 +372,9 @@ fun IcebreakrrApp(
           tagsViewModel = tagsViewModel,
           permissionManager = permissionManager)
 
-  val startDestination = if (isTesting) Route.AROUND_YOU else Route.AUTH
+  val startDestination =
+      if (isTesting) Route.AROUND_YOU
+      else (if (currentUser != null) Route.AROUND_YOU else Route.AUTH)
 
   IcebreakrrNavHost(
       profileViewModel,
@@ -442,16 +444,19 @@ fun IcebreakrrNavHost(
         route = Route.AROUND_YOU,
     ) {
       composable(Screen.AROUND_YOU) {
-        AroundYouScreen(
-            navigationActions,
-            profileViewModel,
-            tagsViewModel,
-            filterViewModel,
-            locationViewModel,
-            sortViewModel,
-            permissionManager,
-            appDataStore,
-            isTesting)
+        if (engagementNotificationManager != null) {
+          AroundYouScreen(
+              navigationActions,
+              profileViewModel,
+              tagsViewModel,
+              filterViewModel,
+              locationViewModel,
+              sortViewModel,
+              permissionManager,
+              appDataStore,
+              engagementManager = engagementNotificationManager,
+              isTestMode = isTesting)
+        }
       }
       composable(Screen.OTHER_PROFILE_VIEW + "?userId={userId}") { navBackStackEntry ->
         if (meetingRequestViewModel != null) {

--- a/app/src/main/java/com/github/se/icebreakrr/MainActivity.kt
+++ b/app/src/main/java/com/github/se/icebreakrr/MainActivity.kt
@@ -372,9 +372,7 @@ fun IcebreakrrApp(
           tagsViewModel = tagsViewModel,
           permissionManager = permissionManager)
 
-  val startDestination =
-      if (isTesting) Route.AROUND_YOU
-      else Route.AUTH
+  val startDestination = if (isTesting) Route.AROUND_YOU else Route.AUTH
 
   IcebreakrrNavHost(
       profileViewModel,

--- a/app/src/main/java/com/github/se/icebreakrr/MainActivity.kt
+++ b/app/src/main/java/com/github/se/icebreakrr/MainActivity.kt
@@ -297,7 +297,7 @@ fun IcebreakrrApp(
 
   val startDestination =
       if (isTesting) Route.AROUND_YOU
-      else (if (auth.currentUser != null) Route.AROUND_YOU else Route.AUTH)
+      else Route.AUTH
 
   IcebreakrrNavHost(
       profileViewModel,

--- a/app/src/main/java/com/github/se/icebreakrr/data/AppDataStore.kt
+++ b/app/src/main/java/com/github/se/icebreakrr/data/AppDataStore.kt
@@ -54,12 +54,14 @@ open class AppDataStore(private val dataStore: DataStore<Preferences>) {
       getPreference(lastKnownLocationKey, "").map { json ->
         if (json.isNotBlank()) gson.fromJson(json, GeoPoint::class.java) else null
       }
-  val lastNotificationTimes: Flow<Map<String, Long>> = dataStore.data.map { preferences ->
-    preferences.asMap()
-        .filterKeys { it.toString().startsWith(NOTIFICATION_TIME_PREFIX) }
-        .mapKeys { it.key.toString().removePrefix(NOTIFICATION_TIME_PREFIX) }
-        .mapValues { (it.value as Long) }
-  }
+  val lastNotificationTimes: Flow<Map<String, Long>> =
+      dataStore.data.map { preferences ->
+        preferences
+            .asMap()
+            .filterKeys { it.toString().startsWith(NOTIFICATION_TIME_PREFIX) }
+            .mapKeys { it.key.toString().removePrefix(NOTIFICATION_TIME_PREFIX) }
+            .mapValues { (it.value as Long) }
+      }
 
   /**
    * Saves an authentication token to persistent storage.

--- a/app/src/main/java/com/github/se/icebreakrr/data/AppDataStore.kt
+++ b/app/src/main/java/com/github/se/icebreakrr/data/AppDataStore.kt
@@ -138,10 +138,25 @@ open class AppDataStore(private val dataStore: DataStore<Preferences>) {
     dataStore.edit { preferences -> preferences.remove(key) }
   }
 
+  /**
+   * Saves the timestamp of the last notification sent to a specific user. This is useful for
+   * tracking when notifications were last sent to prevent spam or implement cooldown periods
+   * between notifications.
+   *
+   * @param uid The unique identifier of the user
+   * @param timestamp The time when the notification was sent (in milliseconds since epoch)
+   */
   suspend fun saveNotificationTime(uid: String, timestamp: Long) {
     putPreference(longPreferencesKey(NOTIFICATION_TIME_PREFIX + uid), timestamp)
   }
 
+  /**
+   * Removes the stored notification timestamp for a specific user. This can be used when you want
+   * to reset the notification history for a user, for example when they opt out of notifications or
+   * when testing.
+   *
+   * @param uid The unique identifier of the user whose notification timestamp should be cleared
+   */
   suspend fun clearNotificationTime(uid: String) {
     dataStore.edit { preferences ->
       preferences.remove(longPreferencesKey(NOTIFICATION_TIME_PREFIX + uid))

--- a/app/src/main/java/com/github/se/icebreakrr/model/message/MeetingRequestService.kt
+++ b/app/src/main/java/com/github/se/icebreakrr/model/message/MeetingRequestService.kt
@@ -32,6 +32,8 @@ class MeetingRequestService : FirebaseMessagingService() {
   private val MEETING_REQUEST_NOTIFICATION_ID = 2
   private val MEETING_RESPONSE_NOTIFICATION_ID = 3
   private val MEETING_CANCELLATION_NOTIFICATION_ID = 4
+  private val ENGAGEMENT_NOTIFICATION_START = "A person with similar interests"
+  private val MEETING_CANCELLATION_START = "Cancelled meeting"
 
   /**
    * Checks if the application is currently running in the foreground.
@@ -187,8 +189,8 @@ class MeetingRequestService : FirebaseMessagingService() {
           title == MSG_REQUEST -> MEETING_REQUEST_NOTIFICATION_ID
           title.contains(MSG_RESPONSE_ACCEPTED) || title.contains(MSG_RESPONSE_REJECTED) ->
               MEETING_RESPONSE_NOTIFICATION_ID
-          title.startsWith("Cancelled meeting") -> MEETING_CANCELLATION_NOTIFICATION_ID
-          title.startsWith("A person with similar interests") -> ENGAGEMENT_NOTIFICATION_ID
+          title.startsWith(MEETING_CANCELLATION_START) -> MEETING_CANCELLATION_NOTIFICATION_ID
+          title.startsWith(ENGAGEMENT_NOTIFICATION_START) -> ENGAGEMENT_NOTIFICATION_ID
           else -> MEETING_REQUEST_NOTIFICATION_ID // Default fallback
         }
 

--- a/app/src/main/java/com/github/se/icebreakrr/model/message/MeetingRequestService.kt
+++ b/app/src/main/java/com/github/se/icebreakrr/model/message/MeetingRequestService.kt
@@ -3,9 +3,12 @@ package com.github.se.icebreakrr.model.message
 import android.app.ActivityManager
 import android.app.NotificationChannel
 import android.app.NotificationManager
+import android.app.PendingIntent
 import android.content.Context
+import android.content.Intent
 import android.util.Log
 import androidx.core.app.NotificationCompat
+import com.github.se.icebreakrr.MainActivity
 import com.github.se.icebreakrr.R
 import com.google.firebase.messaging.FirebaseMessagingService
 import com.google.firebase.messaging.RemoteMessage
@@ -182,11 +185,25 @@ class MeetingRequestService : FirebaseMessagingService() {
    * @param message : the message of the notification
    */
   fun createNotificationBuilder(title: String, message: String): NotificationCompat.Builder {
+    // Create an intent to launch the MainActivity
+    val intent = Intent(this, MainActivity::class.java).apply {
+        flags = Intent.FLAG_ACTIVITY_NEW_TASK or Intent.FLAG_ACTIVITY_CLEAR_TASK
+    }
+    
+    val pendingIntent = PendingIntent.getActivity(
+        this, 
+        0, 
+        intent,
+        PendingIntent.FLAG_IMMUTABLE or PendingIntent.FLAG_UPDATE_CURRENT
+    )
+
     return NotificationCompat.Builder(this, MSG_CHANNEL_ID)
-        .setSmallIcon(R.drawable.ic_launcher_foreground) // Replace with app icon
+        .setSmallIcon(R.drawable.ic_launcher_foreground)
         .setContentTitle(title)
         .setContentText(message)
         .setPriority(NotificationCompat.PRIORITY_DEFAULT)
         .setAutoCancel(true)
+        // Add the pending intent to make notification clickable
+        .setContentIntent(pendingIntent)
   }
 }

--- a/app/src/main/java/com/github/se/icebreakrr/model/message/MeetingRequestService.kt
+++ b/app/src/main/java/com/github/se/icebreakrr/model/message/MeetingRequestService.kt
@@ -28,7 +28,10 @@ class MeetingRequestService : FirebaseMessagingService() {
   private val DEFAULT_REASON_CANCELLATION = "Reason : Unknown"
   private val CANCELLED_REASON_CANCELLATION = "Reason : Sender cancelled request"
   private val CLOSED_APP_REASON_CANCELLATION = "Reason : The other user closed the app"
-  private val NOTIFICATION_ID = 0
+  private val ENGAGEMENT_NOTIFICATION_ID = 1
+  private val MEETING_REQUEST_NOTIFICATION_ID = 2
+  private val MEETING_RESPONSE_NOTIFICATION_ID = 3
+  private val MEETING_CANCELLATION_NOTIFICATION_ID =4
 
   /**
    * Checks if the application is currently running in the foreground.
@@ -179,8 +182,16 @@ class MeetingRequestService : FirebaseMessagingService() {
     notificationManager.createNotificationChannel(channel)
 
     val notificationBuilder = createNotificationBuilder(title, message)
+    val notificationId = when {
+      title == MSG_REQUEST -> MEETING_REQUEST_NOTIFICATION_ID
+      title.contains(MSG_RESPONSE_ACCEPTED) || title.contains(MSG_RESPONSE_REJECTED) ->
+        MEETING_RESPONSE_NOTIFICATION_ID
+      title.startsWith("Cancelled meeting") -> MEETING_CANCELLATION_NOTIFICATION_ID
+      title.startsWith("A person with similar interests") -> ENGAGEMENT_NOTIFICATION_ID
+      else -> MEETING_REQUEST_NOTIFICATION_ID // Default fallback
+    }
 
-    notificationManager.notify(NOTIFICATION_ID, notificationBuilder.build())
+    notificationManager.notify(notificationId, notificationBuilder.build())
   }
 
   /**

--- a/app/src/main/java/com/github/se/icebreakrr/model/message/MeetingRequestService.kt
+++ b/app/src/main/java/com/github/se/icebreakrr/model/message/MeetingRequestService.kt
@@ -191,16 +191,14 @@ class MeetingRequestService : FirebaseMessagingService() {
    */
   fun createNotificationBuilder(title: String, message: String): NotificationCompat.Builder {
     // Create an intent to launch the MainActivity
-    val intent = Intent(this, MainActivity::class.java).apply {
-        flags = Intent.FLAG_ACTIVITY_NEW_TASK or Intent.FLAG_ACTIVITY_CLEAR_TASK
-    }
-    
-    val pendingIntent = PendingIntent.getActivity(
-        this, 
-        0, 
-        intent,
-        PendingIntent.FLAG_IMMUTABLE or PendingIntent.FLAG_UPDATE_CURRENT
-    )
+    val intent =
+        Intent(this, MainActivity::class.java).apply {
+          flags = Intent.FLAG_ACTIVITY_NEW_TASK or Intent.FLAG_ACTIVITY_CLEAR_TASK
+        }
+
+    val pendingIntent =
+        PendingIntent.getActivity(
+            this, 0, intent, PendingIntent.FLAG_IMMUTABLE or PendingIntent.FLAG_UPDATE_CURRENT)
 
     return NotificationCompat.Builder(this, MSG_CHANNEL_ID)
         .setSmallIcon(R.drawable.ic_launcher_foreground)

--- a/app/src/main/java/com/github/se/icebreakrr/model/message/MeetingRequestService.kt
+++ b/app/src/main/java/com/github/se/icebreakrr/model/message/MeetingRequestService.kt
@@ -31,7 +31,7 @@ class MeetingRequestService : FirebaseMessagingService() {
   private val ENGAGEMENT_NOTIFICATION_ID = 1
   private val MEETING_REQUEST_NOTIFICATION_ID = 2
   private val MEETING_RESPONSE_NOTIFICATION_ID = 3
-  private val MEETING_CANCELLATION_NOTIFICATION_ID =4
+  private val MEETING_CANCELLATION_NOTIFICATION_ID = 4
 
   /**
    * Checks if the application is currently running in the foreground.
@@ -182,14 +182,15 @@ class MeetingRequestService : FirebaseMessagingService() {
     notificationManager.createNotificationChannel(channel)
 
     val notificationBuilder = createNotificationBuilder(title, message)
-    val notificationId = when {
-      title == MSG_REQUEST -> MEETING_REQUEST_NOTIFICATION_ID
-      title.contains(MSG_RESPONSE_ACCEPTED) || title.contains(MSG_RESPONSE_REJECTED) ->
-        MEETING_RESPONSE_NOTIFICATION_ID
-      title.startsWith("Cancelled meeting") -> MEETING_CANCELLATION_NOTIFICATION_ID
-      title.startsWith("A person with similar interests") -> ENGAGEMENT_NOTIFICATION_ID
-      else -> MEETING_REQUEST_NOTIFICATION_ID // Default fallback
-    }
+    val notificationId =
+        when {
+          title == MSG_REQUEST -> MEETING_REQUEST_NOTIFICATION_ID
+          title.contains(MSG_RESPONSE_ACCEPTED) || title.contains(MSG_RESPONSE_REJECTED) ->
+              MEETING_RESPONSE_NOTIFICATION_ID
+          title.startsWith("Cancelled meeting") -> MEETING_CANCELLATION_NOTIFICATION_ID
+          title.startsWith("A person with similar interests") -> ENGAGEMENT_NOTIFICATION_ID
+          else -> MEETING_REQUEST_NOTIFICATION_ID // Default fallback
+        }
 
     notificationManager.notify(notificationId, notificationBuilder.build())
   }

--- a/app/src/main/java/com/github/se/icebreakrr/model/notification/EngagementNotificationManager.kt
+++ b/app/src/main/java/com/github/se/icebreakrr/model/notification/EngagementNotificationManager.kt
@@ -203,9 +203,7 @@ class EngagementNotificationManager(
           try {
             meetingRequestViewModel.engagementNotification(
                 targetToken = nearbyProfile.fcmToken ?: "null", tag = commonTag)
-            scope.launch {
-              updateLastNotificationTime(nearbyProfile.uid)
-            }
+            scope.launch { updateLastNotificationTime(nearbyProfile.uid) }
             Log.i(TAG, "Successfully sent notification to ${nearbyProfile.uid}")
           } catch (e: Exception) {
             Log.e(TAG, "Failed to send notification to ${nearbyProfile.uid}: ${e.message}", e)

--- a/app/src/main/java/com/github/se/icebreakrr/model/notification/EngagementNotificationManager.kt
+++ b/app/src/main/java/com/github/se/icebreakrr/model/notification/EngagementNotificationManager.kt
@@ -215,6 +215,16 @@ class EngagementNotificationManager(
     }
   }
 
+  /**
+   * Updates the timestamp of the last notification sent to a specific user.
+   *
+   * This method:
+   * 1. Records the current time as the last notification time for the given user ID
+   * 2. Updates both the in-memory cache (lastNotificationTimes) and persistent storage
+   *    (appDataStore)
+   *
+   * @param uid The unique identifier of the user who received the notification
+   */
   private suspend fun updateLastNotificationTime(uid: String) {
     val currentTime = System.currentTimeMillis()
     lastNotificationTimes[uid] = currentTime

--- a/app/src/main/java/com/github/se/icebreakrr/model/notification/EngagementNotificationManager.kt
+++ b/app/src/main/java/com/github/se/icebreakrr/model/notification/EngagementNotificationManager.kt
@@ -72,8 +72,13 @@ class EngagementNotificationManager(
    * Android TIRAMISU+ and launches monitoring in a coroutine.
    */
   fun startMonitoring() {
+    // If already monitoring, just return
+    if (isMonitoring()) {
+      Log.i(TAG, "Monitoring already active, skipping start")
+      return
+    }
+
     Log.i(TAG, "Starting engagement monitoring")
-    stopMonitoring() // Stop any existing monitoring
 
     // Handle permission request
     if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {

--- a/app/src/main/java/com/github/se/icebreakrr/model/profile/ProfilesRepositoryFirestore.kt
+++ b/app/src/main/java/com/github/se/icebreakrr/model/profile/ProfilesRepositoryFirestore.kt
@@ -150,7 +150,7 @@ class ProfilesRepositoryFirestore(
     db.collection(collectionPath)
         .whereGreaterThanOrEqualTo("geohash", centerGeohash)
         .whereLessThanOrEqualTo("geohash", centerGeohash + "\uf8ff")
-        .get()
+        .get(Source.SERVER)
         .addOnSuccessListener { result ->
           waitingDone.value = false
           isWaiting.value = false

--- a/app/src/main/java/com/github/se/icebreakrr/ui/sections/AroundYou.kt
+++ b/app/src/main/java/com/github/se/icebreakrr/ui/sections/AroundYou.kt
@@ -58,6 +58,7 @@ import com.github.se.icebreakrr.R
 import com.github.se.icebreakrr.data.AppDataStore
 import com.github.se.icebreakrr.model.filter.FilterViewModel
 import com.github.se.icebreakrr.model.location.LocationViewModel
+import com.github.se.icebreakrr.model.notification.EngagementNotificationManager
 import com.github.se.icebreakrr.model.profile.Gender
 import com.github.se.icebreakrr.model.profile.ProfilesViewModel
 import com.github.se.icebreakrr.model.sort.SortOption
@@ -115,6 +116,7 @@ fun AroundYouScreen(
     permissionManager: IPermissionManager,
     appDataStore: AppDataStore,
     isTestMode: Boolean = false,
+    engagementManager: EngagementNotificationManager
 ) {
   val filteredProfiles = profilesViewModel.filteredProfiles.collectAsState()
   val isLoading = profilesViewModel.loading.collectAsState()
@@ -188,6 +190,11 @@ fun AroundYouScreen(
     }
   }
   LaunchedEffect(Unit) {
+    // Only start monitoring if it's not already running
+    if (!engagementManager.isMonitoring()) {
+      engagementManager.startMonitoring()
+    }
+
     profilesViewModel.getFilteredProfilesInRadius(
         userLocation.value ?: GeoPoint(DEFAULT_USER_LATITUDE, DEFAULT_USER_LONGITUDE),
         filterViewModel.selectedRadius.value,

--- a/app/src/test/java/com/github/se/icebreakrr/data/AppDataStoreTest.kt
+++ b/app/src/test/java/com/github/se/icebreakrr/data/AppDataStoreTest.kt
@@ -93,10 +93,10 @@ class AppDataStoreTest {
   fun testSaveAndRetrieveNotificationTime() = runTest {
     val uid = "test_user_123"
     val timestamp = System.currentTimeMillis()
-    
+
     // Save notification time
     appDataStore.saveNotificationTime(uid, timestamp)
-    
+
     // Retrieve and verify the saved time
     val retrievedTimes = appDataStore.lastNotificationTimes.first()
     assertEquals(timestamp, retrievedTimes[uid])
@@ -106,17 +106,17 @@ class AppDataStoreTest {
   fun testClearNotificationTime() = runTest {
     val uid = "test_user_123"
     val timestamp = System.currentTimeMillis()
-    
+
     // First save a notification time
     appDataStore.saveNotificationTime(uid, timestamp)
-    
+
     // Verify it was saved
     var retrievedTimes = appDataStore.lastNotificationTimes.first()
     assertEquals(timestamp, retrievedTimes[uid])
-    
+
     // Clear the notification time
     appDataStore.clearNotificationTime(uid)
-    
+
     // Verify it was cleared
     retrievedTimes = appDataStore.lastNotificationTimes.first()
     assertNull(retrievedTimes[uid])
@@ -128,11 +128,11 @@ class AppDataStoreTest {
     val uid2 = "user_2"
     val timestamp1 = System.currentTimeMillis()
     val timestamp2 = timestamp1 + 1000 // 1 second later
-    
+
     // Save notification times for multiple users
     appDataStore.saveNotificationTime(uid1, timestamp1)
     appDataStore.saveNotificationTime(uid2, timestamp2)
-    
+
     // Retrieve and verify all times
     val retrievedTimes = appDataStore.lastNotificationTimes.first()
     assertEquals(2, retrievedTimes.size)
@@ -145,17 +145,17 @@ class AppDataStoreTest {
     val uid = "test_user_123"
     val timestamp1 = System.currentTimeMillis()
     val timestamp2 = timestamp1 + 1000 // 1 second later
-    
+
     // Save initial notification time
     appDataStore.saveNotificationTime(uid, timestamp1)
-    
+
     // Verify initial save
     var retrievedTimes = appDataStore.lastNotificationTimes.first()
     assertEquals(timestamp1, retrievedTimes[uid])
-    
+
     // Overwrite with new timestamp
     appDataStore.saveNotificationTime(uid, timestamp2)
-    
+
     // Verify overwrite
     retrievedTimes = appDataStore.lastNotificationTimes.first()
     assertEquals(timestamp2, retrievedTimes[uid])

--- a/app/src/test/java/com/github/se/icebreakrr/data/AppDataStoreTest.kt
+++ b/app/src/test/java/com/github/se/icebreakrr/data/AppDataStoreTest.kt
@@ -11,6 +11,7 @@ import kotlinx.coroutines.test.TestScope
 import kotlinx.coroutines.test.UnconfinedTestDispatcher
 import kotlinx.coroutines.test.runTest
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
 import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
@@ -86,5 +87,77 @@ class AppDataStoreTest {
 
     assertEquals(null, retrievedToken)
     assertEquals(true, isDiscoverable) // Default value is true
+  }
+
+  @Test
+  fun testSaveAndRetrieveNotificationTime() = runTest {
+    val uid = "test_user_123"
+    val timestamp = System.currentTimeMillis()
+    
+    // Save notification time
+    appDataStore.saveNotificationTime(uid, timestamp)
+    
+    // Retrieve and verify the saved time
+    val retrievedTimes = appDataStore.lastNotificationTimes.first()
+    assertEquals(timestamp, retrievedTimes[uid])
+  }
+
+  @Test
+  fun testClearNotificationTime() = runTest {
+    val uid = "test_user_123"
+    val timestamp = System.currentTimeMillis()
+    
+    // First save a notification time
+    appDataStore.saveNotificationTime(uid, timestamp)
+    
+    // Verify it was saved
+    var retrievedTimes = appDataStore.lastNotificationTimes.first()
+    assertEquals(timestamp, retrievedTimes[uid])
+    
+    // Clear the notification time
+    appDataStore.clearNotificationTime(uid)
+    
+    // Verify it was cleared
+    retrievedTimes = appDataStore.lastNotificationTimes.first()
+    assertNull(retrievedTimes[uid])
+  }
+
+  @Test
+  fun testMultipleNotificationTimes() = runTest {
+    val uid1 = "user_1"
+    val uid2 = "user_2"
+    val timestamp1 = System.currentTimeMillis()
+    val timestamp2 = timestamp1 + 1000 // 1 second later
+    
+    // Save notification times for multiple users
+    appDataStore.saveNotificationTime(uid1, timestamp1)
+    appDataStore.saveNotificationTime(uid2, timestamp2)
+    
+    // Retrieve and verify all times
+    val retrievedTimes = appDataStore.lastNotificationTimes.first()
+    assertEquals(2, retrievedTimes.size)
+    assertEquals(timestamp1, retrievedTimes[uid1])
+    assertEquals(timestamp2, retrievedTimes[uid2])
+  }
+
+  @Test
+  fun testOverwriteNotificationTime() = runTest {
+    val uid = "test_user_123"
+    val timestamp1 = System.currentTimeMillis()
+    val timestamp2 = timestamp1 + 1000 // 1 second later
+    
+    // Save initial notification time
+    appDataStore.saveNotificationTime(uid, timestamp1)
+    
+    // Verify initial save
+    var retrievedTimes = appDataStore.lastNotificationTimes.first()
+    assertEquals(timestamp1, retrievedTimes[uid])
+    
+    // Overwrite with new timestamp
+    appDataStore.saveNotificationTime(uid, timestamp2)
+    
+    // Verify overwrite
+    retrievedTimes = appDataStore.lastNotificationTimes.first()
+    assertEquals(timestamp2, retrievedTimes[uid])
   }
 }

--- a/app/src/test/java/com/github/se/icebreakrr/model/message/MeetingRequestServiceTest.kt
+++ b/app/src/test/java/com/github/se/icebreakrr/model/message/MeetingRequestServiceTest.kt
@@ -158,7 +158,8 @@ class MeetingRequestServiceTest {
     meetingRequestService.showNotification(title, message)
 
     // Assert that the NotificationManager is called with correct parameters
-    verify(mockNotificationManager).notify(eq(0), any())
+    // In the eq() one has to put the fallback notification ID
+    verify(mockNotificationManager).notify(eq(2), any())
   }
 
   @Test

--- a/app/src/test/java/com/github/se/icebreakrr/model/notification/EngagementNotificationManagerTest.kt
+++ b/app/src/test/java/com/github/se/icebreakrr/model/notification/EngagementNotificationManagerTest.kt
@@ -24,7 +24,11 @@ import kotlinx.coroutines.test.setMain
 import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
-import org.mockito.Mockito.*
+import org.mockito.Mockito.doAnswer
+import org.mockito.Mockito.mock
+import org.mockito.Mockito.never
+import org.mockito.Mockito.spy
+import org.mockito.Mockito.times
 import org.mockito.kotlin.any
 import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
@@ -44,7 +48,6 @@ class EngagementNotificationManagerTest {
   private lateinit var tagsViewModel: TagsViewModel
   private lateinit var mockProfilesRepo: ProfilesRepository
   private lateinit var permissionManager: IPermissionManager
-  private val testDispatcher = UnconfinedTestDispatcher()
 
   private val selfProfile =
       Profile(
@@ -73,14 +76,18 @@ class EngagementNotificationManagerTest {
 
   @Before
   fun setUp() {
-    Dispatchers.setMain(testDispatcher)
+    Dispatchers.setMain(UnconfinedTestDispatcher())
 
-    // Mock dependencies
+    // create and configure the mock
+    appDataStore = mock()
     mockProfilesRepo = mock(ProfilesRepository::class.java)
     meetingRequestViewModel = mock()
-    appDataStore = mock()
     filterViewModel = mock()
     tagsViewModel = mock()
+
+    // Mock the required DataStore methods with correct property name
+    whenever(appDataStore.lastNotificationTimes).thenReturn(MutableStateFlow(mapOf<String, Long>()))
+    whenever(appDataStore.isDiscoverable).thenReturn(MutableStateFlow(true))
 
     // Setup profilesViewModel
     val mockProfilePicRepo = mock(ProfilePicRepository::class.java)

--- a/app/src/test/java/com/github/se/icebreakrr/model/profile/ProfilesRepositoryFirestoreTest.kt
+++ b/app/src/test/java/com/github/se/icebreakrr/model/profile/ProfilesRepositoryFirestoreTest.kt
@@ -107,7 +107,7 @@ class ProfilesRepositoryFirestoreTest {
     `when`(mockCollectionReference.whereGreaterThanOrEqualTo(eq("geohash"), any()))
         .thenReturn(mockQuery)
     `when`(mockQuery.whereLessThanOrEqualTo(eq("geohash"), any())).thenReturn(mockQuery)
-    `when`(mockQuery.get()).thenReturn(Tasks.forException(Exception("Test exception")))
+    `when`(mockQuery.get(Source.SERVER)).thenReturn(Tasks.forException(Exception("Test exception")))
 
     profilesRepositoryFirestore.getProfilesInRadius(
         center = GeoPoint(0.0, 0.0),
@@ -239,7 +239,7 @@ class ProfilesRepositoryFirestoreTest {
     `when`(mockCollectionReference.whereGreaterThanOrEqualTo(eq("geohash"), any()))
         .thenReturn(mockQuery)
     `when`(mockQuery.whereLessThanOrEqualTo(eq("geohash"), any())).thenReturn(mockQuery)
-    `when`(mockQuery.get()).thenReturn(Tasks.forResult(mockProfileQuerySnapshot))
+    `when`(mockQuery.get(Source.SERVER)).thenReturn(Tasks.forResult(mockProfileQuerySnapshot))
 
     `when`(mockProfileQuerySnapshot.documents).thenReturn(listOf())
 
@@ -262,7 +262,7 @@ class ProfilesRepositoryFirestoreTest {
     `when`(mockCollectionReference.whereGreaterThanOrEqualTo(eq("geohash"), any()))
         .thenReturn(mockQuery)
     `when`(mockQuery.whereLessThanOrEqualTo(eq("geohash"), any())).thenReturn(mockQuery)
-    `when`(mockQuery.get())
+    `when`(mockQuery.get(Source.SERVER))
         .thenReturn(
             Tasks.forException(
                 FirebaseFirestoreException(
@@ -292,7 +292,7 @@ class ProfilesRepositoryFirestoreTest {
     `when`(mockCollectionReference.whereGreaterThanOrEqualTo(eq("geohash"), any()))
         .thenReturn(mockQuery)
     `when`(mockQuery.whereLessThanOrEqualTo(eq("geohash"), any())).thenReturn(mockQuery)
-    `when`(mockQuery.get()).thenReturn(Tasks.forResult(mockProfileQuerySnapshot))
+    `when`(mockQuery.get(Source.SERVER)).thenReturn(Tasks.forResult(mockProfileQuerySnapshot))
 
     `when`(mockProfileQuerySnapshot.documents).thenReturn(listOf())
 
@@ -318,7 +318,7 @@ class ProfilesRepositoryFirestoreTest {
     `when`(mockCollectionReference.whereGreaterThanOrEqualTo(eq("geohash"), any()))
         .thenReturn(mockQuery)
     `when`(mockQuery.whereLessThanOrEqualTo(eq("geohash"), any())).thenReturn(mockQuery)
-    `when`(mockQuery.get())
+    `when`(mockQuery.get(Source.SERVER))
         .thenReturn(
             Tasks.forException(
                 FirebaseFirestoreException(


### PR DESCRIPTION
### Summary:
- fix offline mode in around you
- make notifications clickable
- reinstate sign in screen, remove again sign in screen
- save in data store the time a notification was last sent to a user
- put different IDs for different types of notifications so that they dont override each other
- put monitoring of notification logic back in around you so that we cans skip sign in screen
