### PR TITLE
Feature/meeting request bug fixes

### DIFF
--- a/app/src/main/java/com/github/se/icebreakrr/model/message/MeetingRequestService.kt
+++ b/app/src/main/java/com/github/se/icebreakrr/model/message/MeetingRequestService.kt
@@ -128,18 +128,20 @@ class MeetingRequestService : FirebaseMessagingService() {
         val stringReason =
             when (message) {
               "DISTANCE" -> DISTANCE_REASON_CANCELLATION
-              //"TIME" -> TIME_REASON_CANCELLATION
+              // "TIME" -> TIME_REASON_CANCELLATION
               "CANCELLED" -> CANCELLED_REASON_CANCELLATION
               "CLOSED" -> CLOSED_APP_REASON_CANCELLATION
               else -> DEFAULT_REASON_CANCELLATION
             }
-        if(stringReason != DEFAULT_REASON_CANCELLATION) {
+        if (stringReason != DEFAULT_REASON_CANCELLATION) {
           MeetingRequestManager.meetingRequestViewModel?.removeFromMeetingRequestSent(senderUid) {
-            MeetingRequestManager.meetingRequestViewModel?.removeFromMeetingRequestInbox(senderUid) {
-              MeetingRequestManager.meetingRequestViewModel?.removeChosenLocalisation(senderUid) {
-                MeetingRequestManager.meetingRequestViewModel?.updateInboxOfMessages {}
-              }
-            }
+            MeetingRequestManager.meetingRequestViewModel?.removeFromMeetingRequestInbox(
+                senderUid) {
+                  MeetingRequestManager.meetingRequestViewModel?.removeChosenLocalisation(
+                      senderUid) {
+                        MeetingRequestManager.meetingRequestViewModel?.updateInboxOfMessages {}
+                      }
+                }
           }
           MeetingRequestManager.meetingRequestViewModel?.stopMeetingRequestTimer(senderUid, this)
           showNotification("Cancelled meeting with $senderName", stringReason)

--- a/app/src/main/java/com/github/se/icebreakrr/model/message/MeetingRequestService.kt
+++ b/app/src/main/java/com/github/se/icebreakrr/model/message/MeetingRequestService.kt
@@ -128,21 +128,22 @@ class MeetingRequestService : FirebaseMessagingService() {
         val stringReason =
             when (message) {
               "DISTANCE" -> DISTANCE_REASON_CANCELLATION
-              "TIME" -> TIME_REASON_CANCELLATION
+              //"TIME" -> TIME_REASON_CANCELLATION
               "CANCELLED" -> CANCELLED_REASON_CANCELLATION
               "CLOSED" -> CLOSED_APP_REASON_CANCELLATION
               else -> DEFAULT_REASON_CANCELLATION
             }
-
-        MeetingRequestManager.meetingRequestViewModel?.removeFromMeetingRequestSent(senderUid) {
-          MeetingRequestManager.meetingRequestViewModel?.removeFromMeetingRequestInbox(senderUid) {
-            MeetingRequestManager.meetingRequestViewModel?.removeChosenLocalisation(senderUid) {
-              MeetingRequestManager.meetingRequestViewModel?.updateInboxOfMessages {}
+        if(stringReason != DEFAULT_REASON_CANCELLATION) {
+          MeetingRequestManager.meetingRequestViewModel?.removeFromMeetingRequestSent(senderUid) {
+            MeetingRequestManager.meetingRequestViewModel?.removeFromMeetingRequestInbox(senderUid) {
+              MeetingRequestManager.meetingRequestViewModel?.removeChosenLocalisation(senderUid) {
+                MeetingRequestManager.meetingRequestViewModel?.updateInboxOfMessages {}
+              }
             }
           }
+          MeetingRequestManager.meetingRequestViewModel?.stopMeetingRequestTimer(senderUid, this)
+          showNotification("Cancelled meeting with $senderName", stringReason)
         }
-        MeetingRequestManager.meetingRequestViewModel?.stopMeetingRequestTimer(senderUid, this)
-        showNotification("Cancelled meeting with $senderName", stringReason)
       }
       "ENGAGEMENT NOTIFICATION" -> {
         // Only show engagement notifications if app is in background

--- a/app/src/main/java/com/github/se/icebreakrr/model/message/MeetingRequestService.kt
+++ b/app/src/main/java/com/github/se/icebreakrr/model/message/MeetingRequestService.kt
@@ -24,7 +24,6 @@ class MeetingRequestService : FirebaseMessagingService() {
   private val MSG_RESPONSE_REJECTED = " rejected your meeting request :("
   private val MSG_REQUEST = "Meeting request received!"
   private val DISTANCE_REASON_CANCELLATION = "Reason : You are too far away"
-  private val TIME_REASON_CANCELLATION = "Reason : Request reached timeout"
   private val DEFAULT_REASON_CANCELLATION = "Reason : Unknown"
   private val CANCELLED_REASON_CANCELLATION = "Reason : Sender cancelled request"
   private val CLOSED_APP_REASON_CANCELLATION = "Reason : The other user closed the app"
@@ -34,6 +33,7 @@ class MeetingRequestService : FirebaseMessagingService() {
   private val MEETING_CANCELLATION_NOTIFICATION_ID = 4
   private val ENGAGEMENT_NOTIFICATION_START = "A person with similar interests"
   private val MEETING_CANCELLATION_START = "Cancelled meeting"
+  private val MEETING_REQUEST_CANCELLED_WITH = "Cancelled meeting with "
 
   /**
    * Checks if the application is currently running in the foreground.
@@ -144,7 +144,7 @@ class MeetingRequestService : FirebaseMessagingService() {
                 }
           }
           MeetingRequestManager.meetingRequestViewModel?.stopMeetingRequestTimer(senderUid, this)
-          showNotification("Cancelled meeting with $senderName", stringReason)
+          showNotification(MEETING_REQUEST_CANCELLED_WITH + senderName, stringReason)
         }
       }
       "ENGAGEMENT NOTIFICATION" -> {

--- a/app/src/main/java/com/github/se/icebreakrr/ui/map/LocationViewMap.kt
+++ b/app/src/main/java/com/github/se/icebreakrr/ui/map/LocationViewMap.kt
@@ -41,7 +41,7 @@ private const val MARKER_TITLE = "Meeting Request's location"
 private const val OUR_MARKER_TITLE = "Our location"
 private const val OUR_MARKER_TEXT = "You are here"
 private const val TEST_UID = "2"
-private val MARKER_HEIGHT = 40.dp
+private val MARKER_HEIGHT = 42.dp
 private const val DEFAULT_SCREEN_COORDINATE = 0F
 private const val USER_UID = "userId"
 

--- a/app/src/main/java/com/github/se/icebreakrr/ui/map/LocationViewMap.kt
+++ b/app/src/main/java/com/github/se/icebreakrr/ui/map/LocationViewMap.kt
@@ -41,7 +41,7 @@ private const val MARKER_TITLE = "Meeting Request's location"
 private const val OUR_MARKER_TITLE = "Our location"
 private const val OUR_MARKER_TEXT = "You are here"
 private const val TEST_UID = "2"
-private val MARKER_HEIGHT = 90.dp
+private val MARKER_HEIGHT = 40.dp
 private const val DEFAULT_SCREEN_COORDINATE = 0F
 private const val USER_UID = "userId"
 

--- a/app/src/main/java/com/github/se/icebreakrr/ui/profile/InboxProfileView.kt
+++ b/app/src/main/java/com/github/se/icebreakrr/ui/profile/InboxProfileView.kt
@@ -1,7 +1,6 @@
 package com.github.se.icebreakrr.ui.profile
 
 import android.util.Log
-import android.widget.Toast
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
@@ -68,6 +67,7 @@ private const val ACCEPT_DECLINE_ICON_BUTTON_PADDING = 12
 private const val ACCEPT_DECLINE_ICON_BUTTON_SIZE = 48
 private const val ACCEPT_DECLINE_ICON_BUTTON_ROUNDED = 100
 private const val ACCEPT_DECLINE_ICON_BUTTON_COLOR = 0xFF65558F
+private const val ACCEPT_MEETING_REQUEST = "The user accepted your meeting request"
 
 /**
  * Screen that appears when you click on a profile in the notification tab. You can accept or
@@ -138,13 +138,6 @@ fun InboxProfileViewScreen(
                           location,
                           locationMessage)
                     }
-                    Toast.makeText(
-                            context,
-                            "You've accepted the request, " +
-                                profile.name +
-                                " is choosing the location of your meeting!",
-                            Toast.LENGTH_SHORT)
-                        .show()
                   },
                   {
                     if (location != null) {
@@ -190,7 +183,7 @@ fun acceptDeclineCode(
     locationMessage: String
 ) {
   meetingRequestViewModel.setMeetingResponse(
-      fcm, "accepting/decline request", accepted, location.toString())
+      fcm, ACCEPT_MEETING_REQUEST, accepted, location.toString())
   meetingRequestViewModel.sendMeetingResponse()
   if (accepted) {
     meetingRequestViewModel.confirmMeetingRequest(uid, Pair(locationMessage, location)) {

--- a/app/src/test/java/com/github/se/icebreakrr/model/message/MeetingRequestServiceTest.kt
+++ b/app/src/test/java/com/github/se/icebreakrr/model/message/MeetingRequestServiceTest.kt
@@ -118,7 +118,7 @@ class MeetingRequestServiceTest {
         mapOf(
             "title" to "MEETING CANCELLATION",
             "senderUID" to "1",
-            "message" to "hello",
+            "message" to MeetingRequestViewModel.CancellationType.CANCELLED.toString(),
             "senderName" to "John Doe")
     `when`(mockRemoteMessage.data).thenReturn(data)
     assertNotNull(MeetingRequestManager.meetingRequestViewModel)


### PR DESCRIPTION
Fixes the following bugs :
- The markers and the textes under the markers are too far away in the LocationViewMap
- A toast is showed when you accept a meeting request (should be remove since it is deprecdated)
- When clicking on a marker in the MapScreen, the message is odd "accepted/cancelled meeting request" , should be replaced
- Remove the timeout cancellation for meeting request since it isn't useful for the app anymore and could cause some unexpected bugs

The new LocationViewMap : 
![image](https://github.com/user-attachments/assets/41db8ea4-55f7-474b-bb69-dafc960be602)
