### PR TITLE
Bugfix/274

### DIFF
--- a/app/src/main/java/com/github/se/icebreakrr/model/location/ILocationService.kt
+++ b/app/src/main/java/com/github/se/icebreakrr/model/location/ILocationService.kt
@@ -9,6 +9,4 @@ interface ILocationService {
   ): Boolean
 
   fun stopLocationUpdates()
-
-  fun createNotificationChannel()
 }


### PR DESCRIPTION
# Prevent crash when returning to app after removing location permissions

This PR addresses the issue where the app crashes when location permissions are removed, and the user returns to the app.  

### Changes  
- **Added `hasRequiredPermissions`:**  
  - A new function to verify `ACCESS_FINE_LOCATION` and `FOREGROUND_SERVICE_LOCATION` permissions.  
  - Ensures the service only runs with required permissions.  

- **Updated `onStartCommand`:**  
  - Integrated `hasRequiredPermissions` to stop the service gracefully if permissions are missing.  
  - Prevents crashes caused by missing permissions.  

- **Refactored `ILocationService`:**  
  - Removed `createNotificationChannel` from the interface and moved it to internal scope.  

- **Improved Tests:**  
  - Added tests to validate behavior of `hasRequiredPermissions` for various permission states.  

### Remark  
- The `PermissionManager` was not used in this implementation due to the difficulty of injecting it given the way `LocationService` is initialized. Additionally, using `PermissionManager` would have made testing more complex. For a simple use case like this, the `hasRequiredPermissions` function is straightforward, effective, and well-suited.  

### Testing  
- Verified behavior with and without location permissions.  
- Ensured the app does not crash and handles permission changes gracefully.  

